### PR TITLE
Fix project_config.hpp not respected

### DIFF
--- a/library/L0_Platform/example/example.mk
+++ b/library/L0_Platform/example/example.mk
@@ -6,8 +6,7 @@ LIBRARY_EXAMPLE += $(LIBRARY_DIR)/L0_Platform/example/startup.cpp
 LIBRARY_EXAMPLE += $(LIBRARY_DIR)/L0_Platform/arm_cortex/m4/ARM_CM4F/port.c
 
 # Give a path to the OPENOCD configuration file
-OPENOCD_CONFIG := $(or $(OPENOCD_CONFIG), \
-                       $(LIBRARY_DIR)/L0_Platform/example/example.cfg)
+OPENOCD_CONFIG ?= $(LIBRARY_DIR)/L0_Platform/example/example.cfg
 
 # This calls the BUILD_LIBRARY macro that generates the the example platform
 # static library.

--- a/library/L0_Platform/lpc17xx/lpc17xx.mk
+++ b/library/L0_Platform/lpc17xx/lpc17xx.mk
@@ -2,8 +2,7 @@ LIBRARY_LPC17XX += $(LIBRARY_DIR)/L0_Platform/lpc17xx/startup.cpp
 LIBRARY_LPC17XX += $(LIBRARY_DIR)/L0_Platform/arm_cortex/m3/ARM_CM3/port.c
 LIBRARY_LPC17XX += $(LIBRARY_DIR)/L0_Platform/arm_cortex/exceptions.cpp
 
-OPENOCD_CONFIG := $(or $(OPENOCD_CONFIG), \
-                       $(LIBRARY_DIR)/L0_Platform/lpc17xx/lpc17xx.cfg)
+OPENOCD_CONFIG  ?= $(LIBRARY_DIR)/L0_Platform/lpc17xx/lpc17xx.cfg
 
 $(eval $(call BUILD_LIBRARY,liblpc17xx,LIBRARY_LPC17XX))
 

--- a/library/L0_Platform/lpc40xx/lpc40xx.mk
+++ b/library/L0_Platform/lpc40xx/lpc40xx.mk
@@ -2,8 +2,7 @@ LIBRARY_LPC40XX += $(LIBRARY_DIR)/L0_Platform/lpc40xx/startup.cpp
 LIBRARY_LPC40XX += $(LIBRARY_DIR)/L0_Platform/arm_cortex/m4/ARM_CM4F/port.c
 LIBRARY_LPC40XX += $(LIBRARY_DIR)/L0_Platform/arm_cortex/exceptions.cpp
 
-OPENOCD_CONFIG := $(or $(OPENOCD_CONFIG), \
-                       $(LIBRARY_DIR)/L0_Platform/lpc40xx/lpc40xx.cfg)
+OPENOCD_CONFIG  ?= $(LIBRARY_DIR)/L0_Platform/lpc40xx/lpc40xx.cfg
 
 $(eval $(call BUILD_LIBRARY,liblpc40xx,LIBRARY_LPC40XX))
 

--- a/library/L0_Platform/msp432p401r/msp432p401r.mk
+++ b/library/L0_Platform/msp432p401r/msp432p401r.mk
@@ -2,8 +2,7 @@ LIBRARY_MSP432P401R += $(LIBRARY_DIR)/L0_Platform/msp432p401r/startup.cpp
 LIBRARY_MSP432P401R += $(LIBRARY_DIR)/L0_Platform/arm_cortex/m4/ARM_CM4F/port.c
 LIBRARY_MSP432P401R += $(LIBRARY_DIR)/L0_Platform/arm_cortex/exceptions.cpp
 
-OPENOCD_CONFIG := $(or $(OPENOCD_CONFIG), \
-                       $(LIBRARY_DIR)/L0_Platform/msp432p401r/msp432p401r.cfg)
+OPENOCD_CONFIG ?= $(LIBRARY_DIR)/L0_Platform/msp432p401r/msp432p401r.cfg
 
 $(eval $(call BUILD_LIBRARY,libmsp432p401r,LIBRARY_MSP432P401R))
 

--- a/library/L0_Platform/stm32f10x/stm32f10x.mk
+++ b/library/L0_Platform/stm32f10x/stm32f10x.mk
@@ -2,8 +2,7 @@ LIBRARY_STM32F10X += $(LIBRARY_DIR)/L0_Platform/stm32f10x/startup.cpp
 LIBRARY_STM32F10X += $(LIBRARY_DIR)/L0_Platform/arm_cortex/m3/ARM_CM3/port.c
 LIBRARY_STM32F10X += $(LIBRARY_DIR)/L0_Platform/arm_cortex/exceptions.cpp
 
