### PR TITLE
Add BitLimits utility math library

### DIFF
--- a/documentation/guides/math_utilities.md
+++ b/documentation/guides/math_utilities.md
@@ -1,0 +1,39 @@
+# Math Utilities
+
+## BitLimits
+
+BitLimits defines compile-time functions that provides Min() and Max() functions
+which calculate the minimum and maximum possible values for an integer of some
+number of bits that can fit within the integer type supplied.
+
+For example, lets say you want to get the maximum possible 12 bit signed  value.
+To get this using BitLimits, you would do the following:
+
+```C++
+// First template parameter is the number of bits, 12, and the second is the
+// integer container type to return the value in.
+//
+// A compile time error will be produced if the number of bits cannot fit within
+// the passed integer type.
+//
+// The return type need not be `auto`.
+constexpr auto kMax = sjsu::BitLimits<12, int16_t>::Max();
+```
+
+Example of getting the minimum value of a 23 bit signed integer:
+
+```C++
+constexpr auto kMax = sjsu::BitLimits<23, int32_t>::Min();
+```
+
+Also works with unsigned values
+
+```C++
+constexpr auto kMax = sjsu::BitLimits<22, uint32_t>::Max();
+```
+
+If you use an unsigned value and ask for its minimum you will always get zero.
+
+```C++
+constexpr auto kMin = sjsu::BitLimits<22, uint32_t>::Min();
+```

--- a/library/utility/math/limits.hpp
+++ b/library/utility/math/limits.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace sjsu
+{
+/// BitLimits defines compile-time functions that provides Min() and Max()
+/// functions which calculate the minimum and maximum possible values for an
+/// integer of some number of bits that can fit within the integer type
+/// supplied.
+///
+/// @tparam bitwidth - the number of bits represented in the value.
+/// @tparam IntType - the container integer for the type.
+template <uint8_t bitwidth, typename IntType>
+class BitLimits
+{
+ public:
+  // Check that the IntType is actually an integer.
+  static_assert(
+      std::is_integral_v<IntType>,
+      "Type must be an integer type such as int8_t, int16_t, uint32_t, etc.");
+
+  // Check that the bitwidth is less than or equal to the size of the IntType.
+  static_assert(
+      bitwidth <= sizeof(IntType) * 8,
+      "The bitwidth exceed the number of bitwidth in the integer type.");
+
+  // Check that bitwidth is not zero.
+  static_assert(bitwidth != 0, "The bitwidth cannot be 0.");
+
+  /// @return constexpr IntType - returns the maximum value available for an
+  /// integer of `bitwidth` size and that can be stored within `IntType`.
+  /// The final value of the function depends also on the sign of the int type.
+  static constexpr IntType Max()
+  {
+    if constexpr (bitwidth == 64)
+    {
+      return std::numeric_limits<IntType>::max();
+    }
+    else if constexpr (std::is_signed_v<IntType>)
+    {
+      IntType max = static_cast<IntType>(((1ULL << bitwidth) / 2ULL) - 1ULL);
+      return max;
+    }
+    else
+    {
+      IntType max = static_cast<IntType>((1ULL << bitwidth) - 1ULL);
+      return max;
+    }
+  }
+
+  /// @return constexpr IntType - returns the minimum value available for an
+  /// integer of `bitwidth` size and that can be stored within `IntType`.
+  /// The final value of the function depends also on the sign of the int type.
+  /// Unsigned ints simply return zero.
+  static constexpr IntType Min()
+  {
+    if constexpr (bitwidth == 64)
+    {
+      return std::numeric_limits<IntType>::min();
+    }
+    else if constexpr (std::is_signed_v<IntType>)
+    {
+      IntType min = static_cast<IntType>(((1ULL << bitwidth) / 2ULL) * -1ULL);
+      return min;
+    }
+    else
+    {
+      return 0U;
+    }
+  }
+};
+}  // namespace sjsu

