### PR TITLE
Make GDB FreeRTOS thread aware for all platforms

### DIFF
--- a/library/L0_Platform/arm_cortex/exceptions.cpp
+++ b/library/L0_Platform/arm_cortex/exceptions.cpp
@@ -1,3 +1,5 @@
+#include <FreeRTOS.h>
+
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>
@@ -9,6 +11,7 @@
 #include "L1_Peripheral/cortex/fpu.hpp"
 #include "utility/log.hpp"
 #include "utility/time.hpp"
+#include "utility/macros.hpp"
 #include "third_party/semihost/trace.h"
 
 extern "C"
@@ -63,6 +66,9 @@ extern "C"
     }
   }
 
+  // Required to get FreeRTOS support in OpenOCD + GDB
+  const volatile int uxTopUsedPriority = configMAX_PRIORITIES - 1;
+
   // Reset entry point for your code.
   // Sets up a simple runtime environment and initializes the C/C++ library.
   void ArmResetHandler()
@@ -76,6 +82,10 @@ extern "C"
     const uint32_t kTopOfStack = reinterpret_cast<intptr_t>(&StackTop);
     sjsu::cortex::__set_PSP(kTopOfStack);
     sjsu::cortex::__set_MSP(kTopOfStack);
+
+    // Required to get the compiler to keep this symbol in the symbol table
+    // rather than garbage collecting it at link time.
+    _SJ2_USED(uxTopUsedPriority);
 
     // Enable FPU (Floating Point Unit)
     // System will crash if floating point instruction is executed before

--- a/library/L0_Platform/example/example.cfg
+++ b/library/L0_Platform/example/example.cfg
@@ -23,10 +23,7 @@ source [find target/lpc40xx.cfg]
 # lower this if you are getting glitches
 adapter_khz 4000
 
