### PR TITLE
Fixed EEPROM driver

### DIFF
--- a/library/L1_Peripheral/lpc40xx/eeprom.hpp
+++ b/library/L1_Peripheral/lpc40xx/eeprom.hpp
@@ -46,7 +46,7 @@ class Eeprom final : public sjsu::Storage
   };
 
   /// Max timeout for program/write operations in milliseconds
-  static constexpr std::chrono::milliseconds kMaxTimeout = 20ms;
+  static constexpr std::chrono::milliseconds kMaxTimeout = 5ms;
 
   Type GetMemoryType() override
   {
@@ -130,7 +130,7 @@ class Eeprom final : public sjsu::Storage
 
     address = bit::Clear(address, kAddressMask);
 
-    // Because the EEPROM uses 32-bit communication, write_data will be casted
+    // Because the EEPROM uses 32-bit communication, write_data will be cast
     // into a uint32_t *
     const uint32_t * write_data = reinterpret_cast<const uint32_t *>(data);
 
@@ -170,9 +170,9 @@ class Eeprom final : public sjsu::Storage
 
       page_offset += kOffsetInterval;
 
-      // If the 64 byte page buffer fills up, then it must be programmed to the
+      // If the 64 byte page buffer fills up, then it must be
       // programmed to the EEPROM before continuing.
-      if (page_offset > 64)
+      if (page_offset == 64)
       {
         Program(eeprom_address);
         page_count++;
@@ -212,17 +212,17 @@ class Eeprom final : public sjsu::Storage
     eeprom_register->ADDR = address;
     eeprom_register->CMD  = kEraseProgram;
 
-    // Poll status register bit to see when writing is finished
+    // Poll status register bit to see when programming is finished
     auto check_register = []() {
-      return !(
-          bit::Read(eeprom_register->INT_STATUS, Status::kProgramStatusMask));
+      return (bit::Read(eeprom_register->INT_STATUS,
+              Status::kProgramStatusMask));
     };
 
     Wait(kMaxTimeout, check_register);
 
     // Clear program interrupt
     eeprom_register->INT_CLR_STATUS =
-        (bit::Set(0, Status::kReadWriteStatusMask));
+        (bit::Set(0, Status::kProgramStatusMask));
   }
 };
 }  // namespace lpc40xx


### PR DESCRIPTION
Turns out there was an exclamation mark in the line checking the status bit for the program operation, and we were using the wrong bit to clear the status register too. Also it turns out we could drop the max timeout down to 5ms after that change.

There was an issue with program() not being called at the right time, so line 175 had to be changed. It calls it one iteration of the loop earlier.

There were also a couple of typos.