--- a/library/utility/math/test/limits_test.cpp
+++ b/library/utility/math/test/limits_test.cpp
@@ -1,0 +1,215 @@
+#include <cstdint>
+#include <limits>
+
+#include "L4_Testing/testing_frameworks.hpp"
+#include "utility/math/limits.hpp"
+
+namespace sjsu
+{
+TEST_CASE("Testing Limits Function", "[limits]")
+{
+  SECTION("int8_t :: 3-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = 3;
+    constexpr auto kExpectedMin = -4;
+
+    // Exercise
+    constexpr auto kMax = BitLimits<3, int8_t>::Max();
+    constexpr auto kMin = BitLimits<3, int8_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("int8_t :: 7-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = 63;
+    constexpr auto kExpectedMin = -64;
+
+    // Exercise
+    constexpr auto kMax = BitLimits<7, int8_t>::Max();
+    constexpr auto kMin = BitLimits<7, int8_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("int16_t :: 12-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = 2047;
+    constexpr auto kExpectedMin = -2048;
+
+    // Exercise
+    constexpr auto kMax = BitLimits<12, int16_t>::Max();
+    constexpr auto kMin = BitLimits<12, int16_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("int32_t :: 24-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = 8388607;
+    constexpr auto kExpectedMin = -8388608;
+
+    // Exercise
+    constexpr auto kMax = BitLimits<24, int32_t>::Max();
+    constexpr auto kMin = BitLimits<24, int32_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("int64_t :: 55-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = 18014398509481983ULL;
+    constexpr auto kExpectedMin = -18014398509481984ULL;
+
+    // Exercise
+    constexpr auto kMax = BitLimits<55, int64_t>::Max();
+    constexpr auto kMin = BitLimits<55, int64_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("int64_t :: 64-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = std::numeric_limits<int64_t>::max();
+    constexpr auto kExpectedMin = std::numeric_limits<int64_t>::min();
+
+    // Exercise
+    constexpr auto kMax = BitLimits<64, int64_t>::Max();
+    constexpr auto kMin = BitLimits<64, int64_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("uint8_t :: 3-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = 3;
+    constexpr auto kExpectedMin = -4;
+
+    // Exercise
+    constexpr auto kMax = BitLimits<3, int8_t>::Max();
+    constexpr auto kMin = BitLimits<3, int8_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("uint8_t :: 7-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = 127;
+    constexpr auto kExpectedMin = 0;
+
+    // Exercise
+    constexpr auto kMax = BitLimits<7, uint8_t>::Max();
+    constexpr auto kMin = BitLimits<7, uint8_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("uint16_t :: 12-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = 4095;
+    constexpr auto kExpectedMin = 0;
+
+    // Exercise
+    constexpr auto kMax = BitLimits<12, uint16_t>::Max();
+    constexpr auto kMin = BitLimits<12, uint16_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("uint32_t :: 24-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = 16777215;
+    constexpr auto kExpectedMin = 0;
+
+    // Exercise
+    constexpr auto kMax = BitLimits<24, uint32_t>::Max();
+    constexpr auto kMin = BitLimits<24, uint32_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("uint64_t :: 55-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = 36028797018963967ULL;
+    constexpr auto kExpectedMin = 0;
+
+    // Exercise
+    constexpr auto kMax = BitLimits<55, uint64_t>::Max();
+    constexpr auto kMin = BitLimits<55, uint64_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+
+  SECTION("uint64_t :: 64-bits")
+  {
+    // Setup
+    constexpr auto kExpectedMax = std::numeric_limits<uint64_t>::max();
+    constexpr auto kExpectedMin = std::numeric_limits<uint64_t>::min();
+
+    // Exercise
+    constexpr auto kMax = BitLimits<64, uint64_t>::Max();
+    constexpr auto kMin = BitLimits<64, uint64_t>::Min();
+
+    // Verify
+    CHECK(kMax == kExpectedMax);
+    CHECK(kMin == kExpectedMin);
+    static_assert(kMax == kExpectedMax);
+    static_assert(kMin == kExpectedMin);
+  }
+}
+}  // namespace sjsu

--- a/library/utility/utility.mk
+++ b/library/utility/utility.mk
@@ -17,6 +17,7 @@ TESTS += $(LIBRARY_DIR)/utility/test/stopwatch_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/test/time_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/test/timeout_timer_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/math/test/average_test.cpp
+TESTS += $(LIBRARY_DIR)/utility/math/test/limits_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/containers/test/string_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/containers/test/vector_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/containers/test/list_test.cpp

--- a/projects/hello_world/project.mk
+++ b/projects/hello_world/project.mk
@@ -1,1 +1,1 @@
-USER_TESTS += $(LIBRARY_DIR)/L0_Platform/test/ram_test.cpp
+USER_TESTS += $(LIBRARY_DIR)/utility/math/test/limits_test.cpp


### PR DESCRIPTION
- Add BitLimits, which is a structure that takes a bit-width and a
  integral type, and provides static compile time functions for
  returning the maximum and minimum representable values for that
  integer size.
- Add unit test for limits
- Use BitLimits in MMA8452 driver
- Fix flipped orientation of MMA8452 driver.

Resolves #1262