### PR TITLE
Optimize Error_t and Returns<>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
             - sudo npm install -g cspell@4.0.38
           script:
             - cd projects/continuous_integration/
-            - make quick-presubmit
+            - make presubmit
             - make spellcheck
             - make doxygen
             # TODO(#1289): Add this back
@@ -38,11 +38,11 @@ matrix:
           osx_image: xcode10
           script:
             - cd projects/continuous_integration/
-            - make quick-presubmit
+            - make presubmit
         - os: osx
           osx_image: xcode11.3
           script:
             - cd projects/continuous_integration/
-            - make quick-presubmit
+            - make presubmit
 install: ./setup
 

--- a/demos/multiplatform/status/source/main.cpp
+++ b/demos/multiplatform/status/source/main.cpp
@@ -3,7 +3,6 @@
 
 namespace
 {
-using sjsu::Error;
 using sjsu::Returns;
 using sjsu::Status;
 }  // namespace
@@ -93,7 +92,8 @@ int main()
   // Check if the result has an error
   if (!result)
   {
-    sjsu::LogError("Getting PLL Code Failed!\n");
+    sjsu::LogError("Getting PLL Code Failed!");
+    result.error()->Print();
     // Error handling would go here...
     return 111;
   }

--- a/library/L0_Platform/freertos/freertos.mk
+++ b/library/L0_Platform/freertos/freertos.mk
@@ -1,4 +1,4 @@
-LINT_FILTER += $(LIBRARY_DIR)/L0_Platform/freertos/
+LINT_FILTER += library/L0_Platform/freertos/
 
 LIBRARY_FREERTOS_COMMON += \
     $(LIBRARY_DIR)/L0_Platform/freertos/freertos_common.cpp

--- a/library/L0_Platform/linux/linux.mk
+++ b/library/L0_Platform/linux/linux.mk
@@ -5,8 +5,8 @@ LIBRARY_LINUX += $(LIBRARY_DIR)/L0_Platform/linux/freertos_posix/port.c
 
 $(eval $(call BUILD_LIBRARY,liblinux,LIBRARY_LINUX))
 
-DEVICE_CC        := gcc-8
-DEVICE_CPPC      := g++-8
+DEVICE_CC        := gcc-9
+DEVICE_CPPC      := g++-9
 DEVICE_OBJDUMP   := objdump
 DEVICE_SIZEC     := size
 DEVICE_OBJCOPY   := objcopy

--- a/library/L1_Peripheral/i2c.hpp
+++ b/library/L1_Peripheral/i2c.hpp
@@ -37,14 +37,16 @@ class I2c
   {
    public:
     static constexpr auto kTimeout =
-        Error(Status::kTimedOut,
-              "I2C took too long to process and timed out! Consider "
-              "increasing the timeout time.");
+        Error_t(Status::kTimedOut,
+                "I2C took too long to process and timed out! Consider "
+                "increasing the timeout time.");
+
     static constexpr auto kBusError =
-        Error(Status::kBusError, "I2C bus error occurred.");
+        Error_t(Status::kBusError, "I2C bus error occurred.");
+
     static constexpr auto kDeviceNotFound =
-        Error(Status::kDeviceNotFound,
-              "I2C address not found/acknowledged by device.");
+        Error_t(Status::kDeviceNotFound,
+                "I2C address not found/acknowledged by device.");
   };
 
   /// A common structure for holding the information needed for I2C

--- a/library/L1_Peripheral/lpc40xx/i2c.hpp
+++ b/library/L1_Peripheral/lpc40xx/i2c.hpp
@@ -399,11 +399,11 @@ class I2c final : public sjsu::I2c
 
     if (i2c_.transaction.status == Status::kBusError)
     {
-      return CommonErrors::kBusError;
+      return DefinedError(CommonErrors::kBusError);
     }
     else if (i2c_.transaction.status == Status::kDeviceNotFound)
     {
-      return CommonErrors::kDeviceNotFound;
+      return DefinedError(CommonErrors::kDeviceNotFound);
     }
     else if (wait_status == Status::kTimedOut)
     {
@@ -412,7 +412,7 @@ class I2c final : public sjsu::I2c
 
       if (i2c_.transaction.out_length == 0 || i2c_.transaction.in_length == 0)
       {
-        return CommonErrors::kTimeout;
+        return DefinedError(CommonErrors::kTimeout);
       }
     }
 

