### PR TITLE
Speed up clang-tidy time in presubmit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
             - sudo npm install -g cspell@4.0.38
           script:
             - cd projects/hello_world/
-            - make presubmit
+            - make quick-presubmit
             - make spellcheck
             - make find-missing-tests
             - make find-unused-tests
@@ -37,11 +37,11 @@ matrix:
           osx_image: xcode10
           script:
             - cd projects/hello_world/
-            - make presubmit
+            - make quick-presubmit
         - os: osx
           osx_image: xcode11.3
           script:
             - cd projects/hello_world/
-            - make presubmit
+            - make quick-presubmit
 install: ./setup
 

--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -54,39 +54,49 @@ function check
 # Return to home project
 cd $SJBASE/projects/hello_world
 
-####################################
-#        Build All Projects        #
-####################################
-time make --no-print-directory all-projects
-BUILD_CAPTURE=$?
-
-####################################
-#           Lint Check             #
-####################################
+# ==============================================================================
+# Lint Check
+# ==============================================================================
 print_divider "Executing 'lint' check"
 
 time make -s lint 1> /dev/null
 LINT_CAPTURE=$?
 print_status $LINT_CAPTURE
 echo ""
-####################################
-#         Clang Tidy Check         #
-####################################
-print_divider "Executing 'tidy' check"
 
-time make -s tidy
-TIDY_CAPTURE=$?
-print_status $TIDY_CAPTURE
-echo ""
-####################################
-#         Unit Test Check          #
-####################################
+# ==============================================================================
+# Clang Tidy Check
+# ==============================================================================
+
+if [ "$1" == "quick" ]; then
+  print_divider "Executing 'commit-tidy' check"
+  time make -s commit-tidy
+  TIDY_CAPTURE=$?
+  print_status $TIDY_CAPTURE
+  echo ""
+else
+  print_divider "Executing 'tidy' check"
+  time make -s tidy
+  TIDY_CAPTURE=$?
+  print_status $TIDY_CAPTURE
+  echo ""
+fi
+
+# ==============================================================================
+# Unit Test Check
+# ==============================================================================
 print_divider "Building and running unit tests"
 
 time make -s library-test WARNINGS_ARE_ERRORS=-Werror
 TEST_CAPTURE=$?
 print_status $TEST_CAPTURE
 echo ""
+
+# ==============================================================================
+# Build All Projects
+# ==============================================================================
+time make --no-print-directory all-projects
+BUILD_CAPTURE=$?
 
 # Check if there were any errors. For this to succeed, this value should be 0
 check $(($BUILD_CAPTURE+$LINT_CAPTURE+$TIDY_CAPTURE+$TEST_CAPTURE))


### PR DESCRIPTION
- Add `commit-tidy` target which only evaluates the source files in
  the latest commit.
- Add `quick-presubmit` target which will use commit-tidy rather than
  tidy target.
- Change travis.yml to use `quick-presubmit` target

Resolves #1279