### PR TITLE
Fix issue with commit-tidy being skipped

### DIFF
--- a/library/L1_Peripheral/i2c.hpp
+++ b/library/L1_Peripheral/i2c.hpp
@@ -32,8 +32,10 @@ class I2c
   /// time.
   static constexpr std::chrono::milliseconds kI2cTimeout = 100ms;
 
-  struct CommonErrors
+  /// Namespace of common I2C transaction errors
+  class CommonErrors
   {
+   public:
     static constexpr auto kTimeout =
         Error(Status::kTimedOut,
               "I2C took too long to process and timed out! Consider "

--- a/projects/continuous_integration/post_library.mk
+++ b/projects/continuous_integration/post_library.mk
@@ -20,14 +20,15 @@ tidy: $(TIDY_FILES)
 	@printf '$(GREEN)Tidy Evaluation Complete. Everything clear!$(RESET)\n'
 
 
-TIDY_COMMIT_SOURCES := $(shell git show --name-only HEAD | grep ".[hc]pp")
+TIDY_COMMIT_SOURCES := $(shell git show --diff-filter=AM --name-only HEAD \
+                               | grep ".[hc]pp")
 SHORT_TIDY_FILES    := $(addprefix $(SJ2_OBJECT_DIR)/, \
                                    $(TIDY_COMMIT_SOURCES:=.tidy))
 commit-tidy: $(SHORT_TIDY_FILES)
 	@printf '$(GREEN)Commit Tidy Evaluation Complete. Everything clear!$(RESET)\n'
 
 
-$(SJ2_OBJECT_DIR)/%.tidy: %
+$(SJ2_OBJECT_DIR)/%.tidy: $(SJSU_DEV2_BASE)/%
 	@mkdir -p "$(dir $@)"
 	@$(CLANG_TIDY) -extra-arg="-std=c++2a" "$<"  -- \
 	  -D PLATFORM=host -D HOST_TEST=1 \


### PR DESCRIPTION
- Fix issue with commit-tidy being skipped due to incorrect make
  recipe signature.
- Fix list of commit sources issue where deleted files were being used
  for commit tidy, which resulted in break as the recipe file no longer
  exists.

Resolves #1331