-OPENOCD_CONFIG := $(or $(OPENOCD_CONFIG), \
-                       $(LIBRARY_DIR)/L0_Platform/stm32f10x/stm32f10x.cfg)
+OPENOCD_CONFIG ?= $(LIBRARY_DIR)/L0_Platform/stm32f10x/stm32f10x.cfg
 
 $(eval $(call BUILD_LIBRARY,libstm32f10x,LIBRARY_STM32F10X))
 

--- a/library/L0_Platform/stm32f4xx/stm32f4xx.mk
+++ b/library/L0_Platform/stm32f4xx/stm32f4xx.mk
@@ -2,8 +2,7 @@ LIBRARY_STM32F4XX += $(LIBRARY_DIR)/L0_Platform/stm32f4xx/startup.cpp
 LIBRARY_STM32F4XX += $(LIBRARY_DIR)/L0_Platform/arm_cortex/m4/ARM_CM4F/port.c
 LIBRARY_STM32F4XX += $(LIBRARY_DIR)/L0_Platform/arm_cortex/exceptions.cpp
 
-OPENOCD_CONFIG := $(or $(OPENOCD_CONFIG), \
-                       $(LIBRARY_DIR)/L0_Platform/stm32f4xx/stm32f4xx.cfg)
+OPENOCD_CONFIG ?= $(LIBRARY_DIR)/L0_Platform/stm32f4xx/stm32f4xx.cfg
 
 $(eval $(call BUILD_LIBRARY,libstm32f4xx,LIBRARY_STM32F4XX))
 

--- a/library/utility/log.hpp
+++ b/library/utility/log.hpp
@@ -124,7 +124,7 @@ struct LogDebug  // NOLINT
     // Required as GCC8 has parsing issues with the C++17 [[maybe_unused]]
     // attribute for constructor's first argument
     _SJ2_USED(format);
-    if constexpr (config::kLogLevel <= SJ2_LOG_LEVEL_DEBUG)
+    if constexpr (config::kLogLevel >= SJ2_LOG_LEVEL_DEBUG)
     {
       Log<Params...>(SJ2_BACKGROUND_PURPLE "   DEBUG", format, params...,
                      location);
@@ -154,7 +154,7 @@ struct LogInfo  // NOLINT
     // Required as GCC8 has parsing issues with the C++17 [[maybe_unused]]
     // attribute for constructor's first argument
     _SJ2_USED(format);
-    if constexpr (config::kLogLevel <= SJ2_LOG_LEVEL_INFO)
+    if constexpr (config::kLogLevel >= SJ2_LOG_LEVEL_INFO)
     {
       Log<Params...>(SJ2_BACKGROUND_GREEN "    INFO", format, params...,
                      location);
@@ -186,7 +186,7 @@ struct LogWarning  // NOLINT
     // Required as GCC8 has parsing issues with the C++17 [[maybe_unused]]
     // attribute for constructor's first argument
     _SJ2_USED(format);
-    if constexpr (config::kLogLevel <= SJ2_LOG_LEVEL_WARNING)
+    if constexpr (config::kLogLevel >= SJ2_LOG_LEVEL_WARNING)
     {
       Log<Params...>(SJ2_BACKGROUND_YELLOW " WARNING", format, params...,
                      location);
@@ -216,7 +216,7 @@ struct LogError  // NOLINT
     // Required as GCC8 has parsing issues with the C++17 [[maybe_unused]]
     // attribute for constructor's first argument
     _SJ2_USED(format);
-    if constexpr (config::kLogLevel <= SJ2_LOG_LEVEL_ERROR)
+    if constexpr (config::kLogLevel >= SJ2_LOG_LEVEL_ERROR)
     {
       Log<Params...>(SJ2_BACKGROUND_RED "   ERROR", format, params...,
                      location);


### PR DESCRIPTION
log.hpp has its constexpr if logic fixed such that log levels are
applied correctly for each log level.

Add protection measures to makefile to detect undefined variables which
in turn found and resolved the following errors:

- Undefined variables meant to be the path to the current project and
  its source directory, and its local library directory.
- Typo in BUILD_LIBRARY macro with undefined "@" symbol, which needed to
  be set to "$$@". This could lead to "malformed" archive issues.
- Defined WARNING_BECOME_ERRORS if not defined by project.mk file or via
  command line.
- The ?= defined PORT, OPENOCD_CONFIG and JTAG bypass this error detection
  so commenting them out but leaving a comment to mention that they are
  there will help to catch errors when developers use the makefile.

Resolves #1309