### PR TITLE
Reduce MacOSX Homebrew Install Times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,36 @@ matrix:
               branch: master
         - os: osx
           osx_image: xcode10
+          cache:
+            directories:
+              - $HOME/Library/Caches/Homebrew
+              - /usr/local/Homebrew
+          before_cache:
+            - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
+            - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find /usr/local/Homebrew \! -regex ".+\.git.+" -delete; fi
+          addons:
+            homebrew:
+              packages:
+              - python@3
           script:
             - cd projects/continuous_integration/
             - make presubmit
         - os: osx
           osx_image: xcode11.3
+          cache:
+            directories:
+              - $HOME/Library/Caches/Homebrew
+              - /usr/local/Homebrew
+          before_cache:
+            - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
+            - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find /usr/local/Homebrew \! -regex ".+\.git.+" -delete; fi
+          addons:
+            homebrew:
+              packages:
+              - python@3
           script:
             - cd projects/continuous_integration/
             - make presubmit
+
 install: ./setup
 

--- a/setup
+++ b/setup
@@ -35,10 +35,8 @@ LINK_PROJECTS=1
 # Import SJSU-Dev2 common shell script functions
 . $BASE/tools/common.sh
 
-function print_status_nl
-{
-  if [ $1 -ne 0 ]
-  then
+function print_status_nl() {
+  if [ $1 -ne 0 ]; then
     printf "$BOLD_RED"
     printf "✘ - failure"
   else
@@ -90,7 +88,7 @@ function install_linux_prerequisites() {
   echo "   Installing git, make, python3 + pip, curl, tar, g++9   "
   echo "└──────────────────────────────────────────────────────── "
   sudo apt install -y git make curl tar tree pv g++-9 \
-                      python3 python3-pip python3-setuptools
+    python3 python3-pip python3-setuptools
   local apt_install=$?
   print_status_nl $apt_install
   echo " ──────────────────────────────────────────────────┐"
@@ -117,10 +115,12 @@ function install_mac_osx_prerequisites() {
   echo " ───────────────────────────────────────────────────┐"
   echo "               Installing Homebrew                   "
   echo "└─────────────────────────────────────────────────── "
-  /usr/bin/ruby -e \
-    "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" \
-    < /dev/null
-  local brew_install=$?
+  which -s brew
+  if [[ $? -eq "0" ]]; then
+    # Install Homebrew
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+    local brew_install=$?
+  fi
   print_status_nl $brew_install
 
   echo " ───────────────────────────────────────────────────┐"
@@ -179,7 +179,7 @@ function download_and_extract_tool_bundle() {
 
   if [[ -f $TOOLS_BUNDLE_PATH ]]; then
     curl -z $TOOLS_BUNDLE_PATH -o $temporary_name \
-          -L0 "$TOOLS_BUNDLE_URL"
+      -L0 "$TOOLS_BUNDLE_URL"
   else
     curl -o $temporary_name -L0 "$TOOLS_BUNDLE_URL"
   fi
@@ -206,18 +206,18 @@ function download_and_extract_tool_bundle() {
     print_status_nl $extract
 
     # Verify that each directory exists
-    ls clang+llvm-*/ &> /dev/null
+    ls clang+llvm-*/ &>/dev/null
     printf "Verify that Clang tools were extracted... "
     local clang_exists=$?
     print_status_nl $clang_exists
 
-    ls gcc-arm*/ &> /dev/null
+    ls gcc-arm*/ &>/dev/null
     printf "Verify that ARM toolchain was extracted... "
     local gcc_exists=$?
     print_status_nl $gcc_exists
 
     printf "Verify that OpenOCD debug tools were extracted... "
-    ls openocd/ &> /dev/null
+    ls openocd/ &>/dev/null
     local openocd_exists=$?
     print_status_nl $openocd_exists
 
@@ -225,7 +225,7 @@ function download_and_extract_tool_bundle() {
     if [[ "$OS" == "Linux" ]]; then
       printf "Verify that OpenOCD debug tools for windows was extracted... "
       ls openocd-wsl/ &>/dev/null
-      openocd_exists=$(($openocd_exists+$?))
+      openocd_exists=$(($openocd_exists + $?))
       print_status_nl $openocd_exists
     fi
 


### PR DESCRIPTION
Detect if homebrew is installed and if so, simply update it. Otherwise
install it on the system.

Resolves #1349