--- a/library/L1_Peripheral/lpc40xx/test/pin_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/pin_test.cpp
@@ -48,9 +48,9 @@ TEST_CASE("Testing lpc40xx Pin")
     SECTION("Invalid function code")
     {
       // Exercise & Verify
-      CHECK(test_subject00.SetPinFunction(0b1000).error().status ==
+      CHECK(test_subject00.SetPinFunction(0b1000).error()->status ==
             Status::kInvalidParameters);
-      CHECK(test_subject25.SetPinFunction(0b1111).error().status ==
+      CHECK(test_subject25.SetPinFunction(0b1111).error()->status ==
             Status::kInvalidParameters);
     }
   }

--- a/library/L1_Peripheral/msp432p401r/test/pin_test.cpp
+++ b/library/L1_Peripheral/msp432p401r/test/pin_test.cpp
@@ -128,7 +128,7 @@ TEST_CASE("Testing Msp432p401r Pin")
       Pin pin(invalid_port_number, 0);
 
       // Verify & Exercise
-      CHECK(pin.Initialize().error().status == Status::kInvalidSettings);
+      CHECK(pin.Initialize().error()->status == Status::kInvalidSettings);
     }
     SECTION("Invalid pin")
     {
@@ -153,7 +153,7 @@ TEST_CASE("Testing Msp432p401r Pin")
       Pin pin(1, invalid_pin_number);
 
       // Verify & Exercise
-      CHECK(pin.Initialize().error().status == Status::kInvalidSettings);
+      CHECK(pin.Initialize().error()->status == Status::kInvalidSettings);
     }
   }
 
@@ -227,7 +227,7 @@ TEST_CASE("Testing Msp432p401r Pin")
       }
 
       // Exercise & Verify
-      CHECK(test_pins[0].pin.SetPinFunction(function_code).error().status ==
+      CHECK(test_pins[0].pin.SetPinFunction(function_code).error()->status ==
             Status::kInvalidParameters);
     }
   }
@@ -259,7 +259,7 @@ TEST_CASE("Testing Msp432p401r Pin")
       bool actual_out;
 
       // Exercise & Verify - Setting pull as repeater
-      CHECK(pin.SetPull(Pin::Resistor::kRepeater).error().status ==
+      CHECK(pin.SetPull(Pin::Resistor::kRepeater).error()->status ==
             Status::kInvalidSettings);
 
       // Exercise - Setting pull up resistor
@@ -337,7 +337,7 @@ TEST_CASE("Testing Msp432p401r Pin")
       INFO("pin: " << static_cast<size_t>(kPinNumber));
 
       // Exercise and Verify
-      CHECK(pin.SetAsOpenDrain({}).error().status == Status::kNotImplemented);
+      CHECK(pin.SetAsOpenDrain({}).error()->status == Status::kNotImplemented);
     }
   }
 

--- a/library/L1_Peripheral/stm32f10x/test/pin_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/pin_test.cpp
@@ -235,7 +235,7 @@ TEST_CASE("Testing stm32f10x Pin")
       for (size_t i = 0; i < test.size(); i++)
       {
         // Exercise & Verify
-        CHECK(test[i].pin.SetPinFunction(0b10).error().status ==
+        CHECK(test[i].pin.SetPinFunction(0b10).error()->status ==
               Status::kInvalidParameters);
       }
     }
@@ -305,7 +305,7 @@ TEST_CASE("Testing stm32f10x Pin")
 
       {
         // Exercise & Verify
-        CHECK(test[i].pin.SetPull(Pin::Resistor::kRepeater).error().status ==
+        CHECK(test[i].pin.SetPull(Pin::Resistor::kRepeater).error()->status ==
               Status::kInvalidSettings);
       }
     }

--- a/library/L1_Peripheral/stm32f4xx/test/pin_test.cpp
+++ b/library/L1_Peripheral/stm32f4xx/test/pin_test.cpp
@@ -202,7 +202,7 @@ TEST_CASE("Testing stm32f4xx Pin")
       stm32f4xx::Pin invalid_pin(port, 0);
 
       // Exercise & Verify
-      CHECK(invalid_pin.Initialize().error().status ==
+      CHECK(invalid_pin.Initialize().error()->status ==
             Status::kInvalidSettings);
     }
   }
@@ -254,7 +254,7 @@ TEST_CASE("Testing stm32f4xx Pin")
         test[i].pin.Initialize();
 
         // Exercise & Verify
-        CHECK(test[i].pin.SetPinFunction(invalid_function).error().status ==
+        CHECK(test[i].pin.SetPinFunction(invalid_function).error()->status ==
               Status::kInvalidParameters);
       }
     }
@@ -303,7 +303,7 @@ TEST_CASE("Testing stm32f4xx Pin")
 
       {
         // Exercise & Verify
-        CHECK(test[i].pin.SetPull(Pin::Resistor::kRepeater).error().status ==
+        CHECK(test[i].pin.SetPull(Pin::Resistor::kRepeater).error()->status ==
               Status::kInvalidSettings);
       }
     }

--- a/library/L2_HAL/memory/test/sd_test.cpp
+++ b/library/L2_HAL/memory/test/sd_test.cpp
@@ -106,7 +106,7 @@ TEST_CASE("Testing SD Card Driver Class")
 
   SECTION("Disable()")
   {
-    CHECK(Status::kNotImplemented == sd.Disable().error().status);
+    CHECK(Status::kNotImplemented == sd.Disable().error()->status);
   }
 
   SECTION("GetBlockSize()")

