### PR TITLE
Refactor: Accelerometer Interface

### DIFF
--- a/demos/sjtwo/mma8452q/makefile
+++ b/demos/sjtwo/mma8452q/makefile
@@ -1,0 +1,15 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/mma8452q/project.mk
+++ b/demos/sjtwo/mma8452q/project.mk
@@ -1,0 +1,3 @@
+USER_TESTS += $(LIBRARY_DIR)/L2_HAL/sensors/movement/accelerometer/test/mma8452q_test.cpp
+
+PLATFORM = lpc40xx

--- a/demos/sjtwo/mma8452q/project_config.hpp
+++ b/demos/sjtwo/mma8452q/project_config.hpp
@@ -1,0 +1,8 @@
+// This file overrides the default configuration options in the
+// library/config.hpp file. Open library/config.hpp to see which configuration
+// options you can change.
+#pragma once
+
+#define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_DEBUG
+
+#include "config.hpp"

--- a/demos/sjtwo/mma8452q/source/main.cpp
+++ b/demos/sjtwo/mma8452q/source/main.cpp
@@ -1,0 +1,31 @@
+#include <cstdint>
+
+#include "L1_Peripheral/lpc40xx/i2c.hpp"
+#include "L2_HAL/sensors/movement/accelerometer/mma8452q.hpp"
+#include "utility/log.hpp"
+
+int main()
+{
+  sjsu::LogInfo("MMA8452q Application Starting...");
+
+  sjsu::lpc40xx::I2c i2c(sjsu::lpc40xx::I2c::Bus::kI2c2);
+  sjsu::Mma8452q sensor(i2c);
+
+  sjsu::LogInfo("Initializing accelerometer peripherals...");
+  SJ2_RETURN_VALUE_ON_ERROR(sensor.Initialize(), 1);
+
+  sjsu::LogInfo("Enabling accelerometer...");
+  SJ2_RETURN_VALUE_ON_ERROR(sensor.Enable(), 1);
+
+  while (true)
+  {
+    // Read the current acceleration from the sensor
+    auto current_acceleration = SJ2_RETURN_VALUE_ON_ERROR(sensor.Read(), 2);
+
+    // Print the acceleration values
+    current_acceleration.Print();
+
+    sjsu::Delay(100ms);
+  }
+  return 0;
+}

--- a/library/L2_HAL/sensors/movement/accelerometer/test/mma8452q_test.cpp
+++ b/library/L2_HAL/sensors/movement/accelerometer/test/mma8452q_test.cpp
@@ -3,11 +3,45 @@
 
 namespace sjsu
 {
-// Uncomment this when can class has been created
 EMIT_ALL_METHODS(Mma8452q);
 
 TEST_CASE("Accelerometer", "[accelerometer]")
 {
-  SECTION("Initialize") {}
+  Mock<sjsu::I2c> mock_i2c;
+  Fake(Method(mock_i2c, Initialize));
+  Mma8452q test_subject(mock_i2c.get());
+
+  SECTION("Initialize")
+  {
+    SECTION("Success")
+    {
+      // Setup
+      When(Method(mock_i2c, Initialize)).AlwaysReturn(Status::kSuccess);
+
+      // Exercise
+      auto result = test_subject.Initialize();
+
+      // Verify
+      Verify(Method(mock_i2c, Initialize));
+      // Verify: Initialize should not have an error
+      CHECK(result.has_value());
+    }
+
+    SECTION("Failure")
+    {
+      // Setup
+      When(Method(mock_i2c, Initialize)).AlwaysReturn(Status::kNotReadyYet);
+
+      // Exercise
+      auto result = test_subject.Initialize();
+
+      // Verify
+      Verify(Method(mock_i2c, Initialize));
+      // Verify: Initialize should not have an error
+      CHECK(!result.has_value());
+    }
+  }
+
+  // TODO(#1260): Add the rest of the unit tests.
 }
 }  // namespace sjsu

--- a/library/utility/units.hpp
+++ b/library/utility/units.hpp
@@ -26,6 +26,7 @@
 #define ENABLE_PREDEFINED_TIME_UNITS
 #define ENABLE_PREDEFINED_CHARGE_UNITS
 #define ENABLE_PREDEFINED_DATA_UNITS
+#define ENABLE_PREDEFINED_ACCELERATION_UNITS
 
 #include "third_party/units/units.h"
 #include <chrono>


### PR DESCRIPTION
- Removes dynamic control of full-scale.
- Accelerometers must return values in m/s^2 units. Interface must
  handle conversion from data to the actual value in acceleration
  regardless of full-scale.
- Accelerometer interface now returns a single acceleration structure
  containing all acceleration axis, rather than using individual methods
  for each axis. This reduces the vtable size, the number of i2c
  transactions and function calls required to get all acceleration axis.
- Modifies MMA8456q to fit the new interface. This class represents the
  example of what an accelerometer class should look like.
- Adds the startings of a unit test for the MMA8456q driver.

Resolves #1080