### PR TITLE
Fix hard fault on cortex M4F platform devices

### DIFF
--- a/library/L0_Platform/arm_cortex/exceptions.cpp
+++ b/library/L0_Platform/arm_cortex/exceptions.cpp
@@ -6,6 +6,7 @@
 #include "L0_Platform/startup.hpp"
 #include "L0_Platform/arm_cortex/m4/core_cm4.h"
 #include "L1_Peripheral/cortex/interrupt.hpp"
+#include "L1_Peripheral/cortex/fpu.hpp"
 #include "utility/log.hpp"
 #include "utility/time.hpp"
 #include "third_party/semihost/trace.h"
@@ -75,6 +76,12 @@ extern "C"
     const uint32_t kTopOfStack = reinterpret_cast<intptr_t>(&StackTop);
     sjsu::cortex::__set_PSP(kTopOfStack);
     sjsu::cortex::__set_MSP(kTopOfStack);
+
+    // Enable FPU (Floating Point Unit)
+    // System will crash if floating point instruction is executed before
+    // Initializing the FPU first.
+    // Processors without FPU, like cortex M3, will ignore this and do nothing.
+    sjsu::cortex::InitializeFloatingPointUnit();
 
     sjsu::SystemInitialize();
     // Check if Debugger is connected

--- a/library/L0_Platform/lpc40xx/startup.cpp
+++ b/library/L0_Platform/lpc40xx/startup.cpp
@@ -167,10 +167,6 @@ namespace sjsu
 SJ2_WEAK(void InitializePlatform());
 void InitializePlatform()
 {
-  // Enable FPU (Floating Point Unit)
-  // System will crash if floating point instruction is executed before
-  // Initializing the FPU first.
-  sjsu::cortex::InitializeFloatingPointUnit();
   // Set the platform's interrupt controller.
   // This will be used by other libraries to enable and disable interrupts.
   sjsu::InterruptController::SetPlatformController(&interrupt_controller);

--- a/library/L0_Platform/msp432p401r/startup.cpp
+++ b/library/L0_Platform/msp432p401r/startup.cpp
@@ -9,7 +9,6 @@
 #include "L0_Platform/startup.hpp"
 #include "L0_Platform/msp432p401r/msp432p401r.h"
 #include "L1_Peripheral/cortex/dwt_counter.hpp"
-#include "L1_Peripheral/cortex/fpu.hpp"
 #include "L1_Peripheral/cortex/system_timer.hpp"
 #include "L1_Peripheral/interrupt.hpp"
 #include "L1_Peripheral/msp432p401r/system_controller.hpp"
@@ -156,11 +155,6 @@ namespace sjsu
 SJ2_WEAK(void InitializePlatform());
 void InitializePlatform()
 {
-  // Enable FPU (Floating Point Unit)
-  // System will crash if floating point instruction is executed before
-  // Initializing the FPU first.
-  sjsu::cortex::InitializeFloatingPointUnit();
-
   sjsu::newlib::SetStdout(Msp432p401rStdOut);
   sjsu::newlib::SetStdin(Msp432p401rStdIn);
 

--- a/library/L0_Platform/stm32f4xx/startup.cpp
+++ b/library/L0_Platform/stm32f4xx/startup.cpp
@@ -9,7 +9,6 @@
 #include "L0_Platform/startup.hpp"
 #include "L0_Platform/stm32f4xx/stm32f4xx.h"
 #include "L1_Peripheral/cortex/dwt_counter.hpp"
-#include "L1_Peripheral/cortex/fpu.hpp"
 #include "L1_Peripheral/cortex/system_timer.hpp"
 #include "L1_Peripheral/interrupt.hpp"
 #include "L1_Peripheral/stm32f4xx/system_controller.hpp"
@@ -205,11 +204,6 @@ namespace sjsu
 SJ2_WEAK(void InitializePlatform());
 void InitializePlatform()
 {
-  // Enable FPU (Floating Point Unit)
-  // System will crash if floating point instruction is executed before
-  // Initializing the FPU first.
-  sjsu::cortex::InitializeFloatingPointUnit();
-
   sjsu::newlib::SetStdout(Stm32f4xxStdOut);
   sjsu::newlib::SetStdin(Stm32f4xxStdIn);
 

--- a/library/L1_Peripheral/cortex/fpu.hpp
+++ b/library/L1_Peripheral/cortex/fpu.hpp
@@ -15,7 +15,7 @@ inline void InitializeFloatingPointUnit()
 {
   if constexpr (build::kPlatform != build::Platform::host)
   {
-    __asm(
+    __asm__ __volatile__(
         // CPACR is located at address 0xE000ED88
         "LDR.W   R0, =0xE000ED88\n"
         // Read CPACR


### PR DESCRIPTION
Add call to sjsu::cortex::InitializeFloatingPointUnit() in
ArmResetHandler().

This actually solves a future bug where any constructor uses floating
point arithmetic before InitializePlatform() has run.

Does not seem to bother Cortex M3 systems as they have the same
registers but the FPU bits are reserved. All Cortexs Above 3 have this
register.