### PR TITLE
Silence FreeRTOS Linux Build Warnings

### DIFF
--- a/library/L0_Platform/linux/freertos_posix/port.c
+++ b/library/L0_Platform/linux/freertos_posix/port.c
@@ -89,6 +89,10 @@
 #include <assert.h>
 #include <string.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wconversion"
+
 /* Scheduler includes. */
 #include "FreeRTOS.h"
 #include "task.h"
@@ -882,3 +886,4 @@ unsigned long ulPortGetTimerValue( void )
     return ( unsigned long ) xTimes.tms_utime;
 }
 
+#pragma GCC diagnostic pop

--- a/library/third_party/unity.c
+++ b/library/third_party/unity.c
@@ -1,3 +1,7 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wconversion"
+
 #include "third_party/fatfs/source/ff.c"         // NOLINT
 #include "third_party/fatfs/source/ffsystem.c"   // NOLINT
 #include "third_party/fatfs/source/ffunicode.c"  // NOLINT
@@ -10,3 +14,5 @@
 #include "third_party/FreeRTOS/Source/tasks.c"                    // NOLINT
 #include "third_party/FreeRTOS/Source/queue.c"                    // NOLINT
 #include "third_party/FreeRTOS/Source/portable/MemMang/heap_3.c"  // NOLINT
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
- Silence warnings produced by FreeRTOS in linux builds
- Make snprintf a weak function to allow libnano libraries to use that
  version of the library versus the tiny printf.