### PR TITLE
Migrate SystemController to v2.0

### DIFF
--- a/demos/arm_cortex/system_timer/source/main.cpp
+++ b/demos/arm_cortex/system_timer/source/main.cpp
@@ -15,7 +15,7 @@ void DemoSystemIsr()
   sjsu::LogInfo("System Timer Tick #%d ...", counter++);
 }
 
-sjsu::SystemController::PeripheralID GetSystemTimerID()
+sjsu::SystemController::ResourceID GetSystemTimerID()
 {
   if constexpr (sjsu::build::IsPlatform(sjsu::build::Platform::lpc17xx))
   {
@@ -41,7 +41,7 @@ sjsu::SystemController::PeripheralID GetSystemTimerID()
   else
   {
     // For all other systems just return some
-    return sjsu::SystemController::PeripheralID::Define<0xFF>();
+    return sjsu::SystemController::ResourceID::Define<0xFF>();
   }
 }
 
@@ -51,7 +51,7 @@ int main()
 
   // The specific clock associated with the system timer is different for
   // platform, thus we need to get the system timer's ID
-  sjsu::SystemController::PeripheralID system_timer_id = GetSystemTimerID();
+  sjsu::SystemController::ResourceID system_timer_id = GetSystemTimerID();
   sjsu::cortex::SystemTimer system_timer(system_timer_id);
 
   system_timer.SetCallback(DemoSystemIsr);

--- a/documentation/design_docs/L1/msp432p401r/system_controller.md
+++ b/documentation/design_docs/L1/msp432p401r/system_controller.md
@@ -13,20 +13,20 @@
     - [void LockClockSystemRegister() const](#void-lockclocksystemregister-const)
   - [Initialization](#initialization)
     - [Returns&lt;void> Initialize() override](#returnsvoid-initialize-override)
-    - [Returns&lt;units::frequency::hertz_t> ConfigureDcoClock() const](#returnsunitsfrequencyhertzt-configuredcoclock-const)
-    - [Returns&lt;units::frequency::hertz_t> ConfigureReferenceClock() const](#returnsunitsfrequencyhertzt-configurereferenceclock-const)
+    - [Returns&lt;units::frequency::hertz_t> ConfigureDcoClock() const](#returnsunitsfrequencyhertz_t-configuredcoclock-const)
+    - [Returns&lt;units::frequency::hertz_t> ConfigureReferenceClock() const](#returnsunitsfrequencyhertz_t-configurereferenceclock-const)
     - [Returns&lt;void> SetClockSource(Clock clock, Oscillator oscillator) const](#returnsvoid-setclocksourceclock-clock-oscillator-oscillator-const)
     - [Returns&lt;void> SetClockDivider(Clock clock, ClockDivider divider) const](#returnsvoid-setclockdividerclock-clock-clockdivider-divider-const)
     - [void WaitForClockReadyStatus(Clock clock) const](#void-waitforclockreadystatusclock-clock-const)
   - [Getting the Clock Rate of a Clock Signal](#getting-the-clock-rate-of-a-clock-signal)
-    - [Returns&lt;units::frequency::hertz_t> GetClockRate(PeripheralID peripheral) const override](#returnsunitsfrequencyhertzt-getclockrateperipheralid-peripheral-const-override)
+    - [Returns&lt;units::frequency::hertz_t> GetClockRate(ResourceID peripheral) const override](#returnsunitsfrequencyhertz_t-getclockrateresourceid-peripheral-const-override)
   - [Unused Functions](#unused-functions)
 - [Caveats](#caveats)
 - [Future Advancements](#future-advancements)
 - [Testing Plan](#testing-plan)
   - [Unit Testing Scheme](#unit-testing-scheme)
     - [Initialize()](#initialize)
-    - [GetClockRate(PeripheralID peripheral)](#getclockrateperipheralid-peripheral)
+    - [GetClockRate(ResourceID peripheral)](#getclockrateresourceid-peripheral)
     - [SetClockDivider(Clock clock, ClockDivider divider)](#setclockdividerclock-clock-clockdivider-divider)
     - [IsPeripheralPoweredUp()](#isperipheralpoweredup)
   - [Demonstration Project](#demonstration-project)
@@ -85,12 +85,12 @@ class SystemController : public sjsu::SystemController
   Returns<void> Initialize() override;
   void * GetClockConfiguration() override;
   Returns<units::frequency::hertz_t> GetClockRate(
-     PeripheralID peripheral) const override;
+     ResourceID peripheral) const override;
   Returns<void> SetClockDivider(Clock clock, ClockDivider divider) const;
 
-  bool IsPeripheralPoweredUp(PeripheralID) const override;
-  void PowerUpPeripheral(PeripheralID) const override;
-  void PowerDownPeripheral(PeripheralID) const override;
+  bool IsPeripheralPoweredUp(ResourceID) const override;
+  void PowerUpPeripheral(ResourceID) const override;
+  void PowerDownPeripheral(ResourceID) const override;
 
  private:
   void UnlockClockSystemRegisters() const;
@@ -179,7 +179,7 @@ divider.
 
 ## Getting the Clock Rate of a Clock Signal
 
-### Returns&lt;units::frequency::hertz_t> GetClockRate(PeripheralID peripheral) const override
+### Returns&lt;units::frequency::hertz_t> GetClockRate(ResourceID peripheral) const override
 Gets the clock rate of one of the 10 available clock modules.
 
 An **Error_t** is returned if `peripheral` is not one of the defined peripherals
@@ -189,9 +189,9 @@ in the `Modules` namespace.
 The following functions are not implemented or used:
 
 ```c++
-bool IsPeripheralPoweredUp(const PeripheralID &) const override
-void PowerUpPeripheral(const PeripheralID &) const override
-void PowerDownPeripheral(const PeripheralID &) const override
+bool IsPeripheralPoweredUp(const ResourceID &) const override
+void PowerUpPeripheral(const ResourceID &) const override
+void PowerDownPeripheral(const ResourceID &) const override
 ```
 
 # Caveats
@@ -251,7 +251,7 @@ each primary clock. Additionally, clock divider values of 1, 2, 4, 8, 16, 32,
    - The function should return an error if the clock source is not
      `Oscillator::kLowFrequency`, or `Oscillator::kReference`.
 
-### GetClockRate(PeripheralID peripheral)
+### GetClockRate(ResourceID peripheral)
 The clock rates of clock signals that have a fixed frequency are verified.
 
 1. When `peripheral` = `Modules::kLowFrequencyClock`

--- a/library/L1_Peripheral/cortex/system_timer.hpp
+++ b/library/L1_Peripheral/cortex/system_timer.hpp
@@ -108,7 +108,7 @@ class SystemTimer final : public sjsu::SystemTimer
   /// @param id - id of the system controller for this platform. This is used to
   /// recover the operating speed of the SystemTimer.
   /// @param priority - the interrupt priority of
-  explicit constexpr SystemTimer(sjsu::SystemController::PeripheralID id,
+  explicit constexpr SystemTimer(sjsu::SystemController::ResourceID id,
                                  uint8_t priority = -1)
       : id_(id), priority_(priority)
   {
@@ -198,7 +198,7 @@ class SystemTimer final : public sjsu::SystemTimer
   }
 
  private:
-  sjsu::SystemController::PeripheralID id_;
+  sjsu::SystemController::ResourceID id_;
   uint8_t priority_;
 };
 }  // namespace cortex

--- a/library/L1_Peripheral/cortex/test/system_timer_test.cpp
+++ b/library/L1_Peripheral/cortex/test/system_timer_test.cpp
@@ -44,10 +44,10 @@ TEST_CASE("Testing ARM Cortex SystemTimer", "[cortex-system-timer]")
   sjsu::InterruptController::SetPlatformController(
       &mock_interrupt_controller.get());
 
-  using PeripheralID = sjsu::SystemController::PeripheralID;
+  using ResourceID = sjsu::SystemController::ResourceID;
 
   constexpr uint8_t kExpectedPriority = 3;
-  constexpr PeripheralID kId = PeripheralID::Define<0>();
+  constexpr ResourceID kId = ResourceID::Define<0>();
   SystemTimer test_subject(kId, kExpectedPriority);
 
   SECTION("Initialize()")

--- a/library/L1_Peripheral/inactive.hpp
+++ b/library/L1_Peripheral/inactive.hpp
@@ -239,16 +239,16 @@ inline sjsu::SystemController & GetInactive<sjsu::SystemController>()
     {
       return nullptr;
     }
-    units::frequency::hertz_t GetClockRate(PeripheralID) const override
+    units::frequency::hertz_t GetClockRate(ResourceID) const override
     {
       return 0_Hz;
     }
-    bool IsPeripheralPoweredUp(PeripheralID) const override
+    bool IsPeripheralPoweredUp(ResourceID) const override
     {
       return false;
     }
-    void PowerUpPeripheral(PeripheralID) const override {}
-    void PowerDownPeripheral(PeripheralID) const override {}
+    void PowerUpPeripheral(ResourceID) const override {}
+    void PowerDownPeripheral(ResourceID) const override {}
   };
 
   static InactiveSystemController inactive;

--- a/library/L1_Peripheral/lpc17xx/system_controller.hpp
+++ b/library/L1_Peripheral/lpc17xx/system_controller.hpp
@@ -26,33 +26,33 @@ class SystemController final : public sjsu::SystemController
   {
    public:
     //! @cond Doxygen_Suppress
-    static constexpr auto kTimer0            = PeripheralID::Define<1>();
-    static constexpr auto kTimer1            = PeripheralID::Define<2>();
-    static constexpr auto kUart0             = PeripheralID::Define<3>();
-    static constexpr auto kUart1             = PeripheralID::Define<4>();
-    static constexpr auto kPwm1              = PeripheralID::Define<6>();
-    static constexpr auto kI2c0              = PeripheralID::Define<7>();
-    static constexpr auto kSpi               = PeripheralID::Define<8>();
-    static constexpr auto kRtc               = PeripheralID::Define<9>();
-    static constexpr auto kSsp1              = PeripheralID::Define<10>();
-    static constexpr auto kAdc               = PeripheralID::Define<12>();
-    static constexpr auto kCan1              = PeripheralID::Define<13>();
-    static constexpr auto kCan2              = PeripheralID::Define<14>();
-    static constexpr auto kGpio              = PeripheralID::Define<15>();
-    static constexpr auto kRit               = PeripheralID::Define<16>();
-    static constexpr auto kMotorControlPwm   = PeripheralID::Define<17>();
-    static constexpr auto kQuadratureEncoder = PeripheralID::Define<18>();
-    static constexpr auto kI2c1              = PeripheralID::Define<19>();
-    static constexpr auto kSsp0              = PeripheralID::Define<21>();
-    static constexpr auto kTimer2            = PeripheralID::Define<22>();
-    static constexpr auto kTimer3            = PeripheralID::Define<23>();
-    static constexpr auto kUart2             = PeripheralID::Define<24>();
-    static constexpr auto kUart3             = PeripheralID::Define<25>();
-    static constexpr auto kI2c2              = PeripheralID::Define<26>();
-    static constexpr auto kI2s               = PeripheralID::Define<27>();
-    static constexpr auto kGpdma             = PeripheralID::Define<29>();
-    static constexpr auto kEthernet          = PeripheralID::Define<30>();
-    static constexpr auto kUsb               = PeripheralID::Define<31>();
+    static constexpr auto kTimer0            = ResourceID::Define<1>();
+    static constexpr auto kTimer1            = ResourceID::Define<2>();
+    static constexpr auto kUart0             = ResourceID::Define<3>();
+    static constexpr auto kUart1             = ResourceID::Define<4>();
+    static constexpr auto kPwm1              = ResourceID::Define<6>();
+    static constexpr auto kI2c0              = ResourceID::Define<7>();
+    static constexpr auto kSpi               = ResourceID::Define<8>();
+    static constexpr auto kRtc               = ResourceID::Define<9>();
+    static constexpr auto kSsp1              = ResourceID::Define<10>();
+    static constexpr auto kAdc               = ResourceID::Define<12>();
+    static constexpr auto kCan1              = ResourceID::Define<13>();
+    static constexpr auto kCan2              = ResourceID::Define<14>();
+    static constexpr auto kGpio              = ResourceID::Define<15>();
+    static constexpr auto kRit               = ResourceID::Define<16>();
+    static constexpr auto kMotorControlPwm   = ResourceID::Define<17>();
+    static constexpr auto kQuadratureEncoder = ResourceID::Define<18>();
+    static constexpr auto kI2c1              = ResourceID::Define<19>();
+    static constexpr auto kSsp0              = ResourceID::Define<21>();
+    static constexpr auto kTimer2            = ResourceID::Define<22>();
+    static constexpr auto kTimer3            = ResourceID::Define<23>();
+    static constexpr auto kUart2             = ResourceID::Define<24>();
+    static constexpr auto kUart3             = ResourceID::Define<25>();
+    static constexpr auto kI2c2              = ResourceID::Define<26>();
+    static constexpr auto kI2s               = ResourceID::Define<27>();
+    static constexpr auto kGpdma             = ResourceID::Define<29>();
+    static constexpr auto kEthernet          = ResourceID::Define<30>();
+    static constexpr auto kUsb               = ResourceID::Define<31>();
     //! @endcond
   };
 
@@ -64,37 +64,37 @@ class SystemController final : public sjsu::SystemController
   {
    public:
     //! @cond Doxygen_Suppress
-    static constexpr auto kWdt                = PeripheralID::Define<0>();
-    static constexpr auto kTimer0             = PeripheralID::Define<1>();
-    static constexpr auto kTimer1             = PeripheralID::Define<2>();
-    static constexpr auto kUart0              = PeripheralID::Define<3>();
-    static constexpr auto kUart1              = PeripheralID::Define<4>();
-    static constexpr auto kPwm1               = PeripheralID::Define<6>();
-    static constexpr auto kI2c0               = PeripheralID::Define<7>();
-    static constexpr auto kSpi                = PeripheralID::Define<8>();
-    static constexpr auto kSsp1               = PeripheralID::Define<10>();
-    static constexpr auto kDac                = PeripheralID::Define<11>();
-    static constexpr auto kAdc                = PeripheralID::Define<12>();
-    static constexpr auto kCan1               = PeripheralID::Define<13>();
-    static constexpr auto kCan2               = PeripheralID::Define<14>();
-    static constexpr auto kAcf                = PeripheralID::Define<15>();
-    static constexpr auto kQuadratureEncoder  = PeripheralID::Define<16>();
-    static constexpr auto kGpioInt            = PeripheralID::Define<17>();
-    static constexpr auto kPowerControlBlock  = PeripheralID::Define<18>();
-    static constexpr auto kI2c1               = PeripheralID::Define<19>();
-    static constexpr auto kSsp0               = PeripheralID::Define<21>();
-    static constexpr auto kTimer2             = PeripheralID::Define<22>();
-    static constexpr auto kTimer3             = PeripheralID::Define<23>();
-    static constexpr auto kUart2              = PeripheralID::Define<24>();
-    static constexpr auto kUart3              = PeripheralID::Define<25>();
-    static constexpr auto kI2c2               = PeripheralID::Define<26>();
-    static constexpr auto kI2s                = PeripheralID::Define<27>();
-    static constexpr auto kRit                = PeripheralID::Define<29>();
-    static constexpr auto kSystemControlBlock = PeripheralID::Define<30>();
-    static constexpr auto kMotorControlPwm    = PeripheralID::Define<31>();
+    static constexpr auto kWdt                = ResourceID::Define<0>();
+    static constexpr auto kTimer0             = ResourceID::Define<1>();
+    static constexpr auto kTimer1             = ResourceID::Define<2>();
+    static constexpr auto kUart0              = ResourceID::Define<3>();
+    static constexpr auto kUart1              = ResourceID::Define<4>();
+    static constexpr auto kPwm1               = ResourceID::Define<6>();
+    static constexpr auto kI2c0               = ResourceID::Define<7>();
+    static constexpr auto kSpi                = ResourceID::Define<8>();
+    static constexpr auto kSsp1               = ResourceID::Define<10>();
+    static constexpr auto kDac                = ResourceID::Define<11>();
+    static constexpr auto kAdc                = ResourceID::Define<12>();
+    static constexpr auto kCan1               = ResourceID::Define<13>();
+    static constexpr auto kCan2               = ResourceID::Define<14>();
+    static constexpr auto kAcf                = ResourceID::Define<15>();
+    static constexpr auto kQuadratureEncoder  = ResourceID::Define<16>();
+    static constexpr auto kGpioInt            = ResourceID::Define<17>();
+    static constexpr auto kPowerControlBlock  = ResourceID::Define<18>();
+    static constexpr auto kI2c1               = ResourceID::Define<19>();
+    static constexpr auto kSsp0               = ResourceID::Define<21>();
+    static constexpr auto kTimer2             = ResourceID::Define<22>();
+    static constexpr auto kTimer3             = ResourceID::Define<23>();
+    static constexpr auto kUart2              = ResourceID::Define<24>();
+    static constexpr auto kUart3              = ResourceID::Define<25>();
+    static constexpr auto kI2c2               = ResourceID::Define<26>();
+    static constexpr auto kI2s                = ResourceID::Define<27>();
+    static constexpr auto kRit                = ResourceID::Define<29>();
+    static constexpr auto kSystemControlBlock = ResourceID::Define<30>();
+    static constexpr auto kMotorControlPwm    = ResourceID::Define<31>();
     // Definitions not associated with a specific peripheral.
-    static constexpr auto kCpu = PeripheralID::Define<32>();
-    static constexpr auto kUsb = PeripheralID::Define<33>();
+    static constexpr auto kCpu = ResourceID::Define<32>();
+    static constexpr auto kUsb = ResourceID::Define<33>();
     //! @endcond
   };
 
@@ -151,11 +151,24 @@ class SystemController final : public sjsu::SystemController
     kDivideBy10 = 0b1001,
   };
 
+  // ===========================================================================
+  // Register and Bit Mask Definitions
+  // ===========================================================================
+
   /// Namespace for the Clock Source Select register (CLKSRCSEL) bit masks. The
   /// CLKSRCSEL register is used to select the oscillator used to drive the
   /// system clock and PLL0.
   struct ClockSourceSelectRegister  // NOLINT
   {
+    /// @see 4.4.1 Clock Source Select register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=36
+    ///
+    /// @returns The CLKSRCSEL bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&system_controller->CLKSRCSEL);
+    }
+
     /// Clock source select bit mask.
     static constexpr auto kSelectMask = bit::MaskFromRange(0, 1);
   };
@@ -164,6 +177,15 @@ class SystemController final : public sjsu::SystemController
   /// register (SCS) used to configure the main oscillator.
   struct SystemControlsRegister  // NOLINT
   {
+    /// @see 3.7.1 System Controls and Status register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=30
+    ///
+    /// @returns The SCS bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&system_controller->SCS);
+    }
+
     /// Main oscillator frequency range select bit mask.
     static constexpr auto kOscillatorRangeMask = bit::MaskFromRange(4);
     /// Main oscillator enable bit mask.
@@ -179,6 +201,15 @@ class SystemController final : public sjsu::SystemController
     /// (PLL0CFG).
     struct ConfigurationRegister  // NOLINT
     {
+      /// @see 4.5.4 PLL0 Configuration register
+      ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=39
+      ///
+      /// @returns The PLL0CFG bit register.
+      static bit::Register<uint32_t> Register()
+      {
+        return bit::Register(&system_controller->PLL0CFG);
+      }
+
       /// PLL0 multiplier bit mask.
       static constexpr auto kMultiplierMask = bit::MaskFromRange(0, 14);
       /// PLL0 pre-divider bit mask.
@@ -189,6 +220,15 @@ class SystemController final : public sjsu::SystemController
     /// (PLL0STAT).
     struct StatusRegister  // NOLINT
     {
+      /// @see 4.5.5 PLL0 Status register
+      ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=40
+      ///
+      /// @returns The PLL0STAT bit register.
+      static bit::Register<uint32_t> Register()
+      {
+        return bit::Register(&system_controller->PLL0STAT);
+      }
+
       /// PLL0 multiplier bit mask.
       static constexpr auto kMultiplierMask = bit::MaskFromRange(0, 14);
       /// PLL0 pre-divider bit mask.
@@ -206,6 +246,12 @@ class SystemController final : public sjsu::SystemController
   struct Pll1  // NOLINT
   {
     /// The available PLL1 multipliers.
+    ///
+    /// @note Since only the divider value of 2 is available for PLL1, the
+    ///       multiplier value should be selected based on the main oscillator.
+    ///
+    /// @see Table 37. PLL1 Multiplier values
+    ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=55
     enum class Multiplier : uint8_t
     {
       /// The multiplier to use when the main oscillator is 12 MHz.
@@ -220,6 +266,15 @@ class SystemController final : public sjsu::SystemController
     /// (PLL1CFG).
     struct ConfigurationRegister  // NOLINT
     {
+      /// @see 4.6.3 PLL1 Configuration register
+      ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=51
+      ///
+      /// @returns The PLL1CFG bit register.
+      static bit::Register<uint32_t> Register()
+      {
+        return bit::Register(&system_controller->PLL1CFG);
+      }
+
       /// PLL1 multiplier bit mask
       static constexpr auto kMultiplierMask = bit::MaskFromRange(0, 4);
       /// PLL1 pre-divider bit mask
@@ -230,6 +285,15 @@ class SystemController final : public sjsu::SystemController
     /// (PLL1STAT).
     struct StatusRegister  // NOLINT
     {
+      /// @see 4.6.4 PLL1 Status register
+      ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=51
+      ///
+      /// @returns The PLL1STAT bit register.
+      static bit::Register<uint32_t> Register()
+      {
+        return bit::Register(&system_controller->PLL1STAT);
+      }
+
       /// PLL1 multiplier bit mask
       static constexpr auto kMultiplierMask = bit::MaskFromRange(0, 4);
       /// PLL1 pre-divider bit mask
@@ -247,6 +311,19 @@ class SystemController final : public sjsu::SystemController
   /// (PLL0CON and PLL1CON).
   struct PllControlRegister  // NOLINT
   {
+    /// @see 4.5.3 PLL0 Control register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=38
+    /// @see 4.6.2 PLL1 Control register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=50
+    ///
+    /// @returns The PLL0CON bit register at index 0 and PLL1CON bit register at
+    ///          index 1.
+    static std::array<bit::Register<uint32_t>, 2> Register()
+    {
+      return { bit::Register(&system_controller->PLL0CON),
+               bit::Register(&system_controller->PLL1CON) };
+    }
+
     /// PLL enable bit mask.
     static constexpr auto kEnableMask = bit::MaskFromRange(0);
     /// PLL connect/disconnect bit mask.
@@ -257,6 +334,15 @@ class SystemController final : public sjsu::SystemController
   /// register (CCLKCFG).
   struct CpuClockRegister  // NOLINT
   {
+    /// @see 4.7.1 CPU Clock Configuration register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=56
+    ///
+    /// @returns The CCLKCFG bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&system_controller->CCLKCFG);
+    }
+
     /// The 8-bit CPU clock divider bitmask.
     static constexpr auto kDividerMask = bit::MaskFromRange(0, 7);
   };
@@ -265,9 +351,22 @@ class SystemController final : public sjsu::SystemController
   /// register (USBCLKCFG).
   struct UsbClockRegister  // NOLINT
   {
+    /// @see 4.7.2 USB Clock Configuration register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=57
+    ///
+    /// @returns The USBCLKCFG bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&system_controller->USBCLKCFG);
+    }
+
     /// The 4-bit USB clock divider bitmask.
     static constexpr auto kDividerMask = bit::MaskFromRange(0, 3);
   };
+
+  // ===========================================================================
+  // Clock Configuration
+  // ===========================================================================
 
   /// @see 4.1 Summary of clocking and power control functions
   ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=31
@@ -363,6 +462,13 @@ class SystemController final : public sjsu::SystemController
   {
   }
 
+  /// @attention If configuration of the system clocks is desired, one should
+  ///            consult the user manual of the target MCU in use to determine
+  ///            the valid clock configuration values that can/should be used.
+  ///            The Initialize() method is only responsible for configuring the
+  ///            clock system based on configurations in the ClockConfiguration.
+  ///            Incorrect configurations may result in a hard fault or cause
+  ///            the clock system(s) to supply incorrect clock rate(s).
   void Initialize() override
   {
     units::frequency::hertz_t osc_clk =
@@ -382,8 +488,9 @@ class SystemController final : public sjsu::SystemController
     DisableAndDisconnectPll(&system_controller->PLL1CON,
                             &system_controller->PLL1FEED);
     // Disable the main oscillator.
-    system_controller->SCS = bit::Clear(
-        system_controller->SCS, SystemControlsRegister::kOscillatorEnableMask);
+    SystemControlsRegister::Register()
+        .Clear(SystemControlsRegister::kOscillatorEnableMask)
+        .Save();
     SetSystemClockSource(Oscillator::kIrc);
 
     // =========================================================================
@@ -461,24 +568,13 @@ class SystemController final : public sjsu::SystemController
     {
       case UsbClockSource::kPll0:
       {
-        SJ2_ASSERT_FATAL(
-            clock_configuration_.cpu.clock_source == CpuClockSource::kPll0,
-            "The CPU clock source must be PLL0 in order to use PLL0 as a clock "
-            "source for the USB clock.");
-
         uint8_t usb_clock_divider_select =
             Value(clock_configuration_.usb.divider);
         uint32_t usb_clock_divider = usb_clock_divider_select + 1;
         usb_clk                    = pll_clk / usb_clock_divider;
-
-        SJ2_ASSERT_FATAL(usb_clk == kUsbClockFrequency,
-                         "Attempting to use PLL0 to drive the USB clock, but "
-                         "the PLL0 configuration and USB clock divider are not "
-                         "configured to produce a frequency of 48 MHz.");
-
-        system_controller->USBCLKCFG =
-            bit::Insert(system_controller->USBCLKCFG, usb_clock_divider_select,
-                        UsbClockRegister::kDividerMask);
+        UsbClockRegister::Register()
+            .Insert(usb_clock_divider_select, UsbClockRegister::kDividerMask)
+            .Save();
         break;
       }
       case UsbClockSource::kPll1:
@@ -513,24 +609,27 @@ class SystemController final : public sjsu::SystemController
     return &clock_configuration_;
   }
 
-  bool IsPeripheralPoweredUp(PeripheralID peripheral_select) const override
+  bool IsPeripheralPoweredUp(ResourceID peripheral_select) const override
   {
-    return bit::Read(system_controller->PCONP, peripheral_select.device_id);
+    return bit::Register(&system_controller->PCONP)
+        .Read(bit::MaskFromRange(peripheral_select.device_id));
   }
 
-  void PowerUpPeripheral(PeripheralID peripheral_select) const override
+  void PowerUpPeripheral(ResourceID peripheral_select) const override
   {
-    system_controller->PCONP =
-        bit::Set(system_controller->PCONP, peripheral_select.device_id);
+    bit::Register(&system_controller->PCONP)
+        .Set(bit::MaskFromRange(peripheral_select.device_id))
+        .Save();
   }
 
-  void PowerDownPeripheral(PeripheralID peripheral_select) const override
+  void PowerDownPeripheral(ResourceID peripheral_select) const override
   {
-    system_controller->PCONP =
-        bit::Clear(system_controller->PCONP, peripheral_select.device_id);
+    bit::Register(&system_controller->PCONP)
+        .Clear(bit::MaskFromRange(peripheral_select.device_id))
+        .Save();
   }
 
-  units::frequency::hertz_t GetClockRate(PeripheralID peripheral) const override
+  units::frequency::hertz_t GetClockRate(ResourceID peripheral) const override
   {
     switch (peripheral.device_id)
     {
@@ -555,9 +654,23 @@ class SystemController final : public sjsu::SystemController
   /// @param source The oscillator used to drive the system clock.
   void SetSystemClockSource(Oscillator source) const
   {
-    system_controller->CLKSRCSEL =
-        bit::Insert(system_controller->CLKSRCSEL, Value(source),
-                    ClockSourceSelectRegister::kSelectMask);
+    ClockSourceSelectRegister::Register()
+        .Insert(Value(source), ClockSourceSelectRegister::kSelectMask)
+        .Save();
+  }
+
+  /// Sets divider used for the CPU clock (CCLK).
+  ///
+  /// @note If PLL0 is connected, a divider value of 1 is not allowed since the
+  ///       produced clock rate must not exceed the maximum allowed CPU clock.
+  ///
+  /// @param cpu_divider 8-bit divider ranging from 1 to 255.
+  void SetCpuClockDivider(uint8_t cpu_divider) const
+  {
+    SJ2_ASSERT_FATAL(cpu_divider != 0, "The CPU clock cannot be divided by 0.");
+    CpuClockRegister::Register()
+        .Insert((cpu_divider - 1), CpuClockRegister::kDividerMask)
+        .Save();
   }
 
   /// Configures the System Controls register (SCS) to enable the use of the
@@ -566,39 +679,37 @@ class SystemController final : public sjsu::SystemController
   /// @see https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=30
   void EnableMainOscillator() const
   {
-    uint32_t system_controls = system_controller->SCS;
-    auto frequency           = clock_configuration_.main_oscillator.frequency;
-
-    constexpr units::frequency::hertz_t kMinFrequency = 1_MHz;
-    constexpr units::frequency::hertz_t kMaxFrequency = 25_MHz;
-    SJ2_ASSERT_FATAL(
-        (kMinFrequency <= frequency) && (frequency <= kMaxFrequency),
-        "The frequency of the main oscillator must be between 1 "
-        "MHz and 25 MHz.");
+    auto scs_register = SystemControlsRegister::Register();
+    auto frequency    = clock_configuration_.main_oscillator.frequency;
 
     if (1_MHz <= frequency && frequency <= 15_MHz)
     {
-      system_controls = bit::Clear(
-          system_controls, SystemControlsRegister::kOscillatorRangeMask);
+      scs_register.Clear(SystemControlsRegister::kOscillatorRangeMask);
     }
     else if (15_MHz <= frequency && frequency <= 25_MHz)
     {
-      system_controls = bit::Set(system_controls,
-                                 SystemControlsRegister::kOscillatorRangeMask);
+      scs_register.Set(SystemControlsRegister::kOscillatorRangeMask);
     }
-    system_controls = bit::Set(system_controls,
-                               SystemControlsRegister::kOscillatorEnableMask);
+    else
+    {
+      SJ2_ASSERT_FATAL(false,
+                       "The frequency of the main oscillator must be between 1 "
+                       "MHz and 25 MHz.");
+    }
 
-    system_controller->SCS = system_controls;
+    scs_register.Set(SystemControlsRegister::kOscillatorEnableMask).Save();
 
     // Wait for the main oscillator to become stable before proceeding with any
     // other operations.
-    while (!bit::Read(system_controller->SCS,
-                      SystemControlsRegister::kOscillatorStatusMask))
+    while (!scs_register.Read(SystemControlsRegister::kOscillatorStatusMask))
     {
       continue;
     }
   }
+
+  // ===========================================================================
+  // PLL Configuration Functions
+  // ===========================================================================
 
   /// Disconnect and then disable the specified PLL.
   ///
@@ -610,14 +721,14 @@ class SystemController final : public sjsu::SystemController
     // NOTE: It is very important not to merge any steps.
 
     // =========================================================================
-    // Step 1. Disconnect PLL0 with one feed sequence.
+    // Step 1. Disconnect PLL with one feed sequence.
     // =========================================================================
     *pll_control_register =
         bit::Clear(*pll_control_register, PllControlRegister::kConnectMask);
     WritePllFeedSequence(pll_feed_register);
 
     // =========================================================================
-    // Step 2. Disable PLL0 with one feed sequence.
+    // Step 2. Disable PLL with one feed sequence.
     // =========================================================================
     *pll_control_register =
         bit::Clear(*pll_control_register, PllControlRegister::kEnableMask);
@@ -710,19 +821,18 @@ class SystemController final : public sjsu::SystemController
     // =========================================================================
     uint16_t multiplier = clock_configuration_.pll0.multiplier;
     uint8_t pre_divider = clock_configuration_.pll0.pre_divider;
-    system_controller->PLL0CFG =
-        bit::Insert(system_controller->PLL0CFG, (multiplier - 1),
-                    Pll0::ConfigurationRegister::kMultiplierMask);
-    system_controller->PLL0CFG =
-        bit::Insert(system_controller->PLL0CFG, (pre_divider - 1),
-                    Pll0::ConfigurationRegister::kPreDividerMask);
+    Pll0::ConfigurationRegister::Register()
+        .Insert((multiplier - 1), Pll0::ConfigurationRegister::kMultiplierMask)
+        .Insert((pre_divider - 1), Pll0::ConfigurationRegister::kPreDividerMask)
+        .Save();
     WritePllFeedSequence(pll_feed_register);
 
     // =========================================================================
     // Step 6. Enable PLL0 with one feed sequence.
     // =========================================================================
-    system_controller->PLL0CON =
-        bit::Set(system_controller->PLL0CON, PllControlRegister::kEnableMask);
+    PllControlRegister::Register()[0]
+        .Set(PllControlRegister::kEnableMask)
+        .Save();
     WritePllFeedSequence(pll_feed_register);
 
     // =========================================================================
@@ -742,8 +852,9 @@ class SystemController final : public sjsu::SystemController
     // =========================================================================
     // Step 9. Connect PLL0 with one feed sequence.
     // =========================================================================
-    system_controller->PLL0CON =
-        bit::Set(system_controller->PLL0CON, PllControlRegister::kConnectMask);
+    PllControlRegister::Register()[0]
+        .Set(PllControlRegister::kConnectMask)
+        .Save();
     WritePllFeedSequence(pll_feed_register);
 
     WaitForPllConnectionStatus(pll_status_register,
@@ -776,20 +887,22 @@ class SystemController final : public sjsu::SystemController
     //         sequence.
     // =========================================================================
     uint8_t multiplier = Value(clock_configuration_.pll1.multiplier);
+    // NOTE: only the divider value of 2 is available.
+    // SEE: Table 36. PLL1 Divider values
+    //      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=55
     constexpr uint8_t kDividerSelect = 0b01;
-    system_controller->PLL1CFG =
-        bit::Insert(system_controller->PLL1CFG, multiplier,
-                    Pll1::ConfigurationRegister::kMultiplierMask);
-    system_controller->PLL1CFG =
-        bit::Insert(system_controller->PLL1CFG, kDividerSelect,
-                    Pll1::ConfigurationRegister::kDividerMask);
+    Pll1::ConfigurationRegister::Register()
+        .Insert(multiplier, Pll1::ConfigurationRegister::kMultiplierMask)
+        .Insert(kDividerSelect, Pll1::ConfigurationRegister::kDividerMask)
+        .Save();
     WritePllFeedSequence(pll_feed_register);
 
     // =========================================================================
     // Step 4. Enable PLL1 with one feed sequence.
     // =========================================================================
-    system_controller->PLL1CON =
-        bit::Set(system_controller->PLL1CON, PllControlRegister::kEnableMask);
+    PllControlRegister::Register()[1]
+        .Set(PllControlRegister::kEnableMask)
+        .Save();
     WritePllFeedSequence(pll_feed_register);
 
     // =========================================================================
@@ -802,27 +915,14 @@ class SystemController final : public sjsu::SystemController
     // =========================================================================
     // Step 6. Connect PLL1 with one feed sequence.
     // =========================================================================
-    system_controller->PLL1CON =
-        bit::Set(system_controller->PLL1CON, PllControlRegister::kConnectMask);
+    PllControlRegister::Register()[1]
+        .Set(PllControlRegister::kConnectMask)
+        .Save();
     WritePllFeedSequence(pll_feed_register);
 
     WaitForPllConnectionStatus(pll_status_register,
                                Pll1::StatusRegister::kEnableMask,
                                Pll1::StatusRegister::kConnectMask);
-  }
-
-  /// Sets divider used for the CPU clock (CCLK).
-  ///
-  /// @note If PLL0 is connected, a divider value of 1 is not allowed since the
-  ///       produced clock rate must not exceed the maximum allowed CPU clock.
-  ///
-  /// @param cpu_divider 8-bit divider ranging from 1 to 255.
-  void SetCpuClockDivider(uint8_t cpu_divider) const
-  {
-    SJ2_ASSERT_FATAL(cpu_divider != 0, "The CPU clock cannot be divided by 0.");
-    system_controller->CCLKCFG =
-        bit::Insert(system_controller->CCLKCFG, (cpu_divider - 1),
-                    CpuClockRegister::kDividerMask);
   }
 
   /// Clock system configurations.

--- a/library/L1_Peripheral/lpc17xx/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/lpc17xx/test/system_controller_test.cpp
@@ -341,7 +341,7 @@ TEST_CASE("Testing LPC176x/5x System Controller", "[lpc17xx-SystemController]")
     constexpr uint32_t kPeripheralCount = 32;
     for (uint32_t i = 0; i < kPeripheralCount; i++)
     {
-      SystemController::PeripheralID peripheral = { .device_id = i };
+      SystemController::ResourceID peripheral = { .device_id = i };
       CHECK(system_controller.GetClockRate(peripheral) ==
             expected_cpu_clock_rate);
     }

--- a/library/L1_Peripheral/lpc40xx/can.hpp
+++ b/library/L1_Peripheral/lpc40xx/can.hpp
@@ -269,7 +269,7 @@ class Can final : public sjsu::Can
     /// Pointer to the LPC CAN peripheral in memory
     LPC_CAN_TypeDef * registers;
     /// Peripheral's ID
-    sjsu::SystemController::PeripheralID id;
+    sjsu::SystemController::ResourceID id;
   };
 
   /// Container for the LPC40xx CANBUS registers

--- a/library/L1_Peripheral/lpc40xx/i2c.hpp
+++ b/library/L1_Peripheral/lpc40xx/i2c.hpp
@@ -67,8 +67,8 @@ class I2c final : public sjsu::I2c
   {
     /// Holds a pointer to the LPC_I2C peripheral registers
     LPC_I2C_TypeDef * registers;
-    /// PeripheralID of the I2C peripheral to power on at initialization.
-    sjsu::SystemController::PeripheralID id;
+    /// ResourceID of the I2C peripheral to power on at initialization.
+    sjsu::SystemController::ResourceID id;
     /// IRQ number for this I2C port.
     sjsu::cortex::IRQn_Type irq_number;
     /// A reference to the transaction structure for this specific port. Each

--- a/library/L1_Peripheral/lpc40xx/pulse_capture.hpp
+++ b/library/L1_Peripheral/lpc40xx/pulse_capture.hpp
@@ -46,7 +46,7 @@ class PulseCapture final : public sjsu::PulseCapture
     /// Pointer to memory-mapped timer peripheral registres
     LPC_TIM_TypeDef * timer_register;
     /// Peripheral ID of the timer peripheral to power on at initialization
-    sjsu::SystemController::PeripheralID id;
+    sjsu::SystemController::ResourceID id;
     /// Interrupt number associated with this timer
     IRQn irq;
     /// Callback invoked during a capture event

--- a/library/L1_Peripheral/lpc40xx/pwm.hpp
+++ b/library/L1_Peripheral/lpc40xx/pwm.hpp
@@ -90,7 +90,7 @@ class Pwm final : public sjsu::Pwm
     /// Holds the address to the LPC PWM peripheral.
     LPC_PWM_TypeDef * registers;
     /// The power on id for the above LPC PWM peripheral.
-    sjsu::SystemController::PeripheralID id;
+    sjsu::SystemController::ResourceID id;
   };
 
   /// Defines all information necessary to control a specific PWM channel.

--- a/library/L1_Peripheral/lpc40xx/spi.hpp
+++ b/library/L1_Peripheral/lpc40xx/spi.hpp
@@ -109,8 +109,8 @@ class Spi final : public sjsu::Spi
     /// Pointer to the LPC SSP peripheral in memory
     LPC_SSP_TypeDef * registers;
 
-    /// PeripheralID of the SSP peripheral to power on at initialization
-    sjsu::SystemController::PeripheralID power_on_bit;
+    /// ResourceID of the SSP peripheral to power on at initialization
+    sjsu::SystemController::ResourceID power_on_bit;
 
     /// Refernce to the M.ASTER-O.UT-S.LAVE-I.N (output from microcontroller)
     /// spi pin.

--- a/library/L1_Peripheral/lpc40xx/system_controller.hpp
+++ b/library/L1_Peripheral/lpc40xx/system_controller.hpp
@@ -90,41 +90,41 @@ class SystemController final : public sjsu::SystemController
   {
    public:
     //! @cond Doxygen_Suppress
-    static constexpr auto kLcd               = PeripheralID::Define<0>();
-    static constexpr auto kTimer0            = PeripheralID::Define<1>();
-    static constexpr auto kTimer1            = PeripheralID::Define<2>();
-    static constexpr auto kUart0             = PeripheralID::Define<3>();
-    static constexpr auto kUart1             = PeripheralID::Define<4>();
-    static constexpr auto kPwm0              = PeripheralID::Define<5>();
-    static constexpr auto kPwm1              = PeripheralID::Define<6>();
-    static constexpr auto kI2c0              = PeripheralID::Define<7>();
-    static constexpr auto kUart4             = PeripheralID::Define<8>();
-    static constexpr auto kRtc               = PeripheralID::Define<9>();
-    static constexpr auto kSsp1              = PeripheralID::Define<10>();
-    static constexpr auto kEmc               = PeripheralID::Define<11>();
-    static constexpr auto kAdc               = PeripheralID::Define<12>();
-    static constexpr auto kCan1              = PeripheralID::Define<13>();
-    static constexpr auto kCan2              = PeripheralID::Define<14>();
-    static constexpr auto kGpio              = PeripheralID::Define<15>();
-    static constexpr auto kSpifi             = PeripheralID::Define<16>();
-    static constexpr auto kMotorControlPwm   = PeripheralID::Define<17>();
-    static constexpr auto kQuadratureEncoder = PeripheralID::Define<18>();
-    static constexpr auto kI2c1              = PeripheralID::Define<19>();
-    static constexpr auto kSsp2              = PeripheralID::Define<20>();
-    static constexpr auto kSsp0              = PeripheralID::Define<21>();
-    static constexpr auto kTimer2            = PeripheralID::Define<22>();
-    static constexpr auto kTimer3            = PeripheralID::Define<23>();
-    static constexpr auto kUart2             = PeripheralID::Define<24>();
-    static constexpr auto kUart3             = PeripheralID::Define<25>();
-    static constexpr auto kI2c2              = PeripheralID::Define<26>();
-    static constexpr auto kI2s               = PeripheralID::Define<27>();
-    static constexpr auto kSdCard            = PeripheralID::Define<28>();
-    static constexpr auto kGpdma             = PeripheralID::Define<29>();
-    static constexpr auto kEthernet          = PeripheralID::Define<30>();
-    static constexpr auto kUsb               = PeripheralID::Define<31>();
-    static constexpr auto kEeprom            = PeripheralID::Define<32>();
+    static constexpr auto kLcd               = ResourceID::Define<0>();
+    static constexpr auto kTimer0            = ResourceID::Define<1>();
+    static constexpr auto kTimer1            = ResourceID::Define<2>();
+    static constexpr auto kUart0             = ResourceID::Define<3>();
+    static constexpr auto kUart1             = ResourceID::Define<4>();
+    static constexpr auto kPwm0              = ResourceID::Define<5>();
+    static constexpr auto kPwm1              = ResourceID::Define<6>();
+    static constexpr auto kI2c0              = ResourceID::Define<7>();
+    static constexpr auto kUart4             = ResourceID::Define<8>();
+    static constexpr auto kRtc               = ResourceID::Define<9>();
+    static constexpr auto kSsp1              = ResourceID::Define<10>();
+    static constexpr auto kEmc               = ResourceID::Define<11>();
+    static constexpr auto kAdc               = ResourceID::Define<12>();
+    static constexpr auto kCan1              = ResourceID::Define<13>();
+    static constexpr auto kCan2              = ResourceID::Define<14>();
+    static constexpr auto kGpio              = ResourceID::Define<15>();
+    static constexpr auto kSpifi             = ResourceID::Define<16>();
+    static constexpr auto kMotorControlPwm   = ResourceID::Define<17>();
+    static constexpr auto kQuadratureEncoder = ResourceID::Define<18>();
+    static constexpr auto kI2c1              = ResourceID::Define<19>();
+    static constexpr auto kSsp2              = ResourceID::Define<20>();
+    static constexpr auto kSsp0              = ResourceID::Define<21>();
+    static constexpr auto kTimer2            = ResourceID::Define<22>();
+    static constexpr auto kTimer3            = ResourceID::Define<23>();
+    static constexpr auto kUart2             = ResourceID::Define<24>();
+    static constexpr auto kUart3             = ResourceID::Define<25>();
+    static constexpr auto kI2c2              = ResourceID::Define<26>();
+    static constexpr auto kI2s               = ResourceID::Define<27>();
+    static constexpr auto kSdCard            = ResourceID::Define<28>();
+    static constexpr auto kGpdma             = ResourceID::Define<29>();
+    static constexpr auto kEthernet          = ResourceID::Define<30>();
+    static constexpr auto kUsb               = ResourceID::Define<31>();
+    static constexpr auto kEeprom            = ResourceID::Define<32>();
     // Definitions not associated with a specific peripheral.
-    static constexpr auto kCpu = PeripheralID::Define<33>();
+    static constexpr auto kCpu = ResourceID::Define<33>();
     //! @endcond
   };
 
@@ -153,6 +153,10 @@ class SystemController final : public sjsu::SystemController
     kClock6 = 0b0101 << 12,
   };
 
+  // ===========================================================================
+  // Register and Bit Mask Definitions
+  // ===========================================================================
+
   /// Namespace for PLL configuration bit masks
   struct PllRegister  // NOLINT
   {
@@ -178,6 +182,15 @@ class SystemController final : public sjsu::SystemController
   /// Namespace of Oscillator register bitmasks
   struct OscillatorRegister  // NOLINT
   {
+    /// @see Table 33. System Controls and Status register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10562.pdf#page=45
+    ///
+    /// @returns The SCS bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&system_controller->SCS);
+    }
+
     /// IRC or Main oscillator select bit
     static constexpr bit::Mask kSelect = bit::MaskFromRange(0);
 
@@ -194,6 +207,15 @@ class SystemController final : public sjsu::SystemController
   /// Namespace of Clock register bitmasks
   struct CpuClockRegister  // NOLINT
   {
+    /// @see Table 20. CPU Clock Selection register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10562.pdf#page=33
+    ///
+    /// @returns The CCLKSEL bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&system_controller->CCLKSEL);
+    }
+
     /// CPU clock divider amount
     static constexpr bit::Mask kDivider = bit::MaskFromRange(0, 4);
 
@@ -204,6 +226,15 @@ class SystemController final : public sjsu::SystemController
   /// Namespace of Peripheral register bitmasks
   struct PeripheralClockRegister  // NOLINT
   {
+    /// @see Table 23. Peripheral Clock Selection register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10562.pdf#page=34
+    ///
+    /// @returns The PCLKSEL bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&system_controller->PCLKSEL);
+    }
+
     /// Main single peripheral clock divider shared across all peripherals,
     /// except for USB and SPIFI.
     static constexpr bit::Mask kDivider = bit::MaskFromRange(0, 4);
@@ -212,6 +243,15 @@ class SystemController final : public sjsu::SystemController
   /// Namespace of EMC register bitmasks
   struct EmcClockRegister  // NOLINT
   {
+    /// @see Table 19. EMC Clock Selection register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10562.pdf#page=32
+    ///
+    /// @returns The EMCCLKSEL bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&system_controller->EMCCLKSEL);
+    }
+
     /// EMC Clock Register divider bit
     static constexpr bit::Mask kDivider = bit::MaskFromRange(0);
   };
@@ -219,6 +259,15 @@ class SystemController final : public sjsu::SystemController
   /// Namespace of USB register bitmasks
   struct UsbClockRegister  // NOLINT
   {
+    /// @see Table 21. USB Clock Selection register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10562.pdf#page=33
+    ///
+    /// @returns The USBCLKSEL bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&system_controller->USBCLKSEL);
+    }
+
     /// USB clock divider constant
     static constexpr bit::Mask kDivider = bit::MaskFromRange(0, 4);
 
@@ -229,6 +278,15 @@ class SystemController final : public sjsu::SystemController
   /// Namespace of SPIFI register bitmasks
   struct SpiFiClockRegister  // NOLINT
   {
+    /// @see SPIFI Clock Selection register
+    ///      https://www.nxp.com/docs/en/user-guide/UM10562.pdf#page=35
+    ///
+    /// @returns The SPIFISEL bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&system_controller->SPIFISEL);
+    }
+
     /// SPIFI clock divider constant
     static constexpr bit::Mask kDivider = bit::MaskFromRange(0, 4);
 
@@ -236,9 +294,16 @@ class SystemController final : public sjsu::SystemController
     static constexpr bit::Mask kSelect = bit::MaskFromRange(8, 9);
   };
 
+  // ===========================================================================
+  // Clock Configuration
+  // ===========================================================================
+
   /// Clock configuration structure for use the lpc40xx microcontrollers
   /// See page 21 of a diagram of the clock tree that this datastructure
   /// represents: datasheets/sjtwo/LPC40xx/UM10562.pdf
+  ///
+  /// @see Fig 4. Clock generation
+  ///      https://www.nxp.com/docs/en/user-guide/UM10562.pdf#page=21
   struct ClockConfiguration  // NOLINT
   {
     // =========================================================================
@@ -319,24 +384,27 @@ class SystemController final : public sjsu::SystemController
     return &clock_configuration_;
   }
 
-  bool IsPeripheralPoweredUp(PeripheralID peripheral_select) const override
+  bool IsPeripheralPoweredUp(ResourceID peripheral_select) const override
   {
-    return bit::Read(system_controller->PCONP, peripheral_select.device_id);
+    return bit::Register(&system_controller->PCONP)
+        .Read(bit::MaskFromRange(peripheral_select.device_id));
   }
 
-  void PowerUpPeripheral(PeripheralID peripheral_select) const override
+  void PowerUpPeripheral(ResourceID peripheral_select) const override
   {
-    system_controller->PCONP =
-        bit::Set(system_controller->PCONP, peripheral_select.device_id);
+    bit::Register(&system_controller->PCONP)
+        .Set(bit::MaskFromRange(peripheral_select.device_id))
+        .Save();
   }
 
-  void PowerDownPeripheral(PeripheralID peripheral_select) const override
+  void PowerDownPeripheral(ResourceID peripheral_select) const override
   {
-    system_controller->PCONP =
-        bit::Clear(system_controller->PCONP, peripheral_select.device_id);
+    bit::Register(&system_controller->PCONP)
+        .Clear(bit::MaskFromRange(peripheral_select.device_id))
+        .Save();
   }
 
-  units::frequency::hertz_t GetClockRate(PeripheralID peripheral) const override
+  units::frequency::hertz_t GetClockRate(ResourceID peripheral) const override
   {
     switch (peripheral.device_id)
     {
@@ -363,6 +431,13 @@ class SystemController final : public sjsu::SystemController
     }
   }
 
+  /// @attention If configuration of the system clocks is desired, one should
+  ///            consult the user manual of the target MCU in use to determine
+  ///            the valid clock configuration values that can/should be used.
+  ///            The Initialize() method is only responsible for configuring the
+  ///            clock system based on configurations in the ClockConfiguration.
+  ///            Incorrect configurations may result in a hard fault or cause
+  ///            the clock system(s) to supply incorrect clock rate(s).
   void Initialize() override
   {
     LPC_SC_TypeDef * sys = system_controller;
@@ -382,17 +457,18 @@ class SystemController final : public sjsu::SystemController
     //         Make sure PLLs are not clock sources for everything.
     // =========================================================================
     // Set CPU clock to system clock
-    sys->CCLKSEL =
-        bit::Insert(sys->CCLKSEL, Value(CpuClockSelect::kSystemClock),
-                    CpuClockRegister::kSelect);
+    CpuClockRegister::Register()
+        .Insert(Value(CpuClockSelect::kSystemClock), CpuClockRegister::kSelect)
+        .Save();
     // Set USB clock to system clock
-    sys->USBCLKSEL =
-        bit::Insert(sys->USBCLKSEL, Value(UsbClockSelect::kSystemClock),
-                    UsbClockRegister::kSelect);
+    UsbClockRegister::Register()
+        .Insert(Value(UsbClockSelect::kSystemClock), UsbClockRegister::kSelect)
+        .Save();
     // Set SPIFI clock to system clock
-    sys->SPIFISEL =
-        bit::Insert(sys->SPIFISEL, Value(SpifiClockSelect::kSystemClock),
-                    SpiFiClockRegister::kSelect);
+    SpiFiClockRegister::Register()
+        .Insert(Value(SpifiClockSelect::kSystemClock),
+                SpiFiClockRegister::kSelect)
+        .Save();
 
     // Set the clock source to IRC and not external oscillator. The next phase
     // disables that clock source, which will stop the system if this is not
@@ -407,8 +483,9 @@ class SystemController final : public sjsu::SystemController
     sys->PLL0CON = 0;
     sys->PLL1CON = 0;
     // Disabling external oscillator if it is not going to be used
-    system_controller->SCS =
-        bit::Clear(system_controller->SCS, OscillatorRegister::kExternalEnable);
+    OscillatorRegister::Register()
+        .Clear(OscillatorRegister::kExternalEnable)
+        .Save();
 
     // =========================================================================
     // Step 3. Select oscillator source for System Clock and Main PLL
@@ -445,20 +522,25 @@ class SystemController final : public sjsu::SystemController
     // Step 5. Set clock dividers for each clock source
     // =========================================================================
     // Set CPU clock divider
-    sys->CCLKSEL = bit::Insert(sys->CCLKSEL, config.cpu.divider,
-                               CpuClockRegister::kDivider);
+    CpuClockRegister::Register()
+        .Insert(config.cpu.divider, CpuClockRegister::kDivider)
+        .Save();
     // Set EMC clock divider
-    sys->EMCCLKSEL = bit::Insert(sys->EMCCLKSEL, Value(config.emc_divider),
-                                 EmcClockRegister::kDivider);
+    EmcClockRegister::Register()
+        .Insert(Value(config.emc_divider), EmcClockRegister::kDivider)
+        .Save();
     // Set Peripheral clock divider
-    sys->PCLKSEL = bit::Insert(sys->PCLKSEL, config.peripheral_divider,
-                               PeripheralClockRegister::kDivider);
+    PeripheralClockRegister::Register()
+        .Insert(config.peripheral_divider, PeripheralClockRegister::kDivider)
+        .Save();
     // Set USB clock divider
-    sys->USBCLKSEL = bit::Insert(sys->USBCLKSEL, Value(config.usb.divider),
-                                 UsbClockRegister::kDivider);
+    UsbClockRegister::Register()
+        .Insert(Value(config.usb.divider), UsbClockRegister::kDivider)
+        .Save();
     // Set SPIFI clock divider
-    sys->SPIFISEL = bit::Insert(sys->SPIFISEL, config.spifi.divider,
-                                SpiFiClockRegister::kDivider);
+    SpiFiClockRegister::Register()
+        .Insert(config.spifi.divider, SpiFiClockRegister::kDivider)
+        .Save();
 
     switch (config.cpu.clock)
     {
@@ -521,16 +603,19 @@ class SystemController final : public sjsu::SystemController
     // Step 7. Finally select the sources for each clock
     // =========================================================================
     // Set CPU clock the source defined in the configuration
-    sys->CCLKSEL = bit::Insert(sys->CCLKSEL, Value(config.cpu.clock),
-                               CpuClockRegister::kSelect);
+    CpuClockRegister::Register()
+        .Insert(Value(config.cpu.clock), CpuClockRegister::kSelect)
+        .Save();
 
     // Set USB clock the source defined in the configuration
-    sys->USBCLKSEL = bit::Insert(sys->USBCLKSEL, Value(config.usb.clock),
-                                 UsbClockRegister::kSelect);
+    UsbClockRegister::Register()
+        .Insert(Value(config.usb.clock), UsbClockRegister::kSelect)
+        .Save();
 
     // Set SPIFI clock the source defined in the configuration
-    sys->SPIFISEL = bit::Insert(sys->SPIFISEL, Value(config.spifi.clock),
-                                SpiFiClockRegister::kSelect);
+    SpiFiClockRegister::Register()
+        .Insert(Value(config.spifi.clock), SpiFiClockRegister::kSelect)
+        .Save();
   }
 
  private:
@@ -599,28 +684,27 @@ class SystemController final : public sjsu::SystemController
 
   void EnableExternalOscillator() const
   {
-    auto frequency = clock_configuration_.external_oscillator_frequency;
+    auto scs_register = OscillatorRegister::Register();
+    auto frequency    = clock_configuration_.external_oscillator_frequency;
     if (1_MHz <= frequency && frequency <= 20_MHz)
     {
-      system_controller->SCS =
-          bit::Clear(system_controller->SCS, OscillatorRegister::kRangeSelect);
+      scs_register.Clear(OscillatorRegister::kRangeSelect);
     }
     else if (20_MHz <= frequency && frequency <= 25_MHz)
     {
-      system_controller->SCS =
-          bit::Set(system_controller->SCS, OscillatorRegister::kRangeSelect);
+      scs_register.Set(OscillatorRegister::kRangeSelect);
+    }
+    else
+    {
+      SJ2_ASSERT_FATAL(
+          false,
+          "External Oscillator Frequency is outside of the the acceptable 1 "
+          "MHz <--> 25 MHz.");
     }
 
-    SJ2_ASSERT_FATAL(
-        1_MHz <= frequency && frequency <= 25_MHz,
-        "External Oscillator Frequency is outside of the the acceptable 1 "
-        "MHz <--> 25 MHz.");
+    scs_register.Set(OscillatorRegister::kExternalEnable).Save();
 
-    system_controller->SCS =
-        bit::Set(system_controller->SCS, OscillatorRegister::kExternalEnable);
-
-    while (
-        !bit::Read(system_controller->SCS, OscillatorRegister::kExternalReady))
+    while (!scs_register.Read(OscillatorRegister::kExternalReady))
     {
       continue;
     }

--- a/library/L1_Peripheral/lpc40xx/test/adc_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/adc_test.cpp
@@ -81,7 +81,7 @@ TEST_CASE("Testing lpc40xx adc", "[lpc40xx-adc]")
     // Verify
     // Verify that PowerUpPeripheral() was called with the ADC peripheral id
     Verify(Method(mock_system_controller, PowerUpPeripheral)
-               .Matching([](sjsu::SystemController::PeripheralID id) {
+               .Matching([](sjsu::SystemController::ResourceID id) {
                  return SystemController::Peripherals::kAdc.device_id ==
                         id.device_id;
                }));

--- a/library/L1_Peripheral/lpc40xx/test/can_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/can_test.cpp
@@ -52,7 +52,7 @@ TEST_CASE("Testing lpc40xx Can", "[lpc40xx-can]")
   SECTION("Initialize()")
   {
     // Setup
-    auto check_power_up = [](sjsu::SystemController::PeripheralID id) -> bool {
+    auto check_power_up = [](sjsu::SystemController::ResourceID id) -> bool {
       return sjsu::lpc40xx::SystemController::Peripherals::kCan1.device_id ==
              id.device_id;
     };

--- a/library/L1_Peripheral/lpc40xx/test/i2c_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/i2c_test.cpp
@@ -75,7 +75,7 @@ TEST_CASE("Testing lpc40xx I2C", "[lpc40xx-i2c]")
     constexpr uint32_t kHigh = static_cast<uint32_t>(kSclh);
 
     Verify(Method(mock_system_controller, PowerUpPeripheral)
-               .Matching([](sjsu::SystemController::PeripheralID id) {
+               .Matching([](sjsu::SystemController::ResourceID id) {
                  return sjsu::lpc40xx::SystemController::Peripherals::kI2c0
                             .device_id == id.device_id;
                }));

--- a/library/L1_Peripheral/lpc40xx/test/pwm_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/pwm_test.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Testing lpc40xx PWM instantiation", "[lpc40xx-pwm]")
 
     // Verify
     Verify(Method(mock_system_controller, PowerUpPeripheral)
-               .Matching([](sjsu::SystemController::PeripheralID id) {
+               .Matching([](sjsu::SystemController::ResourceID id) {
                  return sjsu::lpc40xx::SystemController::Peripherals::kPwm0
                             .device_id == id.device_id;
                }));

--- a/library/L1_Peripheral/lpc40xx/test/spi_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/spi_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Testing lpc40xx SPI", "[lpc40xx-Spi]")
   SECTION("Initialize")
   {
     Verify(Method(mock_system_controller, PowerUpPeripheral)
-               .Matching([](sjsu::SystemController::PeripheralID id) {
+               .Matching([](sjsu::SystemController::ResourceID id) {
                  return sjsu::lpc40xx::SystemController::Peripherals::kSsp0
                             .device_id == id.device_id;
                }));

--- a/library/L1_Peripheral/lpc40xx/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/system_controller_test.cpp
@@ -34,7 +34,7 @@ TEST_CASE("sjsu::lpc40xx::SystemController", "[lpc40xx-system-controller]")
     {
       // Setup
       INFO("Error on peripheral ID " << i);
-      const sjsu::SystemController::PeripheralID kTestPeripheral = {
+      const sjsu::SystemController::ResourceID kTestPeripheral = {
         .device_id = i
       };
       // Setup: Set the power bits to all zero to isolate the change made by
@@ -56,7 +56,7 @@ TEST_CASE("sjsu::lpc40xx::SystemController", "[lpc40xx-system-controller]")
     {
       // Setup
       INFO("Error on peripheral ID " << i);
-      const sjsu::SystemController::PeripheralID kTestPeripheral = {
+      const sjsu::SystemController::ResourceID kTestPeripheral = {
         .device_id = i
       };
       // Setup: Set all of the power bits to all 1s to isolate the change made
@@ -80,7 +80,7 @@ TEST_CASE("sjsu::lpc40xx::SystemController", "[lpc40xx-system-controller]")
     {
       // Setup
       INFO("Error on peripheral ID " << i);
-      const sjsu::SystemController::PeripheralID kTestPeripheral = {
+      const sjsu::SystemController::ResourceID kTestPeripheral = {
         .device_id = i
       };
       // Setup: Set all of the power bits to all 1s to isolate the change made
@@ -95,7 +95,7 @@ TEST_CASE("sjsu::lpc40xx::SystemController", "[lpc40xx-system-controller]")
     {
       // Setup
       INFO("Error on peripheral ID " << i);
-      const sjsu::SystemController::PeripheralID kTestPeripheral = {
+      const sjsu::SystemController::ResourceID kTestPeripheral = {
         .device_id = i
       };
       // Setup: Set all of the power bits to all 1s to isolate the change made

--- a/library/L1_Peripheral/lpc40xx/test/timer_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/timer_test.cpp
@@ -10,7 +10,7 @@ TEST_CASE("Testing lpc40xx Timer", "[lpc40xx-timer]")
   LPC_TIM_TypeDef local_timer_registers;
   testing::ClearStructure(&local_timer_registers);
 
-  constexpr SystemController::PeripheralID kExpectedPeripheralId =
+  constexpr SystemController::ResourceID kExpectedPeripheralId =
       SystemController::Peripherals::kTimer0;
   constexpr units::frequency::hertz_t kClockFrequency = 12_MHz;
   constexpr int kExpectedIrq                          = 0;
@@ -48,7 +48,7 @@ TEST_CASE("Testing lpc40xx Timer", "[lpc40xx-timer]")
 
     // Verify
     Verify(Method(mock_system_controller, PowerUpPeripheral)
-               .Matching([](sjsu::SystemController::PeripheralID id) {
+               .Matching([](sjsu::SystemController::ResourceID id) {
                  return kExpectedPeripheralId.device_id == id.device_id;
                }),
            Method(mock_interrupt_controller, Enable));

--- a/library/L1_Peripheral/lpc40xx/test/uart_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/uart_test.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Testing lpc40xx Uart", "[lpc40xx-Uart]")
     constexpr uint32_t kExpectedFdr = (kExpectedMul << 4) | kExpectedDivAdd;
 
     Verify(Method(mock_system_controller, PowerUpPeripheral)
-               .Matching([](sjsu::SystemController::PeripheralID id) {
+               .Matching([](sjsu::SystemController::ResourceID id) {
                  return sjsu::lpc40xx::SystemController::Peripherals::kUart2
                             .device_id == id.device_id;
                }));

--- a/library/L1_Peripheral/lpc40xx/timer.hpp
+++ b/library/L1_Peripheral/lpc40xx/timer.hpp
@@ -29,7 +29,7 @@ class Timer final : public sjsu::Timer
     /// Address to the timer peripheral registers
     LPC_TIM_TypeDef * peripheral;
     /// ID of the timer peripheral (used to power on the peripheral)
-    sjsu::SystemController::PeripheralID id;
+    sjsu::SystemController::ResourceID id;
     /// Interrupt Request Number for this timer
     int irq;
   };

--- a/library/L1_Peripheral/lpc40xx/uart.hpp
+++ b/library/L1_Peripheral/lpc40xx/uart.hpp
@@ -221,8 +221,8 @@ class Uart final : public sjsu::Uart
   {
     /// Address of the LPC_UART peripheral in memory
     LPC_UART_TypeDef * registers;
-    /// PeripheralID of the UART peripheral to power on at initialization.
-    sjsu::SystemController::PeripheralID power_on_id;
+    /// ResourceID of the UART peripheral to power on at initialization.
+    sjsu::SystemController::ResourceID power_on_id;
     /// Refernce to a uart transmitter pin
     const sjsu::Pin & tx;
     /// Refernce to a uart receiver pin

--- a/library/L1_Peripheral/stm32f10x/system_controller.hpp
+++ b/library/L1_Peripheral/stm32f10x/system_controller.hpp
@@ -14,6 +14,9 @@ namespace stm32f10x
 {
 /// System controller for stm32f10x that controls clock sources, clock speed,
 /// clock outputs control, and peripheral enabling
+///
+/// @see 8 Connectivity line devices: reset and clock control (RCC)
+///      https://www.st.com/resource/en/reference_manual/cd00171190-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf#page=123
 class SystemController : public sjsu::SystemController
 {
  public:
@@ -29,75 +32,75 @@ class SystemController : public sjsu::SystemController
     static constexpr uint32_t kAHB = kBits * 0;
 
     //! @cond Doxygen_Suppress
-    static constexpr auto kDma1  = PeripheralID::Define<kAHB + 0>();
-    static constexpr auto kDma2  = PeripheralID::Define<kAHB + 1>();
-    static constexpr auto kSram  = PeripheralID::Define<kAHB + 2>();
-    static constexpr auto kFlitf = PeripheralID::Define<kAHB + 4>();
-    static constexpr auto kCrc   = PeripheralID::Define<kAHB + 6>();
-    static constexpr auto kFsmc  = PeripheralID::Define<kAHB + 8>();
-    static constexpr auto kSdio  = PeripheralID::Define<kAHB + 10>();
+    static constexpr auto kDma1  = ResourceID::Define<kAHB + 0>();
+    static constexpr auto kDma2  = ResourceID::Define<kAHB + 1>();
+    static constexpr auto kSram  = ResourceID::Define<kAHB + 2>();
+    static constexpr auto kFlitf = ResourceID::Define<kAHB + 4>();
+    static constexpr auto kCrc   = ResourceID::Define<kAHB + 6>();
+    static constexpr auto kFsmc  = ResourceID::Define<kAHB + 8>();
+    static constexpr auto kSdio  = ResourceID::Define<kAHB + 10>();
     //! @endcond
 
     /// Bit position of APB1
     static constexpr uint32_t kAPB1 = kBits * 1;
 
     //! @cond Doxygen_Suppress
-    static constexpr auto kTimer2         = PeripheralID::Define<kAPB1 + 0>();
-    static constexpr auto kTimer3         = PeripheralID::Define<kAPB1 + 1>();
-    static constexpr auto kTimer4         = PeripheralID::Define<kAPB1 + 2>();
-    static constexpr auto kTimer5         = PeripheralID::Define<kAPB1 + 3>();
-    static constexpr auto kTimer6         = PeripheralID::Define<kAPB1 + 4>();
-    static constexpr auto kTimer7         = PeripheralID::Define<kAPB1 + 5>();
-    static constexpr auto kTimer12        = PeripheralID::Define<kAPB1 + 6>();
-    static constexpr auto kTimer13        = PeripheralID::Define<kAPB1 + 7>();
-    static constexpr auto kTimer14        = PeripheralID::Define<kAPB1 + 8>();
-    static constexpr auto kWindowWatchdog = PeripheralID::Define<kAPB1 + 11>();
-    static constexpr auto kSpi2           = PeripheralID::Define<kAPB1 + 14>();
-    static constexpr auto kSpi3           = PeripheralID::Define<kAPB1 + 15>();
-    static constexpr auto kUsart2         = PeripheralID::Define<kAPB1 + 17>();
-    static constexpr auto kUsart3         = PeripheralID::Define<kAPB1 + 18>();
-    static constexpr auto kUart4          = PeripheralID::Define<kAPB1 + 19>();
-    static constexpr auto kUart5          = PeripheralID::Define<kAPB1 + 20>();
-    static constexpr auto kI2c1           = PeripheralID::Define<kAPB1 + 21>();
-    static constexpr auto kI2c2           = PeripheralID::Define<kAPB1 + 22>();
-    static constexpr auto kUsb            = PeripheralID::Define<kAPB1 + 23>();
-    static constexpr auto kCan1           = PeripheralID::Define<kAPB1 + 25>();
-    static constexpr auto kBackupClock    = PeripheralID::Define<kAPB1 + 27>();
-    static constexpr auto kPower          = PeripheralID::Define<kAPB1 + 28>();
-    static constexpr auto kDac            = PeripheralID::Define<kAPB1 + 29>();
+    static constexpr auto kTimer2         = ResourceID::Define<kAPB1 + 0>();
+    static constexpr auto kTimer3         = ResourceID::Define<kAPB1 + 1>();
+    static constexpr auto kTimer4         = ResourceID::Define<kAPB1 + 2>();
+    static constexpr auto kTimer5         = ResourceID::Define<kAPB1 + 3>();
+    static constexpr auto kTimer6         = ResourceID::Define<kAPB1 + 4>();
+    static constexpr auto kTimer7         = ResourceID::Define<kAPB1 + 5>();
+    static constexpr auto kTimer12        = ResourceID::Define<kAPB1 + 6>();
+    static constexpr auto kTimer13        = ResourceID::Define<kAPB1 + 7>();
+    static constexpr auto kTimer14        = ResourceID::Define<kAPB1 + 8>();
+    static constexpr auto kWindowWatchdog = ResourceID::Define<kAPB1 + 11>();
+    static constexpr auto kSpi2           = ResourceID::Define<kAPB1 + 14>();
+    static constexpr auto kSpi3           = ResourceID::Define<kAPB1 + 15>();
+    static constexpr auto kUsart2         = ResourceID::Define<kAPB1 + 17>();
+    static constexpr auto kUsart3         = ResourceID::Define<kAPB1 + 18>();
+    static constexpr auto kUart4          = ResourceID::Define<kAPB1 + 19>();
+    static constexpr auto kUart5          = ResourceID::Define<kAPB1 + 20>();
+    static constexpr auto kI2c1           = ResourceID::Define<kAPB1 + 21>();
+    static constexpr auto kI2c2           = ResourceID::Define<kAPB1 + 22>();
+    static constexpr auto kUsb            = ResourceID::Define<kAPB1 + 23>();
+    static constexpr auto kCan1           = ResourceID::Define<kAPB1 + 25>();
+    static constexpr auto kBackupClock    = ResourceID::Define<kAPB1 + 27>();
+    static constexpr auto kPower          = ResourceID::Define<kAPB1 + 28>();
+    static constexpr auto kDac            = ResourceID::Define<kAPB1 + 29>();
     //! @endcond
 
     /// Bit position of AHB2
     static constexpr uint32_t kAPB2 = kBits * 2;
 
     //! @cond Doxygen_Suppress
-    static constexpr auto kAFIO    = PeripheralID::Define<kAPB2 + 0>();
-    static constexpr auto kGpioA   = PeripheralID::Define<kAPB2 + 2>();
-    static constexpr auto kGpioB   = PeripheralID::Define<kAPB2 + 3>();
-    static constexpr auto kGpioC   = PeripheralID::Define<kAPB2 + 4>();
-    static constexpr auto kGpioD   = PeripheralID::Define<kAPB2 + 5>();
-    static constexpr auto kGpioE   = PeripheralID::Define<kAPB2 + 6>();
-    static constexpr auto kGpioF   = PeripheralID::Define<kAPB2 + 7>();
-    static constexpr auto kGpioG   = PeripheralID::Define<kAPB2 + 8>();
-    static constexpr auto kAdc1    = PeripheralID::Define<kAPB2 + 9>();
-    static constexpr auto kAdc2    = PeripheralID::Define<kAPB2 + 10>();
-    static constexpr auto kTimer1  = PeripheralID::Define<kAPB2 + 11>();
-    static constexpr auto kSpi1    = PeripheralID::Define<kAPB2 + 12>();
-    static constexpr auto kTimer8  = PeripheralID::Define<kAPB2 + 13>();
-    static constexpr auto kUsart1  = PeripheralID::Define<kAPB2 + 14>();
-    static constexpr auto kAdc3    = PeripheralID::Define<kAPB2 + 15>();
-    static constexpr auto kTimer9  = PeripheralID::Define<kAPB2 + 19>();
-    static constexpr auto kTimer10 = PeripheralID::Define<kAPB2 + 20>();
-    static constexpr auto kTimer11 = PeripheralID::Define<kAPB2 + 21>();
+    static constexpr auto kAFIO    = ResourceID::Define<kAPB2 + 0>();
+    static constexpr auto kGpioA   = ResourceID::Define<kAPB2 + 2>();
+    static constexpr auto kGpioB   = ResourceID::Define<kAPB2 + 3>();
+    static constexpr auto kGpioC   = ResourceID::Define<kAPB2 + 4>();
+    static constexpr auto kGpioD   = ResourceID::Define<kAPB2 + 5>();
+    static constexpr auto kGpioE   = ResourceID::Define<kAPB2 + 6>();
+    static constexpr auto kGpioF   = ResourceID::Define<kAPB2 + 7>();
+    static constexpr auto kGpioG   = ResourceID::Define<kAPB2 + 8>();
+    static constexpr auto kAdc1    = ResourceID::Define<kAPB2 + 9>();
+    static constexpr auto kAdc2    = ResourceID::Define<kAPB2 + 10>();
+    static constexpr auto kTimer1  = ResourceID::Define<kAPB2 + 11>();
+    static constexpr auto kSpi1    = ResourceID::Define<kAPB2 + 12>();
+    static constexpr auto kTimer8  = ResourceID::Define<kAPB2 + 13>();
+    static constexpr auto kUsart1  = ResourceID::Define<kAPB2 + 14>();
+    static constexpr auto kAdc3    = ResourceID::Define<kAPB2 + 15>();
+    static constexpr auto kTimer9  = ResourceID::Define<kAPB2 + 19>();
+    static constexpr auto kTimer10 = ResourceID::Define<kAPB2 + 20>();
+    static constexpr auto kTimer11 = ResourceID::Define<kAPB2 + 21>();
     //! @endcond
 
     /// Bit position of systems outside of any bus
     static constexpr uint32_t kBeyond = kBits * 3;
 
     //! @cond Doxygen_Suppress
-    static constexpr auto kCpu         = PeripheralID::Define<kBeyond + 0>();
-    static constexpr auto kSystemTimer = PeripheralID::Define<kBeyond + 1>();
-    static constexpr auto kI2s         = PeripheralID::Define<kBeyond + 2>();
+    static constexpr auto kCpu         = ResourceID::Define<kBeyond + 0>();
+    static constexpr auto kSystemTimer = ResourceID::Define<kBeyond + 1>();
+    static constexpr auto kI2s         = ResourceID::Define<kBeyond + 2>();
     //! @endcond
   };
 
@@ -159,6 +162,15 @@ class SystemController : public sjsu::SystemController
   /// Bit masks for the CFGR register
   struct ClockConfigurationRegisters  // NOLINT
   {
+    /// @see 8.3.2 Clock configuration register (RCC_CFGR)
+    ///      https://www.st.com/resource/en/reference_manual/cd00171190-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf#page=134
+    ///
+    /// @returns The RCC_CFGR bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&clock_control->CFGR);
+    }
+
     /// Controls which clock signal is sent to the MCO pin
     static constexpr auto kMco = bit::MaskFromRange(24, 26);
 
@@ -197,6 +209,15 @@ class SystemController : public sjsu::SystemController
   /// Bit masks for the CR register
   struct ClockControlRegisters  // NOLINT
   {
+    /// @see 8.3.1 Clock control register (RCC_CR)
+    ///      https://www.st.com/resource/en/reference_manual/cd00171190-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf#page=132
+    ///
+    /// @returns The RCC_CR bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&clock_control->CR);
+    }
+
     /// Indicates if the PLL is enabled and ready
     static constexpr auto kPllReady = bit::MaskFromRange(25);
     /// Used to enable the PLL
@@ -230,6 +251,15 @@ class SystemController : public sjsu::SystemController
   /// Bitmasks for the BDCR register
   struct RtcRegisters  // NOLINT
   {
+    /// @see 8.3.9 Backup domain control register (RCC_BDCR)
+    ///      https://www.st.com/resource/en/reference_manual/cd00171190-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf#page=150
+    ///
+    /// @returns The RCC_BDCR bit register.
+    static bit::Register<uint32_t> Register()
+    {
+      return bit::Register(&clock_control->BDCR);
+    }
+
     /// Will reset all clock states for the RTC
     static constexpr auto kBackupDomainReset = bit::MaskFromRange(16);
     /// Enables the RTC clock
@@ -267,7 +297,8 @@ class SystemController : public sjsu::SystemController
     kDivideBy1Point5 = 0,
   };
 
-  /// RM0008 page 126 describes the clock tree for the stm32f10x
+  /// @see Figure 11. Clock Tree
+  ///      https://www.st.com/resource/en/reference_manual/cd00171190-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf#page=126
   struct ClockConfiguration  // NOLINT
   {
     /// Defines the frequency of the high speed external clock signal
@@ -301,7 +332,7 @@ class SystemController : public sjsu::SystemController
     {
       bool enable      = false;
       RtcSource source = RtcSource::kLowSpeedInternal;
-    } rtc;
+    } rtc = {};
 
     /// Defines the configuration of the dividers beyond system clock mux.
     struct
@@ -343,8 +374,16 @@ class SystemController : public sjsu::SystemController
   {
   }
 
-  // Clock tree 8. page 86
-
+  /// @attention If configuration of the system clocks is desired, one should
+  ///            consult the user manual of the target MCU in use to determine
+  ///            the valid clock configuration values that can/should be used.
+  ///            The Initialize() method is only responsible for configuring the
+  ///            clock system based on configurations in the ClockConfiguration.
+  ///            Incorrect configurations may result in a hard fault or cause
+  ///            the clock system(s) to supply incorrect clock rate(s).
+  ///
+  /// @see Figure 11. Clock Tree
+  ///      https://www.st.com/resource/en/reference_manual/cd00171190-stm32f101xx-stm32f102xx-stm32f103xx-stm32f105xx-and-stm32f107xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf#page=126
   void Initialize() override
   {
     units::frequency::hertz_t system_clock = 0_Hz;
@@ -354,28 +393,25 @@ class SystemController : public sjsu::SystemController
     //         Make sure PLLs are not clock sources for everything.
     // =========================================================================
     // Step 1.1 Set SystemClock to HSI
-    clock_control->CFGR = bit::Insert(
-        clock_control->CFGR, Value(SystemClockSelect::kHighSpeedInternal),
-        ClockConfigurationRegisters::kSystemClockSelect);
+    ClockConfigurationRegisters::Register()
+        .Insert(Value(SystemClockSelect::kHighSpeedInternal),
+                ClockConfigurationRegisters::kSystemClockSelect)
+        .Save();
 
     // Step 1.4 Reset RTC clock registers
-    clock_control->BDCR =
-        bit::Set(clock_control->BDCR, RtcRegisters::kBackupDomainReset);
-
+    RtcRegisters::Register().Set(RtcRegisters::kBackupDomainReset).Save();
     // Manually clear the RTC reset bit
-    clock_control->BDCR =
-        bit::Clear(clock_control->BDCR, RtcRegisters::kBackupDomainReset);
+    RtcRegisters::Register().Clear(RtcRegisters::kBackupDomainReset).Save();
 
     // =========================================================================
     // Step 2. Disable PLL and external clock sources
     // =========================================================================
-    // Step 2.1 Disable PLLs
-    clock_control->CR =
-        bit::Clear(clock_control->CR, ClockControlRegisters::kPllEnable);
-
-    // Step 2.1 Disable External Oscillators
-    clock_control->CR = bit::Clear(clock_control->CR,
-                                   ClockControlRegisters::kExternalOscEnable);
+    ClockControlRegisters::Register()
+        // Step 2.1 Disable PLLs
+        .Clear(ClockControlRegisters::kPllEnable)
+        // Step 2.1 Disable External Oscillators
+        .Clear(ClockControlRegisters::kExternalOscEnable)
+        .Save();
 
     // =========================================================================
     // Step 3. Enable External Oscillators
@@ -383,11 +419,12 @@ class SystemController : public sjsu::SystemController
     // Step 3.1 Enable High speed external Oscillator
     if (config_.high_speed_external != 0_MHz)
     {
-      clock_control->CR = bit::Set(clock_control->CR,
-                                   ClockControlRegisters::kExternalOscEnable);
+      ClockControlRegisters::Register()
+          .Set(ClockControlRegisters::kExternalOscEnable)
+          .Save();
 
-      while (!bit::Read(clock_control->CR,
-                        ClockControlRegisters::kExternalOscReady))
+      while (!ClockControlRegisters::Register().Read(
+          ClockControlRegisters::kExternalOscReady))
       {
         continue;
       }
@@ -396,10 +433,9 @@ class SystemController : public sjsu::SystemController
     // Step 3.2 Enable Low speed external Oscillator
     if (config_.low_speed_external != 0_MHz)
     {
-      clock_control->BDCR =
-          bit::Insert(clock_control->BDCR, 1, RtcRegisters::kLowSpeedOscEnable);
+      RtcRegisters::Register().Set(RtcRegisters::kLowSpeedOscEnable).Save();
 
-      while (!bit::Read(clock_control->BDCR, RtcRegisters::kLowSpeedOscReady))
+      while (!RtcRegisters::Register().Read(RtcRegisters::kLowSpeedOscReady))
       {
         continue;
       }
@@ -408,34 +444,29 @@ class SystemController : public sjsu::SystemController
     // =========================================================================
     // Step 4. Set oscillator source for PLLs
     // =========================================================================
-    if (config_.pll.source == PllSource::kHighSpeedExternalDividedBy2)
-    {
-      clock_control->CFGR = bit::Set(
-          clock_control->CFGR, ClockConfigurationRegisters::kHsePreDivider);
-    }
-    else
-    {
-      clock_control->CFGR = bit::Clear(
-          clock_control->CFGR, ClockConfigurationRegisters::kHsePreDivider);
-    }
-
-    clock_control->CFGR =
-        bit::Insert(clock_control->CFGR, Value(config_.pll.source),
-                    ClockConfigurationRegisters::kPllSource);
+    ClockConfigurationRegisters::Register()
+        .Insert((config_.pll.source == PllSource::kHighSpeedExternalDividedBy2),
+                ClockConfigurationRegisters::kHsePreDivider)
+        .Insert(Value(config_.pll.source),
+                ClockConfigurationRegisters::kPllSource)
+        .Save();
 
     // =========================================================================
     // Step 5. Setup PLLs and enable them where necessary
     // =========================================================================
     if (config_.pll.enable)
     {
-      clock_control->CFGR =
-          bit::Insert(clock_control->CFGR, Value(config_.pll.multiply),
-                      ClockConfigurationRegisters::kPllMul);
+      ClockConfigurationRegisters::Register()
+          .Insert(Value(config_.pll.multiply),
+                  ClockConfigurationRegisters::kPllMul)
+          .Save();
 
-      clock_control->CR =
-          bit::Set(clock_control->CR, ClockControlRegisters::kPllEnable);
+      ClockControlRegisters::Register()
+          .Set(ClockControlRegisters::kPllEnable)
+          .Save();
 
-      while (!bit::Read(clock_control->CR, ClockControlRegisters::kPllReady))
+      while (!ClockControlRegisters::Register().Read(
+          ClockControlRegisters::kPllReady))
       {
         continue;
       }
@@ -460,30 +491,23 @@ class SystemController : public sjsu::SystemController
     // =========================================================================
     // Step 6. Setup peripheral dividers
     // =========================================================================
-    // Step 6.1 Set USB divider
-    clock_control->CFGR =
-        bit::Insert(clock_control->CFGR, Value(config_.pll.usb.divider),
-                    ClockConfigurationRegisters::kUsbPrescalar);
-
-    // Step 6.2 Set AHB divider
-    clock_control->CFGR =
-        bit::Insert(clock_control->CFGR, Value(config_.ahb.divider),
-                    ClockConfigurationRegisters::kAHBDivider);
-
-    // Step 6.3 Set APB1 divider
-    clock_control->CFGR =
-        bit::Insert(clock_control->CFGR, Value(config_.ahb.apb1.divider),
-                    ClockConfigurationRegisters::kAPB1Divider);
-
-    // Step 6.4 Set APB2 divider
-    clock_control->CFGR =
-        bit::Insert(clock_control->CFGR, Value(config_.ahb.apb2.divider),
-                    ClockConfigurationRegisters::kAPB2Divider);
-
-    // Step 6.5 Set ADC divider
-    clock_control->CFGR =
-        bit::Insert(clock_control->CFGR, Value(config_.ahb.apb2.adc.divider),
-                    ClockConfigurationRegisters::kAdcDivider);
+    ClockConfigurationRegisters::Register()
+        // Step 6.1 Set USB divider
+        .Insert(Value(config_.pll.usb.divider),
+                ClockConfigurationRegisters::kUsbPrescalar)
+        // Step 6.2 Set AHB divider
+        .Insert(Value(config_.ahb.divider),
+                ClockConfigurationRegisters::kAHBDivider)
+        // Step 6.3 Set APB1 divider
+        .Insert(Value(config_.ahb.apb1.divider),
+                ClockConfigurationRegisters::kAPB1Divider)
+        // Step 6.4 Set APB2 divider
+        .Insert(Value(config_.ahb.apb2.divider),
+                ClockConfigurationRegisters::kAPB2Divider)
+        // Step 6.5 Set ADC divider
+        .Insert(Value(config_.ahb.apb2.adc.divider),
+                ClockConfigurationRegisters::kAdcDivider)
+        .Save();
 
     // =========================================================================
     // Step 7. Set System Clock and RTC Clock
@@ -519,12 +543,13 @@ class SystemController : public sjsu::SystemController
     // Step 7.2 Set system clock source
     // NOTE: return error if clock = SystemClockSelect::kHighSpeedExternal and
     //       high speed external is not enabled.
-    clock_control->CFGR =
-        bit::Insert(clock_control->CFGR, Value(config_.system_clock),
-                    ClockConfigurationRegisters::kSystemClockSelect);
+    ClockConfigurationRegisters::Register()
+        .Insert(Value(config_.system_clock),
+                ClockConfigurationRegisters::kSystemClockSelect)
+        .Save();
 
-    while (bit::Extract(clock_control->CFGR,
-                        ClockConfigurationRegisters::kSystemClockStatus) !=
+    while (ClockConfigurationRegisters::Register().Extract(
+               ClockConfigurationRegisters::kSystemClockStatus) !=
            target_clock_source)
     {
       continue;
@@ -541,14 +566,12 @@ class SystemController : public sjsu::SystemController
       case SystemClockSelect::kPll: system_clock = pll_clock_rate_; break;
     }
 
-    // Step 7.3 Set the RTC oscillator source
-    clock_control->BDCR =
-        bit::Insert(clock_control->BDCR, Value(config_.rtc.source),
-                    RtcRegisters::kRtcSourceSelect);
-
-    // Step 7.4 Enable/Disable the RTC
-    clock_control->BDCR = bit::Insert(clock_control->BDCR, config_.rtc.enable,
-                                      RtcRegisters::kRtcEnable);
+    RtcRegisters::Register()
+        // Step 7.3 Set the RTC oscillator source
+        .Insert(Value(config_.rtc.source), RtcRegisters::kRtcSourceSelect)
+        // Step 7.4 Enable/Disable the RTC
+        .Insert(config_.rtc.enable, RtcRegisters::kRtcEnable)
+        .Save();
 
     // =========================================================================
     // Step 8. Define the clock rates for the system
@@ -673,7 +696,7 @@ class SystemController : public sjsu::SystemController
   }
 
   /// @return the clock rate frequency of a peripheral
-  units::frequency::hertz_t GetClockRate(PeripheralID id) const override
+  units::frequency::hertz_t GetClockRate(ResourceID id) const override
   {
     switch (id.device_id)
     {
@@ -729,29 +752,29 @@ class SystemController : public sjsu::SystemController
     return 0_Hz;
   }
 
-  bool IsPeripheralPoweredUp(PeripheralID id) const override
+  bool IsPeripheralPoweredUp(ResourceID id) const override
   {
     return bit::Read(*EnableRegister(id), EnableBitPosition(id));
   }
 
-  void PowerUpPeripheral(PeripheralID id) const override
+  void PowerUpPeripheral(ResourceID id) const override
   {
     *EnableRegister(id) = bit::Set(*EnableRegister(id), EnableBitPosition(id));
   }
 
-  void PowerDownPeripheral(PeripheralID id) const override
+  void PowerDownPeripheral(ResourceID id) const override
   {
     *EnableRegister(id) =
         bit::Clear(*EnableRegister(id), EnableBitPosition(id));
   }
 
  private:
-  volatile uint32_t * EnableRegister(PeripheralID id) const
+  volatile uint32_t * EnableRegister(ResourceID id) const
   {
     return enable[id.device_id / kBits];
   }
 
-  uint32_t EnableBitPosition(PeripheralID id) const
+  uint32_t EnableBitPosition(ResourceID id) const
   {
     return id.device_id % kBits;
   }

--- a/library/L1_Peripheral/stm32f10x/test/gpio_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/gpio_test.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Testing stm32f10x Gpio", "[stm32f10x-gpio]")
   {
     sjsu::stm32f10x::Gpio gpio = stm32f10x::Gpio('A', 0);
     GPIO_TypeDef & reg;
-    SystemController::PeripheralID id;
+    SystemController::ResourceID id;
   };
 
   std::array<TestStruct_t, 15> test = {
@@ -173,8 +173,8 @@ TEST_CASE("Testing stm32f10x Gpio", "[stm32f10x-gpio]")
   SECTION("SetDirection()")
   {
     auto power_up_matcher =
-        [](sjsu::SystemController::PeripheralID expected_id) {
-          return [expected_id](sjsu::SystemController::PeripheralID actual_id) {
+        [](sjsu::SystemController::ResourceID expected_id) {
+          return [expected_id](sjsu::SystemController::ResourceID actual_id) {
             return expected_id.device_id == actual_id.device_id;
           };
         };

--- a/library/L1_Peripheral/stm32f10x/test/pin_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/pin_test.cpp
@@ -69,8 +69,8 @@ TEST_CASE("Testing stm32f10x Pin", "[stm32f10x-pin]")
   stm32f10x::Pin pin_f0('F', 0);    // F
   stm32f10x::Pin pin_g0('G', 0);    // G
 
-  auto power_up_matcher = [](sjsu::SystemController::PeripheralID expected_id) {
-    return [expected_id](sjsu::SystemController::PeripheralID actual_id) {
+  auto power_up_matcher = [](sjsu::SystemController::ResourceID expected_id) {
+    return [expected_id](sjsu::SystemController::ResourceID actual_id) {
       return expected_id.device_id == actual_id.device_id;
     };
   };
@@ -79,7 +79,7 @@ TEST_CASE("Testing stm32f10x Pin", "[stm32f10x-pin]")
   {
     sjsu::Pin & pin;
     GPIO_TypeDef & reg;
-    SystemController::PeripheralID id;
+    SystemController::ResourceID id;
   };
 
   std::array<TestStruct_t, 12> test = {

--- a/library/L1_Peripheral/stm32f10x/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/system_controller_test.cpp
@@ -14,7 +14,7 @@ EMIT_ALL_METHODS(SystemController);
 
 TEST_CASE("Testing stm32f10x SystemController", "[stm32f10x-systemcontroller]")
 {
-  std::array<const SystemController::PeripheralID *, 10> id = {
+  std::array<const SystemController::ResourceID *, 10> id = {
     // AHB
     &stm32f10x::SystemController::Peripherals::kFlitf,
     &stm32f10x::SystemController::Peripherals::kCrc,
@@ -768,7 +768,7 @@ TEST_CASE("Testing stm32f10x SystemController", "[stm32f10x-systemcontroller]")
 
       // Verify
       CHECK(0_Hz == test_subject.GetClockRate(
-                        SystemController::PeripheralID::Define<0xFFFF>()));
+                        SystemController::ResourceID::Define<0xFFFF>()));
     }
   }
 

--- a/library/L1_Peripheral/stm32f10x/uart.hpp
+++ b/library/L1_Peripheral/stm32f10x/uart.hpp
@@ -41,7 +41,7 @@ class UartBase : public sjsu::Uart
 
     /// The ID of the UART peripheral to be used. This is used to enable the
     /// peripheral clock of th UART peripheral.
-    SystemController::PeripheralID id;
+    SystemController::ResourceID id;
 
     /// Address of the DMA channel for this UART. The STM32F10x UART does not
     /// have a FIFO or buffer of any sort, thus DMA is required for reasonable

--- a/library/L1_Peripheral/stm32f4xx/system_controller.hpp
+++ b/library/L1_Peripheral/stm32f4xx/system_controller.hpp
@@ -14,6 +14,11 @@ namespace stm32f4xx
 {
 /// System controller for stm32f4xx that controls clock sources, clock speed,
 /// clock outputs control, and peripheral enabling
+///
+/// @see 6 Reset and clock control for STM32F42xxx and STM32F43xxx (RCC)
+///      https://www.st.com/resource/en/reference_manual/dm00031020-stm32f405-415-stm32f407-417-stm32f427-437-and-stm32f429-439-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf#page=150
+/// @see Figure 16. Clock tree
+///      https://www.st.com/resource/en/reference_manual/dm00031020-stm32f405-415-stm32f407-417-stm32f427-437-and-stm32f429-439-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf#page=152
 class SystemController : public sjsu::SystemController
 {
  public:
@@ -29,100 +34,100 @@ class SystemController : public sjsu::SystemController
     static constexpr uint32_t kAHB1 = kBits * 0;
 
     //! @cond Doxygen_Suppress
-    static constexpr auto kGpioA       = PeripheralID::Define<kAHB1 + 0>();
-    static constexpr auto kGpioB       = PeripheralID::Define<kAHB1 + 1>();
-    static constexpr auto kGpioC       = PeripheralID::Define<kAHB1 + 2>();
-    static constexpr auto kGpioD       = PeripheralID::Define<kAHB1 + 3>();
-    static constexpr auto kGpioE       = PeripheralID::Define<kAHB1 + 4>();
-    static constexpr auto kGpioF       = PeripheralID::Define<kAHB1 + 5>();
-    static constexpr auto kGpioG       = PeripheralID::Define<kAHB1 + 6>();
-    static constexpr auto kGpioH       = PeripheralID::Define<kAHB1 + 7>();
-    static constexpr auto kGpioI       = PeripheralID::Define<kAHB1 + 8>();
-    static constexpr auto kCrc         = PeripheralID::Define<kAHB1 + 12>();
-    static constexpr auto kBackupSRAM  = PeripheralID::Define<kAHB1 + 18>();
-    static constexpr auto kCcmRam      = PeripheralID::Define<kAHB1 + 20>();
-    static constexpr auto kDma1        = PeripheralID::Define<kAHB1 + 21>();
-    static constexpr auto kDma2        = PeripheralID::Define<kAHB1 + 22>();
-    static constexpr auto kEthernetMac = PeripheralID::Define<kAHB1 + 25>();
-    static constexpr auto kEthernetTx  = PeripheralID::Define<kAHB1 + 26>();
-    static constexpr auto kEthernetRx  = PeripheralID::Define<kAHB1 + 27>();
-    static constexpr auto kEthernetPTP = PeripheralID::Define<kAHB1 + 28>();
-    static constexpr auto kUsbOtg      = PeripheralID::Define<kAHB1 + 29>();
-    static constexpr auto kUsbOtgHS    = PeripheralID::Define<kAHB1 + 30>();
+    static constexpr auto kGpioA       = ResourceID::Define<kAHB1 + 0>();
+    static constexpr auto kGpioB       = ResourceID::Define<kAHB1 + 1>();
+    static constexpr auto kGpioC       = ResourceID::Define<kAHB1 + 2>();
+    static constexpr auto kGpioD       = ResourceID::Define<kAHB1 + 3>();
+    static constexpr auto kGpioE       = ResourceID::Define<kAHB1 + 4>();
+    static constexpr auto kGpioF       = ResourceID::Define<kAHB1 + 5>();
+    static constexpr auto kGpioG       = ResourceID::Define<kAHB1 + 6>();
+    static constexpr auto kGpioH       = ResourceID::Define<kAHB1 + 7>();
+    static constexpr auto kGpioI       = ResourceID::Define<kAHB1 + 8>();
+    static constexpr auto kCrc         = ResourceID::Define<kAHB1 + 12>();
+    static constexpr auto kBackupSRAM  = ResourceID::Define<kAHB1 + 18>();
+    static constexpr auto kCcmRam      = ResourceID::Define<kAHB1 + 20>();
+    static constexpr auto kDma1        = ResourceID::Define<kAHB1 + 21>();
+    static constexpr auto kDma2        = ResourceID::Define<kAHB1 + 22>();
+    static constexpr auto kEthernetMac = ResourceID::Define<kAHB1 + 25>();
+    static constexpr auto kEthernetTx  = ResourceID::Define<kAHB1 + 26>();
+    static constexpr auto kEthernetRx  = ResourceID::Define<kAHB1 + 27>();
+    static constexpr auto kEthernetPTP = ResourceID::Define<kAHB1 + 28>();
+    static constexpr auto kUsbOtg      = ResourceID::Define<kAHB1 + 29>();
+    static constexpr auto kUsbOtgHS    = ResourceID::Define<kAHB1 + 30>();
     //! @endcond
 
     /// Bit position of AHB2
     static constexpr uint32_t kAHB2 = kBits * 1;
 
     //! @cond Doxygen_Suppress
-    static constexpr auto kCamera   = PeripheralID::Define<kAHB2 + 0>();
-    static constexpr auto kCrypto   = PeripheralID::Define<kAHB2 + 4>();
-    static constexpr auto kHash     = PeripheralID::Define<kAHB2 + 5>();
-    static constexpr auto kRandom   = PeripheralID::Define<kAHB2 + 6>();
-    static constexpr auto kUsbOtgFs = PeripheralID::Define<kAHB2 + 7>();
+    static constexpr auto kCamera   = ResourceID::Define<kAHB2 + 0>();
+    static constexpr auto kCrypto   = ResourceID::Define<kAHB2 + 4>();
+    static constexpr auto kHash     = ResourceID::Define<kAHB2 + 5>();
+    static constexpr auto kRandom   = ResourceID::Define<kAHB2 + 6>();
+    static constexpr auto kUsbOtgFs = ResourceID::Define<kAHB2 + 7>();
     //! @endcond
 
     /// Bit position of AHB3
     static constexpr uint32_t kAHB3 = kBits * 2;
 
     //! @cond Doxygen_Suppress
-    static constexpr auto kFlexStaticMemory = PeripheralID::Define<kAHB3 + 0>();
+    static constexpr auto kFlexStaticMemory = ResourceID::Define<kAHB3 + 0>();
     //! @endcond
 
     /// Bit position of APB1
     static constexpr uint32_t kAPB1 = kBits * 3;
 
     //! @cond Doxygen_Suppress
-    static constexpr auto kTimer2         = PeripheralID::Define<kAPB1 + 0>();
-    static constexpr auto kTimer3         = PeripheralID::Define<kAPB1 + 1>();
-    static constexpr auto kTimer4         = PeripheralID::Define<kAPB1 + 2>();
-    static constexpr auto kTimer5         = PeripheralID::Define<kAPB1 + 3>();
-    static constexpr auto kTimer6         = PeripheralID::Define<kAPB1 + 4>();
-    static constexpr auto kTimer7         = PeripheralID::Define<kAPB1 + 5>();
-    static constexpr auto kTimer12        = PeripheralID::Define<kAPB1 + 6>();
-    static constexpr auto kTimer13        = PeripheralID::Define<kAPB1 + 7>();
-    static constexpr auto kTimer14        = PeripheralID::Define<kAPB1 + 8>();
-    static constexpr auto kWindowWatchdog = PeripheralID::Define<kAPB1 + 11>();
-    static constexpr auto kSpi2           = PeripheralID::Define<kAPB1 + 14>();
-    static constexpr auto kSpi3           = PeripheralID::Define<kAPB1 + 15>();
-    static constexpr auto kUsart2         = PeripheralID::Define<kAPB1 + 17>();
-    static constexpr auto kUsart3         = PeripheralID::Define<kAPB1 + 18>();
-    static constexpr auto kUart4          = PeripheralID::Define<kAPB1 + 19>();
-    static constexpr auto kUart5          = PeripheralID::Define<kAPB1 + 20>();
-    static constexpr auto kI2c1           = PeripheralID::Define<kAPB1 + 21>();
-    static constexpr auto kI2c2           = PeripheralID::Define<kAPB1 + 22>();
-    static constexpr auto kI2c3           = PeripheralID::Define<kAPB1 + 23>();
-    static constexpr auto kCan1           = PeripheralID::Define<kAPB1 + 25>();
-    static constexpr auto kCan2           = PeripheralID::Define<kAPB1 + 26>();
-    static constexpr auto kPower          = PeripheralID::Define<kAPB1 + 28>();
-    static constexpr auto kDac            = PeripheralID::Define<kAPB1 + 29>();
+    static constexpr auto kTimer2         = ResourceID::Define<kAPB1 + 0>();
+    static constexpr auto kTimer3         = ResourceID::Define<kAPB1 + 1>();
+    static constexpr auto kTimer4         = ResourceID::Define<kAPB1 + 2>();
+    static constexpr auto kTimer5         = ResourceID::Define<kAPB1 + 3>();
+    static constexpr auto kTimer6         = ResourceID::Define<kAPB1 + 4>();
+    static constexpr auto kTimer7         = ResourceID::Define<kAPB1 + 5>();
+    static constexpr auto kTimer12        = ResourceID::Define<kAPB1 + 6>();
+    static constexpr auto kTimer13        = ResourceID::Define<kAPB1 + 7>();
+    static constexpr auto kTimer14        = ResourceID::Define<kAPB1 + 8>();
+    static constexpr auto kWindowWatchdog = ResourceID::Define<kAPB1 + 11>();
+    static constexpr auto kSpi2           = ResourceID::Define<kAPB1 + 14>();
+    static constexpr auto kSpi3           = ResourceID::Define<kAPB1 + 15>();
+    static constexpr auto kUsart2         = ResourceID::Define<kAPB1 + 17>();
+    static constexpr auto kUsart3         = ResourceID::Define<kAPB1 + 18>();
+    static constexpr auto kUart4          = ResourceID::Define<kAPB1 + 19>();
+    static constexpr auto kUart5          = ResourceID::Define<kAPB1 + 20>();
+    static constexpr auto kI2c1           = ResourceID::Define<kAPB1 + 21>();
+    static constexpr auto kI2c2           = ResourceID::Define<kAPB1 + 22>();
+    static constexpr auto kI2c3           = ResourceID::Define<kAPB1 + 23>();
+    static constexpr auto kCan1           = ResourceID::Define<kAPB1 + 25>();
+    static constexpr auto kCan2           = ResourceID::Define<kAPB1 + 26>();
+    static constexpr auto kPower          = ResourceID::Define<kAPB1 + 28>();
+    static constexpr auto kDac            = ResourceID::Define<kAPB1 + 29>();
     //! @endcond
 
     /// Bit position of APB2
     static constexpr uint32_t kAPB2 = kBits * 4;
 
     //! @cond Doxygen_Suppress
-    static constexpr auto kTimer1  = PeripheralID::Define<kAPB2 + 0>();
-    static constexpr auto kTimer8  = PeripheralID::Define<kAPB2 + 1>();
-    static constexpr auto kUsart1  = PeripheralID::Define<kAPB2 + 4>();
-    static constexpr auto kUsart6  = PeripheralID::Define<kAPB2 + 6>();
-    static constexpr auto kAdc1    = PeripheralID::Define<kAPB2 + 8>();
-    static constexpr auto kAdc2    = PeripheralID::Define<kAPB2 + 9>();
-    static constexpr auto kAdc3    = PeripheralID::Define<kAPB2 + 10>();
-    static constexpr auto kSdIO    = PeripheralID::Define<kAPB2 + 11>();
-    static constexpr auto kSpi1    = PeripheralID::Define<kAPB2 + 12>();
-    static constexpr auto kSysCfg  = PeripheralID::Define<kAPB2 + 14>();
-    static constexpr auto kTimer9  = PeripheralID::Define<kAPB2 + 16>();
-    static constexpr auto kTimer10 = PeripheralID::Define<kAPB2 + 17>();
-    static constexpr auto kTimer11 = PeripheralID::Define<kAPB2 + 18>();
+    static constexpr auto kTimer1  = ResourceID::Define<kAPB2 + 0>();
+    static constexpr auto kTimer8  = ResourceID::Define<kAPB2 + 1>();
+    static constexpr auto kUsart1  = ResourceID::Define<kAPB2 + 4>();
+    static constexpr auto kUsart6  = ResourceID::Define<kAPB2 + 6>();
+    static constexpr auto kAdc1    = ResourceID::Define<kAPB2 + 8>();
+    static constexpr auto kAdc2    = ResourceID::Define<kAPB2 + 9>();
+    static constexpr auto kAdc3    = ResourceID::Define<kAPB2 + 10>();
+    static constexpr auto kSdIO    = ResourceID::Define<kAPB2 + 11>();
+    static constexpr auto kSpi1    = ResourceID::Define<kAPB2 + 12>();
+    static constexpr auto kSysCfg  = ResourceID::Define<kAPB2 + 14>();
+    static constexpr auto kTimer9  = ResourceID::Define<kAPB2 + 16>();
+    static constexpr auto kTimer10 = ResourceID::Define<kAPB2 + 17>();
+    static constexpr auto kTimer11 = ResourceID::Define<kAPB2 + 18>();
     //! @endcond
 
     /// Bit position of systems outside of any bus
     static constexpr uint32_t kBeyond = kBits * 5;
 
     //! @cond Doxygen_Suppress
-    static constexpr auto kCpu         = PeripheralID::Define<kBeyond + 0>();
-    static constexpr auto kSystemTimer = PeripheralID::Define<kBeyond + 1>();
+    static constexpr auto kCpu         = ResourceID::Define<kBeyond + 0>();
+    static constexpr auto kSystemTimer = ResourceID::Define<kBeyond + 1>();
     //! @endcond
   };
 
@@ -145,34 +150,34 @@ class SystemController : public sjsu::SystemController
     return nullptr;
   }
 
-  units::frequency::hertz_t GetClockRate(PeripheralID) const override
+  units::frequency::hertz_t GetClockRate(ResourceID) const override
   {
     return 16_MHz;
   }
 
-  bool IsPeripheralPoweredUp(PeripheralID id) const override
+  bool IsPeripheralPoweredUp(ResourceID id) const override
   {
     return bit::Read(*EnableRegister(id), EnableBitPosition(id));
   }
 
-  void PowerUpPeripheral(PeripheralID id) const override
+  void PowerUpPeripheral(ResourceID id) const override
   {
     *EnableRegister(id) = bit::Set(*EnableRegister(id), EnableBitPosition(id));
   }
 
-  void PowerDownPeripheral(PeripheralID id) const override
+  void PowerDownPeripheral(ResourceID id) const override
   {
     *EnableRegister(id) =
         bit::Clear(*EnableRegister(id), EnableBitPosition(id));
   }
 
  private:
-  volatile uint32_t * EnableRegister(PeripheralID id) const
+  volatile uint32_t * EnableRegister(ResourceID id) const
   {
     return enable[id.device_id / kBits];
   }
 
-  uint32_t EnableBitPosition(PeripheralID id) const
+  uint32_t EnableBitPosition(ResourceID id) const
   {
     return id.device_id % kBits;
   }

--- a/library/L1_Peripheral/stm32f4xx/test/gpio_test.cpp
+++ b/library/L1_Peripheral/stm32f4xx/test/gpio_test.cpp
@@ -60,7 +60,7 @@ TEST_CASE("Testing stm32f4xx Gpio", "[stm32f4xx-gpio]")
   {
     sjsu::stm32f4xx::Gpio gpio;
     GPIO_TypeDef & reg;
-    const SystemController::PeripheralID & id;
+    const SystemController::ResourceID & id;
   };
 
   std::array<TestStruct_t, 14> test = {
@@ -139,8 +139,8 @@ TEST_CASE("Testing stm32f4xx Gpio", "[stm32f4xx-gpio]")
   SECTION("SetDirection()")
   {
     auto power_up_matcher =
-        [](sjsu::SystemController::PeripheralID expected_id) {
-          return [expected_id](sjsu::SystemController::PeripheralID actual_id) {
+        [](sjsu::SystemController::ResourceID expected_id) {
+          return [expected_id](sjsu::SystemController::ResourceID actual_id) {
             return expected_id.device_id == actual_id.device_id;
           };
         };

--- a/library/L1_Peripheral/stm32f4xx/test/pin_test.cpp
+++ b/library/L1_Peripheral/stm32f4xx/test/pin_test.cpp
@@ -74,7 +74,7 @@ TEST_CASE("Testing stm32f4xx Pin", "[stm32f4xx-pin]")
   {
     sjsu::Pin & pin;
     GPIO_TypeDef & gpio;
-    const SystemController::PeripheralID & id;
+    const SystemController::ResourceID & id;
   };
 
   std::array<TestStruct_t, 14> test = {
@@ -155,9 +155,9 @@ TEST_CASE("Testing stm32f4xx Pin", "[stm32f4xx-pin]")
     SECTION("Valid port")
     {
       auto power_up_matcher =
-          [](sjsu::SystemController::PeripheralID expected_id) {
+          [](sjsu::SystemController::ResourceID expected_id) {
             return
-                [expected_id](sjsu::SystemController::PeripheralID actual_id) {
+                [expected_id](sjsu::SystemController::ResourceID actual_id) {
                   return expected_id.device_id == actual_id.device_id;
                 };
           };

--- a/library/L1_Peripheral/stm32f4xx/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/stm32f4xx/test/system_controller_test.cpp
@@ -13,7 +13,7 @@ EMIT_ALL_METHODS(SystemController);
 
 TEST_CASE("Testing stm32f4xx SystemController", "[stm32f4xx-system-controller]")
 {
-  std::array<const SystemController::PeripheralID *, 13> id = {
+  std::array<const SystemController::ResourceID *, 13> id = {
     &stm32f4xx::SystemController::Peripherals::kGpioA,
     &stm32f4xx::SystemController::Peripherals::kGpioH,
     &stm32f4xx::SystemController::Peripherals::kUsbOtgHS,


### PR DESCRIPTION
- Added additional links to various register definitions in documentation.
- Renamed PeripheralID to ResourceID in the SystemController to allow for a 
  more generic name that encapsulates the items or "things" the system controller 
  manages.
- Updated the following to use bit::Register:
  - LPC17xx SystemController
  - LPC40xx SystemController
  - STM32F10xx SystemController