--- a/library/L2_HAL/sensors/environment/temperature/test/tmp102_test.cpp
+++ b/library/L2_HAL/sensors/environment/temperature/test/tmp102_test.cpp
@@ -28,8 +28,8 @@ TEST_CASE("Testing Tmp102 Temperature Sensor")
     SECTION("Initialization failure")
     {
       // Setup
-      constexpr Status kExpectedStatus = Status::kBusError;
-      When(Method(mock_i2c, Initialize)).AlwaysReturn(Error(kExpectedStatus));
+      const auto kExpectedStatus = Error(Status::kBusError, "");
+      When(Method(mock_i2c, Initialize)).AlwaysReturn(kExpectedStatus);
 
       // Exercise
       auto success = temperature_sensor.Initialize();

--- a/library/L2_HAL/sensors/movement/accelerometer/test/mma8452q_test.cpp
+++ b/library/L2_HAL/sensors/movement/accelerometer/test/mma8452q_test.cpp
@@ -30,8 +30,8 @@ TEST_CASE("Accelerometer")
     SECTION("Failure")
     {
       // Setup
-      When(Method(mock_i2c, Initialize))
-          .AlwaysReturn(Error(Status::kNotReadyYet));
+      const auto kExpectedStatus = Error(Status::kNotReadyYet, "");
+      When(Method(mock_i2c, Initialize)).AlwaysReturn(kExpectedStatus);
 
       // Exercise
       auto result = test_subject.Initialize();

--- a/library/config.hpp
+++ b/library/config.hpp
@@ -222,16 +222,6 @@ static_assert(1 <= kFatDriveCount && kFatDriveCount <= 10,
 /// Delcare Constant STORE_ERROR_MESSAGE
 SJ2_DECLARE_CONSTANT(STORE_ERROR_MESSAGE, bool, kStoreErrorMessages);
 
-/// If true, will automatically print errors that occur in the system along with
-/// a stacktrace from when the error occurred.
-#if !defined(SJ2_AUTOMATICALLY_PRINT_ON_ERROR)
-#define SJ2_AUTOMATICALLY_PRINT_ON_ERROR true
-#endif  // !defined(SJ2_AUTOMATICALLY_PRINT_ON_ERROR)
-/// Delcare Constant AUTOMATICALLY_PRINT_ON_ERROR
-SJ2_DECLARE_CONSTANT(AUTOMATICALLY_PRINT_ON_ERROR,
-                     bool,
-                     kAutomaticallyPrintOnError);
-
 /// Enable or disable float support in printf statements. Setting to false will
 /// reduce binary size.
 #if !defined(SJ2_PRINTF_BUFFER_SIZE)

--- a/library/library.mk
+++ b/library/library.mk
@@ -1,6 +1,6 @@
 INCLUDES += $(LIBRARY_DIR)/
 
-LINT_FILTER += $(LIBRARY_DIR)/third_party/
+LINT_FILTER += library/third_party/
 
 include $(LIBRARY_DIR)/L0_Platform/L0.mk
 include $(LIBRARY_DIR)/L1_Peripheral/L1.mk

--- a/projects/continuous_integration/project_config.hpp
+++ b/projects/continuous_integration/project_config.hpp
@@ -3,6 +3,7 @@
 // options you can change.
 #pragma once
 
-#define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_DEBUG
+#define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_ERROR
+#define SJ2_AUTOMATICALLY_PRINT_ON_ERROR false
 
 #include "config.hpp"

--- a/projects/continuous_integration/scripts/presubmit.sh
+++ b/projects/continuous_integration/scripts/presubmit.sh
@@ -67,20 +67,12 @@ echo ""
 # ==============================================================================
 # Clang Tidy Check
 # ==============================================================================
+print_divider "Executing 'commit-tidy' check"
 
-if [ "$1" == "quick" ]; then
-  print_divider "Executing 'commit-tidy' check"
-  time make -s commit-tidy -j4
-  TIDY_CAPTURE=$?
-  print_status $TIDY_CAPTURE
-  echo ""
-else
-  print_divider "Executing 'tidy' check"
-  time make -s tidy -j4
-  TIDY_CAPTURE=$?
-  print_status $TIDY_CAPTURE
-  echo ""
-fi
+time make -s commit-tidy -j4
+TIDY_CAPTURE=$?
+print_status $TIDY_CAPTURE
+echo ""
 
 # ==============================================================================
 # Unit Test Check


### PR DESCRIPTION
Reduce the size of the Error_t object by:

- Replacing source_location object with char* and int
- Converting string_view -> char*
- Returns<> now returns an <const Error_t*> rather than the whole
  object
- Remove error automatic print config (and support for it)

Convert Error() into a macro that creates a static constexpr Error_t
object and returns a tl::unexpected(Error_t*) object. This keeps
compatibility with previous implementation and ensures that the
Error_t is placed in ROM.

Add DefinedError() function for creating tl::unexpected objects from
pre-defined error objects.

Fix issues with CI & Linux Platform:

- Linux GCC changed to version 9
- Change presubmit to use commit-tidy everytime
- Clean up post_libary.mk for CI