-$_TARGETNAME configure -event gdb-attach {
+$_TARGETNAME configure -rtos FreeRTOS -event gdb-attach {
    halt
-}
-$_TARGETNAME configure -event gdb-attach {
    reset init
 }
-

--- a/library/L0_Platform/example/example.mk
+++ b/library/L0_Platform/example/example.mk
@@ -6,7 +6,7 @@ LIBRARY_EXAMPLE += $(LIBRARY_DIR)/L0_Platform/example/startup.cpp
 LIBRARY_EXAMPLE += $(LIBRARY_DIR)/L0_Platform/arm_cortex/m4/ARM_CM4F/port.c
 
 # Give a path to the OPENOCD configuration file
-OPENOCD_CONFIG ?= $(LIBRARY_DIR)/L0_Platform/example/example.cfg
+OPENOCD_CONFIG = $(LIBRARY_DIR)/L0_Platform/example/example.cfg
 
 # This calls the BUILD_LIBRARY macro that generates the the example platform
 # static library.

--- a/library/L0_Platform/lpc17xx/lpc17xx.cfg
+++ b/library/L0_Platform/lpc17xx/lpc17xx.cfg
@@ -5,7 +5,7 @@ source [find target/lpc17xx.cfg]
 # lower this if you are getting glitches
 adapter_khz 4000
 
-$_TARGETNAME configure -event gdb-attach {
+$_TARGETNAME configure -rtos FreeRTOS -event gdb-attach {
    halt
    reset init
 }

--- a/library/L0_Platform/lpc40xx/lpc40xx.cfg
+++ b/library/L0_Platform/lpc40xx/lpc40xx.cfg
@@ -5,7 +5,7 @@ source [find target/lpc40xx.cfg]
 # lower this if you are getting glitches
 adapter_khz 1000
 
-$_TARGETNAME configure -event gdb-attach {
+$_TARGETNAME configure -rtos FreeRTOS -event gdb-attach {
    halt
    reset init
 }

--- a/library/L0_Platform/msp432p401r/msp432p401r.cfg
+++ b/library/L0_Platform/msp432p401r/msp432p401r.cfg
@@ -6,7 +6,7 @@ adapter_khz 2000
 # Override to reset with TRST
 reset_config trst_only
 
-$_TARGETNAME configure -event gdb-attach {
+$_TARGETNAME configure -rtos FreeRTOS -event gdb-attach {
    halt
    reset init
 }

--- a/library/L0_Platform/msp432p401r/msp432p401r.mk
+++ b/library/L0_Platform/msp432p401r/msp432p401r.mk
@@ -2,7 +2,7 @@ LIBRARY_MSP432P401R += $(LIBRARY_DIR)/L0_Platform/msp432p401r/startup.cpp
 LIBRARY_MSP432P401R += $(LIBRARY_DIR)/L0_Platform/arm_cortex/m4/ARM_CM4F/port.c
 LIBRARY_MSP432P401R += $(LIBRARY_DIR)/L0_Platform/arm_cortex/exceptions.cpp
 
-OPENOCD_CONFIG ?= $(LIBRARY_DIR)/L0_Platform/msp432p401r/msp432p401r.cfg
+OPENOCD_CONFIG = $(LIBRARY_DIR)/L0_Platform/msp432p401r/msp432p401r.cfg
 
 $(eval $(call BUILD_LIBRARY,libmsp432p401r,LIBRARY_MSP432P401R))
 

--- a/library/L0_Platform/stm32f10x/stm32f10x.cfg
+++ b/library/L0_Platform/stm32f10x/stm32f10x.cfg
@@ -1,11 +1,11 @@
-# Source the LPC17xx configuration file
+# Source the stm32f1x configuration file
 source [find target/stm32f1x.cfg]
 
 # JTAG Clock rate in kHz
 # lower this if you are getting glitches
 adapter_khz 4000
 
-$_TARGETNAME configure -event gdb-attach {
+$_TARGETNAME configure -rtos FreeRTOS -event gdb-attach {
    halt
    reset init
 }

--- a/library/L0_Platform/stm32f10x/stm32f10x.mk
+++ b/library/L0_Platform/stm32f10x/stm32f10x.mk
@@ -2,7 +2,7 @@ LIBRARY_STM32F10X += $(LIBRARY_DIR)/L0_Platform/stm32f10x/startup.cpp
 LIBRARY_STM32F10X += $(LIBRARY_DIR)/L0_Platform/arm_cortex/m3/ARM_CM3/port.c
 LIBRARY_STM32F10X += $(LIBRARY_DIR)/L0_Platform/arm_cortex/exceptions.cpp
 
-OPENOCD_CONFIG ?= $(LIBRARY_DIR)/L0_Platform/stm32f10x/stm32f10x.cfg
+OPENOCD_CONFIG = $(LIBRARY_DIR)/L0_Platform/stm32f10x/stm32f10x.cfg
 
 $(eval $(call BUILD_LIBRARY,libstm32f10x,LIBRARY_STM32F10X))
 

--- a/library/L0_Platform/stm32f4xx/stm32f4xx.cfg
+++ b/library/L0_Platform/stm32f4xx/stm32f4xx.cfg
@@ -4,7 +4,7 @@ source [find target/stm32f4x.cfg]
 # lower this if you are getting glitches
 adapter_khz 4000
 
-$_TARGETNAME configure -event gdb-attach {
+$_TARGETNAME configure -rtos FreeRTOS -event gdb-attach {
    halt
    reset init
 }

--- a/library/L0_Platform/stm32f4xx/stm32f4xx.mk
+++ b/library/L0_Platform/stm32f4xx/stm32f4xx.mk
@@ -2,7 +2,7 @@ LIBRARY_STM32F4XX += $(LIBRARY_DIR)/L0_Platform/stm32f4xx/startup.cpp
 LIBRARY_STM32F4XX += $(LIBRARY_DIR)/L0_Platform/arm_cortex/m4/ARM_CM4F/port.c
 LIBRARY_STM32F4XX += $(LIBRARY_DIR)/L0_Platform/arm_cortex/exceptions.cpp
 
-OPENOCD_CONFIG ?= $(LIBRARY_DIR)/L0_Platform/stm32f4xx/stm32f4xx.cfg
+OPENOCD_CONFIG = $(LIBRARY_DIR)/L0_Platform/stm32f4xx/stm32f4xx.cfg
 
 $(eval $(call BUILD_LIBRARY,libstm32f4xx,LIBRARY_STM32F4XX))
 


### PR DESCRIPTION
- Add rtos flag to all openocd config files
- Removed ? for OPENOCD_CONFIG file in makefiles as it was not working
  as expected. To change the OPENOCD_CONFIG post_library.mk file.
- Added 4 byte symbol into ARM exceptions class to get open ocd's
  version of FreeRTOS support to operate.