### PR TITLE
Migrate from Status_t to std::error_code

### DIFF
--- a/demos/arm_cortex/dwt_counter/source/main.cpp
+++ b/demos/arm_cortex/dwt_counter/source/main.cpp
@@ -8,7 +8,7 @@ int main()
   dwt_counter.Initialize();
 
   // We are storing the counts in an array to reduce the latency between each
-  // call to GetCount(). If we added a call to printf/LOG_INFO, this will
+  // call to GetCount(). If we added a call to printf/LogInfo, this will
   // introduce latency into the counts, making the tick counts seem larger then
   // they really are.
   constexpr size_t kCountTotal = 25;

--- a/demos/multiplatform/backtrace/source/main.cpp
+++ b/demos/multiplatform/backtrace/source/main.cpp
@@ -27,14 +27,6 @@ int Bar(void)
 {
   Baz();
 
-  SJ2_ASSERT_WARNING(2 < 5,
-                     "This assert warning message shouldn't show up "
-                     "since the condition evaluates to true. If it wasn't "
-                     "true, then this message would be printed to STDOUT. ");
-  SJ2_ASSERT_WARNING(1 == 0,
-                     "This assert warning message SHOULD show up, since the "
-                     "condition is, does 1 == 0, which is false. Since this "
-                     "is just a warning, the program will be stoped.");
   SJ2_ASSERT_FATAL(
       false,
       "SJ2_ASSERT_FATAL will cause the system to abort operations. This "
@@ -53,6 +45,9 @@ int main()
 {
   // This application assumes that all pins are set to function 0 (GPIO)
   sjsu::LogInfo("Backtrace Application Starting...");
+
   Foo();
+
+  // This will never be reached
   return 0;
 }

--- a/demos/multiplatform/status/source/main.cpp
+++ b/demos/multiplatform/status/source/main.cpp
@@ -4,7 +4,6 @@
 namespace
 {
 using sjsu::Returns;
-using sjsu::Status;
 }  // namespace
 
 // Example code that will return an error if invalid input is given.
@@ -23,7 +22,7 @@ Returns<int> CalculatePllCode(int frequency)
     default:
       // When creating an error give it a reasonable status and a helpful
       // message to the user.
-      return Error(Status::kInvalidParameters,
+      return Error(std::errc::invalid_argument,
                    "Frequency must be 1, 2, 4, 8, 16, 32 megahertz.");
   }
 
@@ -49,7 +48,8 @@ Returns<void> SetPllCode(int code)
   // detected.
   if (reg == (0b101 * 2))
   {
-    return Error(Status::kTimedOut, "CPU speed could not stabilize in time.");
+    return Error(std::errc::timed_out,
+                 "CPU speed could not stabilize in time.");
   }
 
   return {};

--- a/demos/sjone/ir_receiver/source/main.cpp
+++ b/demos/sjone/ir_receiver/source/main.cpp
@@ -12,6 +12,7 @@ enum RemoteCode : uint16_t
   kVolumeDown      = 0xB24D,
   kToggleBluetooth = 0x40BF,
 };
+
 /// @see https://www.sbprojects.net/knowledge/ir/nec.php
 constexpr sjsu::infrared::PulseDurationConfiguration_t kNecConfiguration = {
   .header_mark_duration  = 9000us,
@@ -62,6 +63,7 @@ void HandleDataFrame(const sjsu::infrared::DataFrame_t * data_frame)
 int main()
 {
   sjsu::LogInfo("Starting Tsop752 IR Receiver Example...");
+
   // Using timeout of 9ms since the header mark of the NEC remote is 9ms long.
   constexpr std::chrono::microseconds kTimeout               = 9ms;
   constexpr units::frequency::hertz_t kPulseCaptureFrequency = 1_MHz;
@@ -70,12 +72,13 @@ int main()
       sjsu::lpc17xx::PulseCaptureChannel::kCaptureTimer1,
       sjsu::lpc17xx::PulseCapture::CaptureChannelNumber::kChannel0,
       kPulseCaptureFrequency);
+
   sjsu::lpc17xx::Timer timer(sjsu::lpc17xx::TimerPeripheral::kTimer2);
 
   sjsu::Tsop752 ir_receiver(pulse_capture, timer, kTimeout);
+
   ir_receiver.SetInterruptCallback(HandleDataFrame);
-  SJ2_ASSERT_FATAL(ir_receiver.Initialize() == sjsu::Status::kSuccess,
-                   "Failed to initialize Tsop752.");
+  ir_receiver.Initialize();
 
   sjsu::Halt();
   return 0;

--- a/demos/sjone/light_sensor/source/main.cpp
+++ b/demos/sjone/light_sensor/source/main.cpp
@@ -14,15 +14,17 @@ int main()
   sjsu::lpc17xx::Adc adc2(sjsu::lpc17xx::AdcChannel::kChannel2);
 
   sjsu::Temt6000x01 light_sensor(adc2, kPullDownResistance);
-  SJ2_ASSERT_FATAL(light_sensor.Initialize() == sjsu::Status::kSuccess,
-                   "Failed to initialized light sensor!");
+  light_sensor.Initialize();
 
   while (true)
   {
-    sjsu::LogInfo(
-        "Lux: %.4f, Brightness Percentage: %.2f%%",
-        light_sensor.GetIlluminance().to<double>(),
-        static_cast<double>(light_sensor.GetPercentageBrightness() * 100));
+    auto lux = SJ2_RETURN_VALUE_ON_ERROR(light_sensor.GetIlluminance(), -1);
+    auto percent =
+        SJ2_RETURN_VALUE_ON_ERROR(light_sensor.GetPercentageBrightness(), -1);
+
+    sjsu::LogInfo("Lux: %.4f, Brightness Percentage: %.2f%%", lux.to<double>(),
+                  static_cast<double>(percent * 100));
+
     sjsu::Delay(1s);
   }
 

--- a/demos/sjone/parallel_lcd/source/main.cpp
+++ b/demos/sjone/parallel_lcd/source/main.cpp
@@ -5,41 +5,33 @@
 #include "L2_HAL/displays/lcd/st7066u.hpp"
 #include "L2_HAL/io/parallel_bus/parallel_gpio.hpp"
 
-namespace
-{
-// set up control pins for lcd
-sjsu::lpc17xx::Gpio rs(0, 29);  // RS:    Register Select
-sjsu::lpc17xx::Gpio rw(0, 30);  // RW:    Read / Write
-sjsu::lpc17xx::Gpio e(1, 19);   // E:     Chip Enable
-sjsu::lpc17xx::Gpio d7(2, 0);   // D7-D0: Parallel Data Pins
-sjsu::lpc17xx::Gpio d6(2, 1);
-sjsu::lpc17xx::Gpio d5(2, 2);
-sjsu::lpc17xx::Gpio d4(2, 3);
-sjsu::lpc17xx::Gpio d3(2, 4);
-sjsu::lpc17xx::Gpio d2(2, 5);
-sjsu::lpc17xx::Gpio d1(2, 6);
-sjsu::lpc17xx::Gpio d0(2, 7);
-
-std::array<sjsu::Gpio *, 8> data_pins = {
-  &d0, &d1, &d2, &d3, &d4, &d5, &d6, &d7
-};
-sjsu::ParallelGpio data_bus(data_pins.data(), data_pins.size());
-}  // namespace
-
 int main()
 {
   sjsu::LogInfo("Starting Parallel LCD Demo");
+
+  // set up control pins for lcd
+  sjsu::lpc17xx::Gpio rs(0, 29);  // RS:    Register Select
+  sjsu::lpc17xx::Gpio rw(0, 30);  // RW:    Read / Write
+  sjsu::lpc17xx::Gpio e(1, 19);   // E:     Chip Enable
+  sjsu::lpc17xx::Gpio d7(2, 0);   // D7-D0: Parallel Data Pins
+  sjsu::lpc17xx::Gpio d6(2, 1);
+  sjsu::lpc17xx::Gpio d5(2, 2);
+  sjsu::lpc17xx::Gpio d4(2, 3);
+  sjsu::lpc17xx::Gpio d3(2, 4);
+  sjsu::lpc17xx::Gpio d2(2, 5);
+  sjsu::lpc17xx::Gpio d1(2, 6);
+  sjsu::lpc17xx::Gpio d0(2, 7);
+
+  std::array<sjsu::Gpio *, 8> data_pins = { &d0, &d1, &d2, &d3,
+                                            &d4, &d5, &d6, &d7 };
+  sjsu::ParallelGpio data_bus(data_pins.data(), data_pins.size());
 
   constexpr uint8_t kMaxLines        = 4;
   constexpr uint8_t kMaxDisplayWidth = 20;
 
   sjsu::St7066u lcd(sjsu::St7066u::BusMode::kEightBit,
                     sjsu::St7066u::DisplayMode::kMultiLine,
-                    sjsu::St7066u::FontStyle::kFont5x8,
-                    rs,
-                    rw,
-                    e,
-                    data_bus);
+                    sjsu::St7066u::FontStyle::kFont5x8, rs, rw, e, data_bus);
   lcd.Initialize();
   lcd.DisplayText("Parallel LCD", sjsu::St7066u::CursorPosition_t{ 1, 4 });
   lcd.DisplayText("SJSU-DEV2", sjsu::St7066u::CursorPosition_t{ 2, 5 });

--- a/demos/sjtwo/buzzer/source/main.cpp
+++ b/demos/sjtwo/buzzer/source/main.cpp
@@ -10,6 +10,7 @@ int main()
   sjsu::LogInfo("The buzzer will start with a frequency of 1000 Hz");
   sjsu::LogInfo("and a volume of 10 percent i.e. 0.1f");
   sjsu::LogInfo("==================================================");
+
   sjsu::lpc40xx::Pwm pwm_pin(sjsu::lpc40xx::Pwm::Channel::kPwm1);
   sjsu::Buzzer buzzer(pwm_pin);
 
@@ -21,7 +22,7 @@ int main()
   sjsu::Delay(1s);
 
   sjsu::LogInfo(
-      "Buzzer will emit sound at 10 percent volume and 1kHz freqeuncy");
+      "Buzzer will emit sound at 10 percent volume and 1kHz frequency");
   buzzer.Beep(kFrequency, kVolume);
   sjsu::Delay(1s);
   buzzer.Stop();
@@ -41,10 +42,9 @@ int main()
   sjsu::Delay(1s);
   buzzer.Stop();
 
-  sjsu::LogInfo("Restart the example anytime by ");
-  sjsu::LogInfo("pressing the 'reset' button on controller");
+  sjsu::LogInfo(
+      "Restart the example anytime by pressing the 'reset' button on "
+      "controller");
 
-  sjsu::LogInfo("Halting the processor...");
-  sjsu::Halt();
   return 0;
 }

--- a/demos/sjtwo/can/source/main.cpp
+++ b/demos/sjtwo/can/source/main.cpp
@@ -65,7 +65,8 @@ int main(void)
     // See the array appear back on the device
     if (can2.HasData())
     {
-      sjsu::Can::Message_t message = can2.Receive();
+      sjsu::Can::Message_t message =
+          SJ2_RETURN_VALUE_ON_ERROR(can2.Receive(), -1);
       sjsu::LogInfo("CAN 2 received a message!");
       sjsu::LogInfo("ID: 0x%0" PRIX32, message.id);
       for (uint8_t i = 0; i < message.length; i++)
@@ -89,7 +90,8 @@ int main(void)
 
     if (can1.HasData())
     {
-      sjsu::Can::Message_t message = can1.Receive();
+      sjsu::Can::Message_t message =
+          SJ2_RETURN_VALUE_ON_ERROR(can1.Receive(), -2);
       sjsu::LogInfo("CAN 1 received a message!");
       sjsu::LogInfo("ID: 0x%0" PRIx32, message.id);
       for (uint8_t i = 0; i < message.length; i++)

--- a/demos/sjtwo/gpio_frequency_counter/source/main.cpp
+++ b/demos/sjtwo/gpio_frequency_counter/source/main.cpp
@@ -1,37 +1,40 @@
 #include "L1_Peripheral/lpc40xx/gpio.hpp"
 #include "L1_Peripheral/hardware_counter.hpp"
 #include "L1_Peripheral/frequency_counter.hpp"
-#include "L2_HAL/boards/sjtwo.hpp"
 #include "utility/time.hpp"
 #include "utility/log.hpp"
-#include "utility/rtos.hpp"
+#include "utility/status.hpp"
 
 int main()
 {
   sjsu::LogInfo("Gpio Frequency Counter Application Starting...");
+
   // Create a GPIO to read from. This can be any GPIO that supports GPIO
   // interrupts. On the LPC40xx, that would be pins on port 0 and port 2.
   //
   // Feel free to change this to some other gpio port and pin number.
   sjsu::lpc40xx::Gpio gpio(0, 0);
+
   // Pass the GPIO above into the gpio counter to be controlled by it.
   // The second parameter allows you to change which event triggers a count.
   // In this case, we want to trigger on rising and falling edges of the pin.
   // Note that this
   sjsu::GpioCounter counter(gpio, sjsu::Gpio::Edge::kRising);
+
   // Pass the gpio HardwareCounter object to the frequency counter object to be
   // used to calculate the frequency of the signal on that pin.
-  sjsu::FrequencyCounter frequency(&counter);
+  sjsu::FrequencyCounter frequency_counter(&counter);
+
   // Required: Initialize the hardware.
-  frequency.Initialize();
+  frequency_counter.Initialize();
+
   // Required: Enable the counter.
-  frequency.Enable();
+  frequency_counter.Enable();
 
   sjsu::LogInfo(
       "With every rising edge of pin P%u.%u, the counter will increase and its "
       "value will be printed to stdout.",
-      gpio.GetPin().GetPort(),
-      gpio.GetPin().GetPin());
+      gpio.GetPin().GetPort(), gpio.GetPin().GetPin());
 
   sjsu::LogInfo(
       "The more rising edges per second on that pin will result in a higher "
@@ -40,7 +43,9 @@ int main()
   while (true)
   {
     // Using printf here to reduce the latency between each
-    printf("Freq = %f\n", frequency.GetFrequency().to<double>());
+    auto frequency =
+        SJ2_RETURN_VALUE_ON_ERROR(frequency_counter.GetFrequency(), -1);
+    sjsu::LogInfo("Freq = %f\n", frequency.to<double>());
     sjsu::Delay(1000ms);
   }
   return 0;

--- a/demos/sjtwo/gpio_hardware_counter/source/main.cpp
+++ b/demos/sjtwo/gpio_hardware_counter/source/main.cpp
@@ -27,14 +27,15 @@ int main()
       "value will be printed to stdout.",
       gpio.GetPin().GetPort(), gpio.GetPin().GetPin());
 
-  uint32_t previous_count = 0;
+  int32_t previous_count = 0;
+
   while (true)
   {
-    uint32_t current_count = counter.GetCount();
+    int32_t current_count = SJ2_RETURN_VALUE_ON_ERROR(counter.GetCount(), -1);
     // Anytime the count changes, we print out the latest count.
     if (previous_count != current_count)
     {
-      sjsu::LogInfo("Hardare Count %" PRIu32 "\n", current_count);
+      sjsu::LogInfo("Hardare Count %" PRId32 "\n", current_count);
       previous_count = current_count;
     }
     // This throttles how often we print as well as demonstrates that the

--- a/demos/sjtwo/gpio_interrupts/source/main.cpp
+++ b/demos/sjtwo/gpio_interrupts/source/main.cpp
@@ -20,17 +20,25 @@ int main()
   pin3.GetPin().PullUp();
 
   sjsu::LogInfo("Setup P0[15] to interrupt on only Falling edges...");
-  pin0.AttachInterrupt([]() { sjsu::LogInfo("P0[15] interrupt!"); },
-                       sjsu::Gpio::Edge::kFalling);
+  auto was_successful = pin0.AttachInterrupt(
+      []() { sjsu::LogInfo("P0[15] interrupt!"); }, sjsu::Gpio::Edge::kFalling);
+
+  if (!was_successful)
+  {
+    return -1;
+  }
 
   sjsu::LogInfo("Setup P2[9] to interrupt on only Rising edges...");
-  pin1.OnRisingEdge([]() { sjsu::LogInfo("P2[9] interrupt!"); });
+  SJ2_RETURN_VALUE_ON_ERROR(
+      pin1.OnRisingEdge([]() { sjsu::LogInfo("P2[9] interrupt!"); }), -2);
 
   sjsu::LogInfo("Setup P0[29] to interrupt on Rising and Falling edges...");
-  pin2.OnChange([]() { sjsu::LogInfo("P0[29] interrupt!"); });
+  SJ2_RETURN_VALUE_ON_ERROR(
+      pin2.OnChange([]() { sjsu::LogInfo("P0[29] interrupt!"); }), -3);
 
   sjsu::LogInfo("Setup P0[30] to interrupt on Rising and Falling edges...");
-  pin2.OnChange([]() { sjsu::LogInfo("P0[30] interrupt!"); });
+  SJ2_RETURN_VALUE_ON_ERROR(
+      pin2.OnChange([]() { sjsu::LogInfo("P0[30] interrupt!"); }), -4);
 
   sjsu::LogInfo(
       "All of the pins are currently pulled high using an internal pull-up "

--- a/demos/sjtwo/ltc4150/source/main.cpp
+++ b/demos/sjtwo/ltc4150/source/main.cpp
@@ -42,11 +42,11 @@ int main()
   {
     // Grab the calculated charge from the counter, based on how many ticks it
     // received and the polarity.
-    units::charge::milliampere_hour_t recent_charge = counter.GetCharge();
+    units::charge::milliampere_hour_t recent_charge =
+        SJ2_RETURN_VALUE_ON_ERROR(counter.GetCharge(), -1);
 
     // Anytime the charge changes, we print out the latest count.
-    if (!ApproxEquality(previous_charge.to<float>(),
-                        recent_charge.to<float>(),
+    if (!ApproxEquality(previous_charge.to<float>(), recent_charge.to<float>(),
                         kResolution))
     {
       sjsu::LogInfo("Current Charge: %f mAh", recent_charge.to<double>());

--- a/demos/sjtwo/sd_card/source/main.cpp
+++ b/demos/sjtwo/sd_card/source/main.cpp
@@ -55,14 +55,14 @@ class DualGpios : public sjsu::Gpio
     return master_.GetPin();
   }
 
-  void AttachInterrupt(InterruptCallback callback, Edge edge) override
+  Returns<void> AttachInterrupt(InterruptCallback callback, Edge edge) override
   {
-    master_.AttachInterrupt(callback, edge);
+    return master_.AttachInterrupt(callback, edge);
   }
 
-  void DetachInterrupt() const override
+  Returns<void> DetachInterrupt() const override
   {
-    master_.DetachInterrupt();
+    return master_.DetachInterrupt();
   }
 
  private:

--- a/demos/stm32f10x/esp8266/source/main.cpp
+++ b/demos/stm32f10x/esp8266/source/main.cpp
@@ -1,8 +1,11 @@
+#include <cinttypes>
+#include <cstdint>
 #include <string_view>
 
 #include "L1_Peripheral/stm32f10x/uart.hpp"
 #include "L2_HAL/communication/esp8266.hpp"
 #include "utility/log.hpp"
+#include "utility/debug.hpp"
 
 constexpr std::string_view kHost = "www.example.com";
 constexpr std::string_view kGetRequestExample =
@@ -13,19 +16,20 @@ constexpr std::string_view kGetRequestExample =
 int main()
 {
   sjsu::LogInfo("ESP8266 Application Starting...");
-
   // Giving UART a massive 1kB receive buffer to make we don't lose any data.
-  sjsu::stm32f10x::Uart<1024> uart2(sjsu::stm32f10x::UartBase::Port::kUart2);
-  sjsu::Esp8266 wifi(uart2);
+  sjsu::stm32f10x::Uart<1024> uart(sjsu::stm32f10x::UartBase::Port::kUart2);
+  sjsu::Esp8266 wifi(uart);
 
   sjsu::LogInfo("Initializing Esp8266 module...");
-  LOG_ON_FAILURE(wifi.Initialize());
+  if (auto result = wifi.Initialize(); !result)
+  {
+    result.error()->Print();
+  }
 
   while (true)
   {
     sjsu::LogInfo("Connecting to WiFi...");
-    auto status = wifi.ConnectToAccessPoint("ssid", "password");
-    if (status == sjsu::Status::kSuccess)
+    if (wifi.ConnectToAccessPoint("ssid", "password"))
     {
       break;
     }
@@ -36,19 +40,29 @@ int main()
   sjsu::LogInfo("Connected to WiFi!!");
 
   sjsu::LogInfo("Connecting to server (%s)...", kHost.data());
-  LOG_ON_FAILURE(
-      wifi.Connect(sjsu::InternetSocket::Protocol::kTCP, kHost, 80, 5s));
 
-  LOG_ON_FAILURE(
-      wifi.Write(kGetRequestExample.data(), kGetRequestExample.size(), 5s));
+  if (auto result =
+          wifi.Connect(sjsu::InternetSocket::Protocol::kTCP, kHost, 9000, 5s);
+      !result)
+  {
+    result.error()->Print();
+  }
+
+  if (auto result =
+          wifi.Write(kGetRequestExample.data(), kGetRequestExample.size(), 5s);
+      !result)
+  {
+    result.error()->Print();
+  }
 
   std::array<char, 2048> response;
   size_t read_back = 0;
-  read_back += wifi.Read(&response[read_back], response.size(), 10s);
-  read_back +=
-      wifi.Read(&response[read_back], response.size() - read_back, 10s);
+  read_back += SJ2_RETURN_VALUE_ON_ERROR(
+      wifi.Read(&response[read_back], response.size(), 10s), -1);
+  read_back += SJ2_RETURN_VALUE_ON_ERROR(
+      wifi.Read(&response[read_back], response.size() - read_back, 10s), -1);
 
-  sjsu::LogInfo("Printing Response From Server:");
+  sjsu::LogInfo("Printing Server Response:");
   printf("%.*s\n", read_back, response.data());
   puts("===================================================================");
 

--- a/demos/stm32f10x/fatfs/source/main.cpp
+++ b/demos/stm32f10x/fatfs/source/main.cpp
@@ -1,4 +1,5 @@
 #include "L0_Platform/startup.hpp"
+#include "L1_Peripheral/spi.hpp"
 #include "L1_Peripheral/stm32f10x/gpio.hpp"
 #include "L1_Peripheral/stm32f10x/system_controller.hpp"
 #include "L2_HAL/memory/sd.hpp"
@@ -15,7 +16,7 @@ class BitBangSpi : public sjsu::Spi
   {
   }
 
-  sjsu::Status Initialize() const override
+  sjsu::Returns<void> Initialize() const override
   {
     mosi_.SetAsOutput();
     miso_.SetAsInput();
@@ -23,7 +24,7 @@ class BitBangSpi : public sjsu::Spi
     sck_.SetLow();
     mosi_.SetLow();
     miso_.GetPin().PullUp();
-    return sjsu::Status::kSuccess;
+    return {};
   }
 
   uint16_t Transfer(uint16_t data) const override
@@ -53,9 +54,9 @@ class BitBangSpi : public sjsu::Spi
     size_ = size;
   }
 
-  void SetClock(units::frequency::hertz_t frequency,
-                bool = false,
-                bool = false) const override
+  sjsu::Returns<void> SetClock(units::frequency::hertz_t frequency,
+                               bool = false,
+                               bool = false) const override
   {
     if (frequency < 1_MHz)
     {
@@ -65,6 +66,7 @@ class BitBangSpi : public sjsu::Spi
     {
       delay_ = false;
     }
+    return {};
   }
 
  private:

--- a/demos/stm32f10x/sd_card/source/main.cpp
+++ b/demos/stm32f10x/sd_card/source/main.cpp
@@ -1,5 +1,6 @@
 #include "L0_Platform/startup.hpp"
 #include "L1_Peripheral/stm32f10x/gpio.hpp"
+#include "L1_Peripheral/spi.hpp"
 #include "L1_Peripheral/stm32f10x/system_controller.hpp"
 #include "L2_HAL/memory/sd.hpp"
 #include "utility/debug.hpp"
@@ -24,7 +25,7 @@ class BitBangSpi : public sjsu::Spi
   {
   }
 
-  sjsu::Status Initialize() const override
+  sjsu::Returns<void> Initialize() const override
   {
     mosi_.SetAsOutput();
     miso_.SetAsInput();
@@ -32,7 +33,7 @@ class BitBangSpi : public sjsu::Spi
     sck_.SetLow();
     mosi_.SetLow();
     miso_.GetPin().PullUp();
-    return sjsu::Status::kSuccess;
+    return {};
   }
 
   uint16_t Transfer(uint16_t data) const override
@@ -62,9 +63,9 @@ class BitBangSpi : public sjsu::Spi
     size_ = size;
   }
 
-  void SetClock(units::frequency::hertz_t frequency,
-                bool = false,
-                bool = false) const override
+  sjsu::Returns<void> SetClock(units::frequency::hertz_t frequency,
+                               bool = false,
+                               bool = false) const override
   {
     if (frequency < 1_MHz)
     {
@@ -74,6 +75,7 @@ class BitBangSpi : public sjsu::Spi
     {
       delay_ = false;
     }
+    return {};
   }
 
  private:

--- a/demos/stm32f10x/super_bluepill_oled/source/main.cpp
+++ b/demos/stm32f10x/super_bluepill_oled/source/main.cpp
@@ -1,7 +1,7 @@
 #include "L0_Platform/startup.hpp"
+#include "L1_Peripheral/spi.hpp"
 #include "L1_Peripheral/stm32f10x/gpio.hpp"
 #include "L1_Peripheral/stm32f10x/system_controller.hpp"
-#include "L1_Peripheral/spi.hpp"
 #include "L2_HAL/displays/oled/ssd1306.hpp"
 #include "L3_Application/graphics.hpp"
 #include "utility/time.hpp"
@@ -14,13 +14,13 @@ class BitBangSpi : public sjsu::Spi
  public:
   BitBangSpi(sjsu::Gpio & sck, sjsu::Gpio & mosi) : sck_(sck), mosi_(mosi) {}
 
-  sjsu::Status Initialize() const override
+  sjsu::Returns<void> Initialize() const override
   {
     mosi_.SetAsOutput();
     sck_.SetAsOutput();
     sck_.SetLow();
     mosi_.SetLow();
-    return sjsu::Status::kSuccess;
+    return {};
   }
 
   uint16_t Transfer(uint16_t data) const override
@@ -44,10 +44,11 @@ class BitBangSpi : public sjsu::Spi
     size_ = size;
   }
 
-  void SetClock(units::frequency::hertz_t,
-                bool = false,
-                bool = false) const override
+  sjsu::Returns<void> SetClock(units::frequency::hertz_t,
+                         bool = false,
+                         bool = false) const override
   {
+    return {};
   }
 
  private:

--- a/library/L0_Platform/lpc17xx/startup.cpp
+++ b/library/L0_Platform/lpc17xx/startup.cpp
@@ -172,10 +172,14 @@ void InitializePlatform()
 
   system_timer.Initialize();
   system_timer.SetTickFrequency(config::kRtosFrequency);
-  sjsu::Status timer_start_status = system_timer.StartTimer();
-
-  SJ2_ASSERT_FATAL(timer_start_status == sjsu::Status::kSuccess,
-                   "System Timer (used by FreeRTOS) has FAILED to start!");
+  if (auto status = system_timer.StartTimer(); !status)
+  {
+    status.error()->Print();
+    sjsu::LogError(
+        "System Timer (used as the system timer and by "
+        "FreeRTOS) has FAILED to start!");
+    sjsu::Halt();
+  }
 
   arm_dwt_counter.Initialize();
   sjsu::SetUptimeFunction(sjsu::cortex::SystemTimer::GetCount);

--- a/library/L0_Platform/lpc40xx/startup.cpp
+++ b/library/L0_Platform/lpc40xx/startup.cpp
@@ -182,10 +182,14 @@ void InitializePlatform()
 
   system_timer.Initialize();
   system_timer.SetTickFrequency(config::kRtosFrequency);
-  sjsu::Status timer_start_status = system_timer.StartTimer();
-
-  SJ2_ASSERT_FATAL(timer_start_status == sjsu::Status::kSuccess,
-                   "System Timer (used by FreeRTOS) has FAILED to start!");
+  if (auto status = system_timer.StartTimer(); !status)
+  {
+    status.error()->Print();
+    sjsu::LogError(
+        "System Timer (used as the system timer and by "
+        "FreeRTOS) has FAILED to start!");
+    sjsu::Halt();
+  }
 
   arm_dwt_counter.Initialize();
   sjsu::SetUptimeFunction(sjsu::cortex::SystemTimer::GetCount);

--- a/library/L0_Platform/msp432p401r/startup.cpp
+++ b/library/L0_Platform/msp432p401r/startup.cpp
@@ -167,10 +167,14 @@ void InitializePlatform()
 
   system_timer.Initialize();
   system_timer.SetTickFrequency(config::kRtosFrequency);
-  sjsu::Status timer_start_status = system_timer.StartTimer();
-
-  SJ2_ASSERT_FATAL(timer_start_status == sjsu::Status::kSuccess,
-                   "System Timer (used by FreeRTOS) has FAILED to start!");
+  if (auto status = system_timer.StartTimer(); !status)
+  {
+    status.error()->Print();
+    sjsu::LogError(
+        "System Timer (used as the system timer and by "
+        "FreeRTOS) has FAILED to start!");
+    sjsu::Halt();
+  }
 
   arm_dwt_counter.Initialize();
   sjsu::SetUptimeFunction(sjsu::cortex::SystemTimer::GetCount);

--- a/library/L0_Platform/stm32f10x/startup.cpp
+++ b/library/L0_Platform/stm32f10x/startup.cpp
@@ -197,11 +197,16 @@ void InitializePlatform()
 
   system_controller.Initialize();
 
+  system_timer.Initialize();
   system_timer.SetTickFrequency(config::kRtosFrequency);
-  sjsu::Status timer_start_status = system_timer.StartTimer();
-
-  SJ2_ASSERT_FATAL(timer_start_status == sjsu::Status::kSuccess,
-                   "System Timer (used by FreeRTOS) has FAILED to start!");
+  if (auto status = system_timer.StartTimer(); !status)
+  {
+    status.error()->Print();
+    sjsu::LogError(
+        "System Timer (used as the system timer and by "
+        "FreeRTOS) has FAILED to start!");
+    sjsu::Halt();
+  }
 
   arm_dwt_counter.Initialize();
   sjsu::SetUptimeFunction(sjsu::cortex::SystemTimer::GetCount);

--- a/library/L0_Platform/stm32f4xx/startup.cpp
+++ b/library/L0_Platform/stm32f4xx/startup.cpp
@@ -212,11 +212,16 @@ void InitializePlatform()
   sjsu::InterruptController::SetPlatformController(&interrupt_controller);
   sjsu::SystemController::SetPlatformController(&system_controller);
 
+  system_timer.Initialize();
   system_timer.SetTickFrequency(config::kRtosFrequency);
-  sjsu::Status timer_start_status = system_timer.StartTimer();
-
-  SJ2_ASSERT_FATAL(timer_start_status == sjsu::Status::kSuccess,
-                   "System Timer (used by FreeRTOS) has FAILED to start!");
+  if (auto status = system_timer.StartTimer(); !status)
+  {
+    status.error()->Print();
+    sjsu::LogError(
+        "System Timer (used as the system timer and by "
+        "FreeRTOS) has FAILED to start!");
+    sjsu::Halt();
+  }
 
   arm_dwt_counter.Initialize();
   sjsu::SetUptimeFunction(sjsu::cortex::SystemTimer::GetCount);

--- a/library/L1_Peripheral/adc.hpp
+++ b/library/L1_Peripheral/adc.hpp
@@ -15,7 +15,7 @@ class Adc
  public:
   /// Initialize and enable hardware. This must be called before any other
   /// method in this interface is called.
-  virtual Status Initialize() const = 0;
+  virtual Returns<void> Initialize() const = 0;
 
   /// Read the analog signal's value.
   /// The number active bits depends on the ADC being used and be known by

--- a/library/L1_Peripheral/can.hpp
+++ b/library/L1_Peripheral/can.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
+#include <scope>
 
 #include "utility/status.hpp"
 
@@ -56,22 +57,22 @@ class Can
 
   /// Initialize the CANBUS peripheral. Must be called before calling anything
   /// else in the driver.
-  virtual Status Initialize() const = 0;
+  virtual Returns<void> Initialize() const = 0;
 
   /// Enables CANBUS and allows communication. Must be called after Initialize()
   /// before using this driver.
-  virtual void Enable() const = 0;
+  virtual Returns<void> Enable() const = 0;
 
   /// Send a message via CANBUS to the designated device with the supplied ID
   ///
   /// @param message - Message containing the CANBUS contents.
-  virtual void Send(const Message_t & message) const = 0;
+  virtual Returns<void> Send(const Message_t & message) const = 0;
 
   /// Receive data via CANBUS
   ///
   /// @return retrieved can message. Will return with length field = 0 if no
   /// messages exist.
-  virtual Message_t Receive() const = 0;
+  virtual Returns<Message_t> Receive() const = 0;
 
   /// Checks if there is a message available for this channel.
   ///
@@ -91,7 +92,7 @@ class Can
   virtual bool IsBusOff() const = 0;
 
   /// @param baud - baud rate to configure the CANBUS to
-  virtual void SetBaudRate(
+  virtual Returns<void> SetBaudRate(
       units::frequency::hertz_t baud = kStandardBaudRate) const = 0;
 
   // ===========================================================================
@@ -104,14 +105,18 @@ class Can
   /// @param payload - array literal payload to send to the device with ID
   /// @return true - on success
   /// @return false - on failure
-  void Send(uint32_t id, std::initializer_list<uint8_t> payload) const
+  Returns<void> Send(uint32_t id, std::initializer_list<uint8_t> payload) const
   {
     Message_t message;
+
+    message.id     = id;
+    message.length = static_cast<uint8_t>(payload.size());
+
     std::copy_n(payload.begin(),
                 std::min(payload.size(), message.payload.size()),
                 message.payload.begin());
-    message.id = id;
-    Send(message);
+
+    return Send(message);
   }
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/cortex/test/system_timer_test.cpp
+++ b/library/L1_Peripheral/cortex/test/system_timer_test.cpp
@@ -47,7 +47,7 @@ TEST_CASE("Testing ARM Cortex SystemTimer")
   using ResourceID = sjsu::SystemController::ResourceID;
 
   constexpr uint8_t kExpectedPriority = 3;
-  constexpr ResourceID kId = ResourceID::Define<0>();
+  constexpr ResourceID kId            = ResourceID::Define<0>();
   SystemTimer test_subject(kId, kExpectedPriority);
 
   SECTION("Initialize()")
@@ -106,7 +106,7 @@ TEST_CASE("Testing ARM Cortex SystemTimer")
     local_systick.LOAD       = 1000;
 
     // Exercise
-    CHECK(Status::kSuccess == test_subject.StartTimer());
+    CHECK(test_subject.StartTimer());
 
     // Verify
     CHECK(kMask == local_systick.CTRL);
@@ -132,7 +132,7 @@ TEST_CASE("Testing ARM Cortex SystemTimer")
     local_systick.VAL  = 0xBEEF;
 
     // Exercise
-    CHECK(Status::kInvalidSettings == test_subject.StartTimer());
+    CHECK(std::errc::invalid_argument == test_subject.StartTimer());
 
     // Verify
     CHECK(kClkSourceMask == local_systick.CTRL);

--- a/library/L1_Peripheral/frequency_counter.hpp
+++ b/library/L1_Peripheral/frequency_counter.hpp
@@ -17,31 +17,35 @@ class FrequencyCounter
 
   /// Initializes counter hardware. Will NOT start counting at this point. Will
   /// also set the counting direction to count up.
-  virtual void Initialize()
+  virtual Returns<void> Initialize()
   {
-    counter_->Initialize();
-    counter_->SetDirection(HardwareCounter::Direction::kUp);
+    SJ2_RETURN_ON_ERROR(counter_->Initialize());
+    SJ2_RETURN_ON_ERROR(
+        counter_->SetDirection(HardwareCounter::Direction::kUp));
+    return {};
   }
 
   /// Will enable the hardware counter and start the time measurement that will
   /// be used to measure the approximate frequency of the hardware counter.
-  virtual void Enable()
+  virtual Returns<void> Enable()
   {
-    counter_->Enable();
+    SJ2_RETURN_ON_ERROR(counter_->Enable());
     previous_time_ = Uptime();
+    return {};
   }
 
   /// Disable/Stops the hardware counter from counting.
-  virtual void Disable()
+  virtual Returns<void> Disable()
   {
-    counter_->Disable();
+    return counter_->Disable();
   }
 
   /// Resets the frequency counter.
-  virtual void Reset()
+  virtual Returns<void> Reset()
   {
-    previous_count_ = counter_->GetCount();
+    previous_count_ = SJ2_RETURN_ON_ERROR(counter_->GetCount());
     previous_time_  = Uptime();
+    return {};
   }
 
   /// Returns the approximate frequency of the hardware counter by measuring the
@@ -57,9 +61,9 @@ class FrequencyCounter
   /// you expect in order to get reliable results. For more information as to
   /// why this is, see whats called the "Nyquist Frequency".
   /// https://en.wikipedia.org/wiki/Nyquist_frequency
-  virtual units::frequency::hertz_t GetFrequency()
+  virtual Returns<units::frequency::hertz_t> GetFrequency()
   {
-    uint32_t current_count = counter_->GetCount();
+    uint32_t current_count = SJ2_RETURN_ON_ERROR(counter_->GetCount());
     auto current_uptime    = Uptime();
 
     uint32_t count_delta                 = current_count - previous_count_;

--- a/library/L1_Peripheral/gpio.hpp
+++ b/library/L1_Peripheral/gpio.hpp
@@ -71,10 +71,11 @@ class Gpio
   /// @param callback - the callback supplied here will be executed when the
   ///        interrupt condition occurs
   /// @param edge - the pin condition that will trigger the interrupt
-  virtual void AttachInterrupt(InterruptCallback callback, Edge edge) = 0;
+  virtual Returns<void> AttachInterrupt(InterruptCallback callback,
+                                        Edge edge) = 0;
 
   /// Remove interrupt call from pin and deactivate interrupts for this pin
-  virtual void DetachInterrupt() const = 0;
+  virtual Returns<void> DetachInterrupt() const = 0;
 
   // ===========================================================================
   // Utility Methods
@@ -108,27 +109,27 @@ class Gpio
   ///
   /// @param callback - the function to be called when a rising edge event
   ///                   occurs on this pin.
-  void OnRisingEdge(InterruptCallback callback)
+  Returns<void> OnRisingEdge(InterruptCallback callback)
   {
-    AttachInterrupt(callback, Edge::kRising);
+    return AttachInterrupt(callback, Edge::kRising);
   }
 
   /// Set pin to run callback when the pin sees a falling edge
   ///
   /// @param callback - the function to be called when a falling edge event
   ///                   occurs on this pin.
-  void OnFallingEdge(InterruptCallback callback)
+  Returns<void> OnFallingEdge(InterruptCallback callback)
   {
-    AttachInterrupt(callback, Edge::kFalling);
+    return AttachInterrupt(callback, Edge::kFalling);
   }
 
   /// Set pin to run callback when the pin sees a change on the pin's state.
   ///
   /// @param callback - the function to be called when a rising edge or falling
   ///                   edge event occurs on this pin.
-  void OnChange(InterruptCallback callback)
+  Returns<void> OnChange(InterruptCallback callback)
   {
-    AttachInterrupt(callback, Edge::kBoth);
+    return AttachInterrupt(callback, Edge::kBoth);
   }
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/hardware_counter.hpp
+++ b/library/L1_Peripheral/hardware_counter.hpp
@@ -25,29 +25,29 @@ class HardwareCounter
   /// that the counter is set to zero after this call. NOTE: This must not
   /// enable the counter. In order to start counting based on an external input,
   /// an explicit invocation of Enable() must occur.
-  virtual void Initialize() = 0;
+  virtual Returns<void> Initialize() = 0;
 
   /// Set counter to a specific value. There is no guarantee that a count will
   /// not be missed during the invocation of this call.
   ///
   /// @param new_count_value - the value to set the counter to.
-  virtual void Set(int32_t new_count_value) = 0;
+  virtual Returns<void> Set(int32_t new_count_value) = 0;
 
   /// Set the direction of the counter to either up or down. Doing so will cause
   /// the counter to begin counting in that direction as events occur.
   ///
   /// @param direction - the direction (either up or down) to count.
-  virtual void SetDirection(Direction direction) = 0;
+  virtual Returns<void> SetDirection(Direction direction) = 0;
 
   /// Starts counting from clock input. Must be called after Initialize() to
   /// begin counting.
-  virtual void Enable() = 0;
+  virtual Returns<void> Enable() = 0;
 
   /// Stops counting from clock input. Current count is retained.
-  virtual void Disable() = 0;
+  virtual Returns<void> Disable() = 0;
 
   /// Get the current count from hardware timer.
-  virtual int32_t GetCount() = 0;
+  virtual Returns<int32_t> GetCount() = 0;
 
   /// Default virtual destructor
   virtual ~HardwareCounter() = default;
@@ -70,33 +70,36 @@ class GpioCounter : public HardwareCounter
   {
   }
 
-  void Initialize() override
+  Returns<void> Initialize() override
   {
     gpio_.GetPin().SetPull(pull_);
     gpio_.SetAsInput();
+    return {};
   }
-  void Set(int32_t new_count_value) override
+  Returns<void> Set(int32_t new_count_value) override
   {
     count_ = new_count_value;
+    return {};
   }
 
-  void SetDirection(HardwareCounter::Direction direction) override
+  Returns<void> SetDirection(HardwareCounter::Direction direction) override
   {
     direction_ = direction;
+    return {};
   }
 
-  void Enable() override
+  Returns<void> Enable() override
   {
-    gpio_.AttachInterrupt([this] { count_ += Value(direction_.load()); },
-                          edge_);
+    return gpio_.AttachInterrupt([this] { count_ += Value(direction_.load()); },
+                                 edge_);
   }
 
-  void Disable() override
+  Returns<void> Disable() override
   {
-    gpio_.DetachInterrupt();
+    return gpio_.DetachInterrupt();
   }
 
-  int32_t GetCount() override
+  Returns<int32_t> GetCount() override
   {
     return count_;
   }

--- a/library/L1_Peripheral/i2c.hpp
+++ b/library/L1_Peripheral/i2c.hpp
@@ -37,15 +37,15 @@ class I2c
   {
    public:
     static constexpr auto kTimeout =
-        Error_t(Status::kTimedOut,
+        Error_t(std::errc::timed_out,
                 "I2C took too long to process and timed out! Consider "
                 "increasing the timeout time.");
 
     static constexpr auto kBusError =
-        Error_t(Status::kBusError, "I2C bus error occurred.");
+        Error_t(std::errc::io_error, "I2C bus error occurred.");
 
     static constexpr auto kDeviceNotFound =
-        Error_t(Status::kDeviceNotFound,
+        Error_t(std::errc::no_such_device_or_address,
                 "I2C address not found/acknowledged by device.");
   };
 
@@ -109,7 +109,7 @@ class I2c
 
     /// The status of the transaction after it is completed, fails, or times
     /// out.
-    Status status = Status::kSuccess;
+    std::errc status = static_cast<std::errc>(0);
   };
 
   // ===========================================================================
@@ -123,11 +123,9 @@ class I2c
   /// Perform a I2C transaction using the information contained in the
   /// transaction parameter.
   ///
-  /// @return Status::kTimeout if the transaction could not be performed in the
-  ///         set time.
-  ///         Status::kDeviceNotFound if external device does not respond to
-  ///         address on the bus
-  ///         Status::kSuccess if transaction was fulfilled.
+  /// @return std::errc::timed_out, std::errc::io_error, or
+  /// std::errc::no_such_device_or_address, depending on the circumstances of
+  /// the error that occurred during the transaction.
   virtual Returns<void> Transaction(Transaction_t transaction) const = 0;
 
   // ===========================================================================

--- a/library/L1_Peripheral/inactive.hpp
+++ b/library/L1_Peripheral/inactive.hpp
@@ -89,9 +89,9 @@ inline sjsu::Adc & GetInactive<sjsu::Adc>()
   class InactiveAdc : public sjsu::Adc
   {
    public:
-    sjsu::Status Initialize() const override
+    Returns<void> Initialize() const override
     {
-      return sjsu::Status::kNotImplemented;
+      return {};
     }
     uint32_t Read() const override
     {
@@ -158,8 +158,14 @@ inline sjsu::Gpio & GetInactive<sjsu::Gpio>()
     {
       return GetInactive<sjsu::Pin>();
     }
-    void AttachInterrupt(InterruptCallback, Edge) override {}
-    void DetachInterrupt() const override {}
+    Returns<void> AttachInterrupt(InterruptCallback, Edge) override
+    {
+      return {};
+    }
+    Returns<void> DetachInterrupt() const override
+    {
+      return {};
+    }
   };
 
   static InactiveGpio inactive;
@@ -194,16 +200,25 @@ inline sjsu::Pwm & GetInactive<sjsu::Pwm>()
   class InactivePwm : public sjsu::Pwm
   {
    public:
-    Status Initialize(units::frequency::hertz_t) const override
+    Returns<void> Initialize(units::frequency::hertz_t) const override
     {
-      return Status::kNotImplemented;
+      return {};
     }
-    void SetDutyCycle(float) const override {}
-    float GetDutyCycle() const override
+
+    Returns<void> SetDutyCycle(float) const override
+    {
+      return {};
+    }
+
+    Returns<float> GetDutyCycle() const override
     {
       return 0.0;
     }
-    void SetFrequency(units::frequency::hertz_t) const override {}
+
+    Returns<void> SetFrequency(units::frequency::hertz_t) const override
+    {
+      return {};
+    }
   };
 
   static InactivePwm inactive;
@@ -217,16 +232,19 @@ inline sjsu::Spi & GetInactive<sjsu::Spi>()
   class InactiveSpi : public sjsu::Spi
   {
    public:
-    Status Initialize() const override
+    Returns<void> Initialize() const override
     {
-      return Status::kNotImplemented;
+      return {};
     }
     uint16_t Transfer(uint16_t) const override
     {
       return 0xFF;
     }
     void SetDataSize(DataSize) const override {}
-    void SetClock(units::frequency::hertz_t, bool, bool) const override {}
+    Returns<void> SetClock(units::frequency::hertz_t, bool, bool) const override
+    {
+      return {};
+    }
   };
 
   static InactiveSpi inactive;
@@ -286,9 +304,9 @@ inline sjsu::SystemTimer & GetInactive<sjsu::SystemTimer>()
    public:
     void Initialize() const override {}
     void SetCallback(InterruptCallback) const override {}
-    Status StartTimer() const override
+    Returns<void> StartTimer() const override
     {
-      return Status::kNotImplemented;
+      return {};
     }
     int32_t SetTickFrequency(units::frequency::hertz_t) const override
     {
@@ -307,14 +325,19 @@ inline sjsu::Timer & GetInactive<sjsu::Timer>()
   class InactiveTimer : public sjsu::Timer
   {
    public:
-    Status Initialize(units::frequency::hertz_t,
-                      InterruptCallback,
-                      int32_t) const override
+    Returns<void> Initialize(units::frequency::hertz_t,
+                             InterruptCallback,
+                             int32_t) const override
     {
-      return Status::kNotImplemented;
+      return {};
     }
-    void SetMatchBehavior(uint32_t, MatchAction, uint8_t) const override {}
-    uint32_t GetCount() const override
+    Returns<void> SetMatchBehavior(uint32_t,
+                                   MatchAction,
+                                   uint8_t) const override
+    {
+      return {};
+    }
+    Returns<uint32_t> GetCount() const override
     {
       return 0;
     }
@@ -322,9 +345,18 @@ inline sjsu::Timer & GetInactive<sjsu::Timer>()
     {
       return 3;
     }
-    void Start() const override {}
-    void Stop() const override {}
-    void Reset() const override {}
+    Returns<void> Start() const override
+    {
+      return {};
+    }
+    Returns<void> Stop() const override
+    {
+      return {};
+    }
+    Returns<void> Reset() const override
+    {
+      return {};
+    }
   };
 
   static InactiveTimer inactive;
@@ -338,13 +370,13 @@ inline sjsu::Uart & GetInactive<sjsu::Uart>()
   class InactiveUart : public sjsu::Uart
   {
    public:
-    Status Initialize(uint32_t) const override
+    Returns<void> Initialize(uint32_t) const override
     {
-      return Status::kNotImplemented;
+      return {};
     }
-    bool SetBaudRate(uint32_t) const override
+    Returns<void> SetBaudRate(uint32_t) const override
     {
-      return true;
+      return {};
     }
     void Write(const void *, size_t) const override {}
     size_t Read(void *, size_t) const override

--- a/library/L1_Peripheral/lpc17xx/adc.hpp
+++ b/library/L1_Peripheral/lpc17xx/adc.hpp
@@ -27,6 +27,7 @@ struct AdcChannel  // NOLINT
     kCh45Pins   = 0b11,
     kCh67Pins   = 0b10,
   };
+
   inline static const Pin kAdcPinChannel0 = Pin::CreatePin<0, 23>();
   inline static const Pin kAdcPinChannel1 = Pin::CreatePin<0, 24>();
   inline static const Pin kAdcPinChannel2 = Pin::CreatePin<0, 25>();

--- a/library/L1_Peripheral/lpc17xx/pin.hpp
+++ b/library/L1_Peripheral/lpc17xx/pin.hpp
@@ -94,7 +94,7 @@ class Pin final : public sjsu::Pin
   [[deprecated("Unsupported operation")]] Returns<void> SetAsAnalogMode(
       bool) const override
   {
-    return Error(Status::kNotImplemented, "Unsupported operation");
+    return Error(std::errc::operation_not_supported, "");
   }
 
   Returns<void> SetAsOpenDrain(bool set_as_open_drain = true) const override

--- a/library/L1_Peripheral/lpc40xx/adc.hpp
+++ b/library/L1_Peripheral/lpc40xx/adc.hpp
@@ -235,7 +235,7 @@ class Adc final : public sjsu::Adc
   {
   }
 
-  Status Initialize() const override
+  Returns<void> Initialize() const override
   {
     auto & system     = sjsu::SystemController::GetPlatformController();
     const auto kAdcId = sjsu::lpc40xx::SystemController::Peripherals::kAdc;
@@ -266,7 +266,7 @@ class Adc final : public sjsu::Adc
 
     adc_base->CR = control;
 
-    return Status::kSuccess;
+    return {};
   }
 
   uint32_t Read() const override

--- a/library/L1_Peripheral/lpc40xx/dac.hpp
+++ b/library/L1_Peripheral/lpc40xx/dac.hpp
@@ -80,8 +80,11 @@ class Dac final : public sjsu::Dac
   {
     // The DAC output is a 10 bit input and thus it is necessary to
     // ensure dac_output is less than 1024 (largest 10-bit number)
-    SJ2_ASSERT_FATAL(dac_output < kMaximumValue,
-                     "DAC output set above 1023. Must be between 0-1023.");
+    if (dac_output >= kMaximumValue)
+    {
+      return Error(std::errc::invalid_argument,
+                   "DAC output set above 1023. Must be between 0-1023.");
+    }
     dac_register->CR =
         bit::Insert(dac_register->CR, dac_output, Control::kValue);
 
@@ -92,12 +95,7 @@ class Dac final : public sjsu::Dac
   {
     float value         = (voltage * kMaximumValue) / kVref;
     uint32_t conversion = static_cast<uint32_t>(value);
-    SJ2_ASSERT_FATAL(
-        voltage < kVref,
-        "DAC output was set above 3.3V. Must be between 0V and 3.3V.");
-    Write(conversion);
-
-    return {};
+    return Write(conversion);
   }
 
   /// Sets the Bias for the Dac, which determines the settling time, max

--- a/library/L1_Peripheral/lpc40xx/eeprom.hpp
+++ b/library/L1_Peripheral/lpc40xx/eeprom.hpp
@@ -159,9 +159,9 @@ class Eeprom final : public sjsu::Storage
       };
 
       auto timeout_status = Wait(kMaxTimeout, check_register);
-      if (!IsOk(timeout_status))
+      if (!timeout_status)
       {
-        return Error(Status::kTimedOut,
+        return Error(std::errc::timed_out,
                      "Could not write to EEPROM in time.");
       }
 

--- a/library/L1_Peripheral/lpc40xx/pin.hpp
+++ b/library/L1_Peripheral/lpc40xx/pin.hpp
@@ -105,7 +105,7 @@ class Pin final : public sjsu::Pin
     if (function > 0b111)
     {
       return Error(
-          Status::kInvalidParameters,
+          std::errc::invalid_argument,
           "The function code must be a 3-bit value between 0b000 and 0b111.");
     }
     SetPinRegister(function, kFunction);

--- a/library/L1_Peripheral/lpc40xx/spi.hpp
+++ b/library/L1_Peripheral/lpc40xx/spi.hpp
@@ -194,7 +194,7 @@ class Spi final : public sjsu::Spi
   /// Powers on the peripheral, activates the SSP pins and enables the SSP
   /// peripheral.
   /// See page 601 of user manual UM10562 LPC408x/407x for more details.
-  Status Initialize() const override
+  Returns<void> Initialize() const override
   {
     constexpr uint8_t kSpiFormatCode = 0b00;
 
@@ -218,7 +218,8 @@ class Spi final : public sjsu::Spi
     // Enable SSP
     bus_.registers->CR1 =
         bit::Set(bus_.registers->CR1, ControlRegister1::kSpiEnable);
-    return Status::kSuccess;
+
+    return {};
   }
 
   /// An easy way to sets up an SPI peripheral as SPI master with default clock
@@ -278,9 +279,9 @@ class Spi final : public sjsu::Spi
   /// @param read_miso_on_rising - capture serial data on true=first or
   ///        1=second clock cycle
   /// @param frequency - serial clock rate
-  void SetClock(units::frequency::hertz_t frequency,
-                bool positive_clock_on_idle = false,
-                bool read_miso_on_rising    = false) const override
+  Returns<void> SetClock(units::frequency::hertz_t frequency,
+                         bool positive_clock_on_idle = false,
+                         bool read_miso_on_rising    = false) const override
   {
     auto & system = sjsu::SystemController::GetPlatformController();
 
@@ -299,6 +300,7 @@ class Spi final : public sjsu::Spi
     // Store upper 8 bit half of the prescalar in control register 0
     bus_.registers->CR0 = bit::Insert(bus_.registers->CR0, prescaler >> 8,
                                       ControlRegister0::kDividerBit);
+    return {};
   }
 
  private:

--- a/library/L1_Peripheral/lpc40xx/test/pin_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/pin_test.cpp
@@ -48,10 +48,10 @@ TEST_CASE("Testing lpc40xx Pin")
     SECTION("Invalid function code")
     {
       // Exercise & Verify
-      CHECK(test_subject00.SetPinFunction(0b1000).error()->status ==
-            Status::kInvalidParameters);
-      CHECK(test_subject25.SetPinFunction(0b1111).error()->status ==
-            Status::kInvalidParameters);
+      CHECK(test_subject00.SetPinFunction(0b1000) ==
+            std::errc::invalid_argument);
+      CHECK(test_subject25.SetPinFunction(0b1111) ==
+            std::errc::invalid_argument);
     }
   }
 

--- a/library/L1_Peripheral/lpc40xx/test/timer_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/timer_test.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Testing lpc40xx Timer")
         kClockFrequency / kExpectedFrequency;
 
     // Exercise
-    const Status kStatus = timer.Initialize(kExpectedFrequency);
+    REQUIRE(timer.Initialize(kExpectedFrequency));
 
     // Verify
     Verify(Method(mock_system_controller, PowerUpPeripheral)
@@ -52,7 +52,6 @@ TEST_CASE("Testing lpc40xx Timer")
                  return kExpectedPeripheralId.device_id == id.device_id;
                }),
            Method(mock_interrupt_controller, Enable));
-    CHECK(kStatus == Status::kSuccess);
     CHECK(local_timer_registers.PR == kExpectedPrescaler);
   }
 
@@ -127,7 +126,7 @@ TEST_CASE("Testing lpc40xx Timer")
 
     // Exercise
     local_timer_registers.TC = expected_count;
-    uint32_t actual_count    = timer.GetCount();
+    uint32_t actual_count    = timer.GetCount().value();
 
     // Verify
     CHECK(actual_count == expected_count);

--- a/library/L1_Peripheral/lpc40xx/uart.hpp
+++ b/library/L1_Peripheral/lpc40xx/uart.hpp
@@ -297,7 +297,7 @@ class Uart final : public sjsu::Uart
   /// @param port - a reference to a constant lpc40xx::Uart::Port_t definition
   explicit constexpr Uart(const Port_t & port) : port_(port) {}
 
-  Status Initialize(uint32_t baud_rate) const override
+  Returns<void> Initialize(uint32_t baud_rate) const override
   {
     constexpr uint8_t kFIFOEnableAndReset = 0b111;
     sjsu::SystemController::GetPlatformController().PowerUpPeripheral(
@@ -311,10 +311,10 @@ class Uart final : public sjsu::Uart
     port_.tx.PullUp();
     port_.registers->FCR |= kFIFOEnableAndReset;
 
-    return Status::kSuccess;
+    return {};
   }
 
-  bool SetBaudRate(uint32_t baud_rate) const override
+  Returns<void> SetBaudRate(uint32_t baud_rate) const override
   {
     auto & system = sjsu::SystemController::GetPlatformController();
 
@@ -335,7 +335,8 @@ class Uart final : public sjsu::Uart
     port_.registers->DLL = dll;
     port_.registers->FDR = fdr;
     port_.registers->LCR = kStandardUart;
-    return true;
+
+    return {};
   }
 
   void Write(const void * data, size_t size) const override

--- a/library/L1_Peripheral/lpc40xx/watchdog.hpp
+++ b/library/L1_Peripheral/lpc40xx/watchdog.hpp
@@ -30,7 +30,7 @@ class Watchdog final : public sjsu::Watchdog
   {
   }
 
-  Status Initialize(std::chrono::seconds duration) const override
+  Returns<void> Initialize(std::chrono::seconds duration) const override
   {
     constexpr units::frequency::hertz_t kWatchdogClockDivider   = 4_Hz;
     constexpr units::frequency::hertz_t kWatchdogClockFrequency = 500_kHz;
@@ -52,10 +52,10 @@ class Watchdog final : public sjsu::Watchdog
     constexpr uint32_t kTimerWarningMax = 0b11'1111'1111;
     wdt_base->WARNINT                   = kTimerWarningMax;
 
-    return Status::kSuccess;
+    return {};
   }
 
-  void Enable() const override
+  Returns<void> Enable() const override
   {
     // Register WDT_IRQ defined by the structure
     sjsu::InterruptController::GetPlatformController().Enable({
@@ -63,6 +63,8 @@ class Watchdog final : public sjsu::Watchdog
         .interrupt_handler        = []() {},
         .priority                 = priority_,
     });
+
+    return {};
   }
 
   void FeedSequence() const override

--- a/library/L1_Peripheral/msp432p401r/gpio.hpp
+++ b/library/L1_Peripheral/msp432p401r/gpio.hpp
@@ -56,14 +56,14 @@ class Gpio final : public sjsu::Gpio
     return pin_;
   }
 
-  void AttachInterrupt(InterruptCallback, Edge) override
+  Returns<void> AttachInterrupt(InterruptCallback, Edge) override
   {
-    sjsu::LogInfo("Not Implemented");
+    return Error(std::errc::operation_not_supported, "");
   }
 
-  void DetachInterrupt() const override
+  Returns<void> DetachInterrupt() const override
   {
-    sjsu::LogInfo("Not Implemented");
+    return Error(std::errc::operation_not_supported, "");
   }
 
  private:

--- a/library/L1_Peripheral/msp432p401r/pin.hpp
+++ b/library/L1_Peripheral/msp432p401r/pin.hpp
@@ -49,11 +49,11 @@ class Pin final : public sjsu::Pin
     // NOTE: port can only be 1-10 or 'J'
     if (((port_ > 10) || (port_ == 0)) && (port_ != 'J'))
     {
-      return Error(Status::kInvalidSettings, "Port must be 1-10 or J");
+      return Error(std::errc::invalid_argument, "Port must be 1-10 or J");
     }
     if (pin_ > 7)
     {
-      return Error(Status::kInvalidSettings, "Pin must be between 0 and 7");
+      return Error(std::errc::invalid_argument, "Pin must be between 0 and 7");
     }
     return {};
   }
@@ -72,7 +72,7 @@ class Pin final : public sjsu::Pin
     if (function > 0b111)
     {
       return Error(
-          Status::kInvalidParameters,
+          std::errc::invalid_argument,
           "The function code must be a 3-bit value between 0b000 and 0b111.");
     }
 
@@ -121,7 +121,7 @@ class Pin final : public sjsu::Pin
         *resistor_select = bit::Set(*resistor_select, pin_);
         break;
       case Resistor::kRepeater:
-        return Error(Status::kInvalidSettings, "Invalid resistor pull.");
+        return Error(std::errc::not_supported, "Repeater mode not supported");
     }
     return {};
   }
@@ -145,7 +145,7 @@ class Pin final : public sjsu::Pin
 
   Returns<void> SetAsOpenDrain(bool) const override
   {
-    return Error(Status::kNotImplemented, "Open drain is not supported");
+    return Error(std::errc::operation_not_supported, "");
   }
 
   /// @note This function does nothing as setting the analog mode is not
@@ -153,7 +153,7 @@ class Pin final : public sjsu::Pin
   [[deprecated("Unsupported operation")]] Returns<void> SetAsAnalogMode(
       bool) const override
   {
-    return Error(Status::kNotImplemented, "Unsupported operation");
+    return Error(std::errc::operation_not_supported, "");
   }
 
  private:

--- a/library/L1_Peripheral/msp432p401r/system_controller.hpp
+++ b/library/L1_Peripheral/msp432p401r/system_controller.hpp
@@ -564,7 +564,7 @@ class SystemController final : public sjsu::SystemController
       case Clock::kLowSpeedSubsystemMaster: break;
       case Clock::kAuxiliary:
       {
-        SJ2_ASSERT_WARNING(
+        SJ2_ASSERT_FATAL(
             select_value <= Value(Oscillator::kReference),
             "The auxiliary clock can only be driven by kLowFrequency, "
             "kVeryLowFrequency, or kReference. The system will default to "

--- a/library/L1_Peripheral/msp432p401r/test/pin_test.cpp
+++ b/library/L1_Peripheral/msp432p401r/test/pin_test.cpp
@@ -128,8 +128,9 @@ TEST_CASE("Testing Msp432p401r Pin")
       Pin pin(invalid_port_number, 0);
 
       // Verify & Exercise
-      CHECK(pin.Initialize().error()->status == Status::kInvalidSettings);
+      CHECK(pin.Initialize() == std::errc::invalid_argument);
     }
+
     SECTION("Invalid pin")
     {
       // Setup
@@ -153,7 +154,7 @@ TEST_CASE("Testing Msp432p401r Pin")
       Pin pin(1, invalid_pin_number);
 
       // Verify & Exercise
-      CHECK(pin.Initialize().error()->status == Status::kInvalidSettings);
+      CHECK(pin.Initialize() == std::errc::invalid_argument);
     }
   }
 
@@ -227,8 +228,8 @@ TEST_CASE("Testing Msp432p401r Pin")
       }
 
       // Exercise & Verify
-      CHECK(test_pins[0].pin.SetPinFunction(function_code).error()->status ==
-            Status::kInvalidParameters);
+      CHECK(test_pins[0].pin.SetPinFunction(function_code) ==
+            std::errc::invalid_argument);
     }
   }
 
@@ -259,8 +260,7 @@ TEST_CASE("Testing Msp432p401r Pin")
       bool actual_out;
 
       // Exercise & Verify - Setting pull as repeater
-      CHECK(pin.SetPull(Pin::Resistor::kRepeater).error()->status ==
-            Status::kInvalidSettings);
+      CHECK(pin.SetPull(Pin::Resistor::kRepeater) == std::errc::not_supported);
 
       // Exercise - Setting pull up resistor
       pin.SetPull(Pin::Resistor::kPullUp);
@@ -337,7 +337,7 @@ TEST_CASE("Testing Msp432p401r Pin")
       INFO("pin: " << static_cast<size_t>(kPinNumber));
 
       // Exercise and Verify
-      CHECK(pin.SetAsOpenDrain({}).error()->status == Status::kNotImplemented);
+      CHECK(pin.SetAsOpenDrain({}) == std::errc::operation_not_supported);
     }
   }
 

--- a/library/L1_Peripheral/pin.hpp
+++ b/library/L1_Peripheral/pin.hpp
@@ -99,30 +99,30 @@ class Pin
   /// code usage.
   ///
   /// @param function pin function code
-  /// @returns Status::kInvalidParameter only if the function code is invalid.
+  /// @return std::errc::invalid_argument the function code is not valid.
   virtual Returns<void> SetPinFunction(uint8_t function) const = 0;
 
   /// Set pin's resistor pull, setting ot either no resistor pull, pull down,
   /// pull up and repeater.
   ///
   /// @param resistor - which resistor setup you would like.
-  /// @returns An Error only if the resistor setting is not
-  ///          supported.
+  /// @return should return std::errc::not_supported if the pull option is not
+  ///         supported by the MCU.
   virtual Returns<void> SetPull(Resistor resistor) const = 0;
 
   /// Set pin to open drain mode
   ///
   /// @param set_as_open_drain If false, disable open drain feature, pin
   ///        becomes push-pull (a.k.a totem pole).
-  /// @returns Status::kNotImplemented only if open drain configuration is not
-  ///          supported by the MCU.
+  /// @return should return std::errc::not_supported if open drain is not
+  ///         supported by the MCU.
   virtual Returns<void> SetAsOpenDrain(bool set_as_open_drain = true) const = 0;
 
   /// Set pin as analog mode
   ///
   /// @param set_as_analog If false, disable analog mode for pin
-  /// @returns Status::kNotImplemented only if analog mode configuration is not
-  ///          supported by the MCU.
+  /// @return should return std::errc::not_supported if analog mode is not
+  ///         supported by the MCU.
   virtual Returns<void> SetAsAnalogMode(bool set_as_analog = true) const = 0;
 
   // ===========================================================================
@@ -130,21 +130,21 @@ class Pin
   // ===========================================================================
 
   /// Attach internal pull up resistor to pin
-  void PullUp() const
+  Returns<void> PullUp() const
   {
-    SetPull(Resistor::kPullUp);
+    return SetPull(Resistor::kPullUp);
   }
 
   /// Attach internal pull down resistor to pin
-  void PullDown() const
+  Returns<void> PullDown() const
   {
-    SetPull(Resistor::kPullDown);
+    return SetPull(Resistor::kPullDown);
   }
 
   /// Detach internal pull resistor from pin and allow the pin to float
-  void SetFloating() const
+  Returns<void> SetFloating() const
   {
-    SetPull(Resistor::kNone);
+    return SetPull(Resistor::kNone);
   }
 
   /// Getter method for the pin's port.

--- a/library/L1_Peripheral/pulse_capture.hpp
+++ b/library/L1_Peripheral/pulse_capture.hpp
@@ -35,8 +35,8 @@ class PulseCapture
   };
 
   /// Initialize timer for capturing
-  virtual Status Initialize(CaptureCallback isr        = nullptr,
-                            int32_t interrupt_priority = -1) const = 0;
+  virtual Returns<void> Initialize(CaptureCallback isr        = nullptr,
+                                   int32_t interrupt_priority = -1) const = 0;
 
   /// Select edge type to capture on
   virtual void ConfigureCapture(CaptureEdgeMode mode) const = 0;

--- a/library/L1_Peripheral/pwm.hpp
+++ b/library/L1_Peripheral/pwm.hpp
@@ -21,19 +21,25 @@ class Pwm
   /// method in this interface is called.
   ///
   /// @param frequency - starting frequency of PWM waveform
-  virtual Status Initialize(units::frequency::hertz_t frequency) const = 0;
+  virtual Returns<void> Initialize(
+      units::frequency::hertz_t frequency) const = 0;
+
   /// Set output pulse width to following duty cycle.
   ///
   /// @param duty_cycle - duty cycle precent from 0 to 1. Where 0.5 would be a
   ///        50% duty cycle meaning that the pulse will be on for 50% of the
-  ///        time and off for the other 50%.
-  virtual void SetDutyCycle(float duty_cycle) const = 0;
+  ///        time and off for the other 50%. Values above or below 0 and 1 will
+  ///        simply be clamped.
+  virtual Returns<void> SetDutyCycle(float duty_cycle) const = 0;
+
   /// @return current duty cycle from hardware
-  virtual float GetDutyCycle() const = 0;
+  virtual Returns<float> GetDutyCycle() const = 0;
+
   /// Set PWM waveform frequency
   ///
   /// @param frequency - frequency to set the PWM waveform. Cannot be set
   ///        higher than the peripheral frequency of the board.
-  virtual void SetFrequency(units::frequency::hertz_t frequency) const = 0;
+  virtual Returns<void> SetFrequency(
+      units::frequency::hertz_t frequency) const = 0;
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/spi.hpp
+++ b/library/L1_Peripheral/spi.hpp
@@ -42,7 +42,7 @@ class Spi
 
   /// Initialize and enable hardware. This must be called before any other
   /// method in this interface is called.
-  virtual Status Initialize() const = 0;
+  virtual Returns<void> Initialize() const = 0;
 
   /// Send a value via SPI and receive a value back from the serial port
   ///
@@ -63,9 +63,9 @@ class Spi
   ///        nothing is being transmitted.
   /// @param read_miso_on_rising - if true, device will read the the MISO line
   ///        on rising edge of the clock line.
-  virtual void SetClock(units::frequency::hertz_t frequency,
-                        bool positive_clock_on_idle = false,
-                        bool read_miso_on_rising    = false) const = 0;
+  virtual Returns<void> SetClock(units::frequency::hertz_t frequency,
+                                 bool positive_clock_on_idle = false,
+                                 bool read_miso_on_rising    = false) const = 0;
 
   /// Transfer a std::array of data
   ///

--- a/library/L1_Peripheral/stm32f10x/gpio.hpp
+++ b/library/L1_Peripheral/stm32f10x/gpio.hpp
@@ -96,7 +96,7 @@ class Gpio : public sjsu::Gpio
     external_interrupt->PR = (1 << pin);
   }
 
-  void AttachInterrupt(InterruptCallback callback, Edge edge) override
+  Returns<void> AttachInterrupt(InterruptCallback callback, Edge edge) override
   {
     // Clear both falling and raising edges bits
     // They will be assigned in the conditionals below
@@ -194,11 +194,16 @@ class Gpio : public sjsu::Gpio
             .interrupt_handler        = InterruptHandler,
         });
         break;
-      default: SJ2_ASSERT_FATAL(false, "Invalid pin for detected!"); return;
+      default:
+      {
+        return Error(std::errc::invalid_argument, "Pin must be between 0-15");
+      }
     }
+
+    return {};
   }
 
-  void DetachInterrupt() const override
+  Returns<void> DetachInterrupt() const override
   {
     // No need to Enable/Disable the interrupt via the interrupt controller,
     // especially since you would need logic to determine if this is the last
@@ -210,6 +215,7 @@ class Gpio : public sjsu::Gpio
         bit::Clear(external_interrupt->RTSR, pin_.GetPin());
     external_interrupt->FTSR =
         bit::Clear(external_interrupt->FTSR, pin_.GetPin());
+    return {};
   }
 
  private:

--- a/library/L1_Peripheral/stm32f10x/test/pin_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/pin_test.cpp
@@ -235,8 +235,8 @@ TEST_CASE("Testing stm32f10x Pin")
       for (size_t i = 0; i < test.size(); i++)
       {
         // Exercise & Verify
-        CHECK(test[i].pin.SetPinFunction(0b10).error()->status ==
-              Status::kInvalidParameters);
+        CHECK(test[i].pin.SetPinFunction(0b10) ==
+              std::errc::invalid_argument);
       }
     }
   }
@@ -305,8 +305,8 @@ TEST_CASE("Testing stm32f10x Pin")
 
       {
         // Exercise & Verify
-        CHECK(test[i].pin.SetPull(Pin::Resistor::kRepeater).error()->status ==
-              Status::kInvalidSettings);
+        CHECK(test[i].pin.SetPull(Pin::Resistor::kRepeater) ==
+              std::errc::not_supported);
       }
     }
   }

--- a/library/L1_Peripheral/stm32f10x/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/system_controller_test.cpp
@@ -50,9 +50,9 @@ TEST_CASE("Testing stm32f10x SystemController")
   SystemController test_subject(config);
 
   auto system_clock_becomes_ready = [&local_rcc, &config]() {
-    // Delay by 10ms to give enough time for other simulated triggers to
+    // Delay by 5ms to give enough time for other simulated triggers to
     // operate before this cancels.
-    std::this_thread::sleep_for(10ms);
+    std::this_thread::sleep_for(20ms);
     local_rcc.CFGR = bit::Insert(
         local_rcc.CFGR, Value(config.system_clock),
         SystemController::ClockConfigurationRegisters::kSystemClockStatus);
@@ -65,7 +65,7 @@ TEST_CASE("Testing stm32f10x SystemController")
   };
 
   auto high_oscillator_ready = [&local_rcc]() {
-    std::this_thread::sleep_for(1ms);
+    std::this_thread::sleep_for(10ms);
 
     local_rcc.CR =
         bit::Set(local_rcc.CR,
@@ -73,7 +73,7 @@ TEST_CASE("Testing stm32f10x SystemController")
   };
 
   auto low_oscillator_ready = [&local_rcc]() {
-    std::this_thread::sleep_for(1ms);
+    std::this_thread::sleep_for(10ms);
 
     local_rcc.BDCR = bit::Set(
         local_rcc.BDCR, SystemController::RtcRegisters::kLowSpeedOscReady);

--- a/library/L1_Peripheral/stm32f4xx/gpio.hpp
+++ b/library/L1_Peripheral/stm32f4xx/gpio.hpp
@@ -73,14 +73,14 @@ class Gpio : public sjsu::Gpio
     return pin_;
   }
 
-  void AttachInterrupt(InterruptCallback, Edge) override
+  Returns<void> AttachInterrupt(InterruptCallback, Edge) override
   {
-    sjsu::LogInfo("Not Implemented");
+    return Error(std::errc::operation_not_supported, "");
   }
 
-  void DetachInterrupt() const override
+  Returns<void> DetachInterrupt() const override
   {
-    sjsu::LogInfo("Not Implemented");
+    return Error(std::errc::operation_not_supported, "");
   }
 
  private:

--- a/library/L1_Peripheral/stm32f4xx/test/pin_test.cpp
+++ b/library/L1_Peripheral/stm32f4xx/test/pin_test.cpp
@@ -182,8 +182,6 @@ TEST_CASE("Testing stm32f4xx Pin")
       // Setup
       uint8_t port;
 
-      Status expected_status;
-
       SUBCASE("Port 0")
       {
         port = 'J';
@@ -202,8 +200,7 @@ TEST_CASE("Testing stm32f4xx Pin")
       stm32f4xx::Pin invalid_pin(port, 0);
 
       // Exercise & Verify
-      CHECK(invalid_pin.Initialize().error()->status ==
-            Status::kInvalidSettings);
+      CHECK(invalid_pin.Initialize() == std::errc::invalid_argument);
     }
   }
 
@@ -230,7 +227,7 @@ TEST_CASE("Testing stm32f4xx Pin")
         test[i].pin.Initialize();
 
         // Exercise
-        test[i].pin.SetPinFunction(kExpectedFunction[i]);
+        REQUIRE(test[i].pin.SetPinFunction(kExpectedFunction[i]));
 
         // Verify
         CHECK(bit::Extract(test[i].gpio.MODER, Mask2Bit(test[i].pin)) ==
@@ -254,8 +251,8 @@ TEST_CASE("Testing stm32f4xx Pin")
         test[i].pin.Initialize();
 
         // Exercise & Verify
-        CHECK(test[i].pin.SetPinFunction(invalid_function).error()->status ==
-              Status::kInvalidParameters);
+        CHECK(test[i].pin.SetPinFunction(invalid_function) ==
+              std::errc::invalid_argument);
       }
     }
   }
@@ -303,8 +300,8 @@ TEST_CASE("Testing stm32f4xx Pin")
 
       {
         // Exercise & Verify
-        CHECK(test[i].pin.SetPull(Pin::Resistor::kRepeater).error()->status ==
-              Status::kInvalidSettings);
+        CHECK(test[i].pin.SetPull(Pin::Resistor::kRepeater) ==
+              std::errc::not_supported);
       }
     }
   }

--- a/library/L1_Peripheral/system_timer.hpp
+++ b/library/L1_Peripheral/system_timer.hpp
@@ -18,15 +18,17 @@ namespace sjsu
 class SystemTimer
 {
  public:
-  // ==============================
+  // ===========================================================================
   // Interface Methods
-  // ==============================
+  // ===========================================================================
   /// Initialize system timer hardware.
   virtual void Initialize() const = 0;
+
   /// Set the function to be called when the System Timer interrupt fires.
   ///
   /// @param callback - function to be called on system timer event.
   virtual void SetCallback(InterruptCallback callback) const = 0;
+
   /// Set frequency of the timer.
   ///
   /// @param frequency - How many times per second should the system timer
@@ -35,11 +37,9 @@ class SystemTimer
   ///         input frequency.
   virtual int32_t SetTickFrequency(
       units::frequency::hertz_t frequency) const = 0;
+
   /// Start the system timer. Should be done after SetInterrupt and
   /// SetTickFrequency have been called.
-  ///
-  /// @return Status::kSuccess if the system timer started correctly. Otherwise,
-  ///         the exact status is implementation dependent.
-  virtual Status StartTimer() const = 0;
+  virtual Returns<void> StartTimer() const = 0;
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/test/frequency_counter_test.cpp
+++ b/library/L1_Peripheral/test/frequency_counter_test.cpp
@@ -74,7 +74,6 @@ TEST_CASE("Testing FrequencyCounter")
       // Verify: (800 ticks / 4us) => 200MHz
       CHECK(new_actual_frequency == 200_MHz);
     }
-
     Verify(Method(mock_counter, Enable)).Once();
   }
 }

--- a/library/L1_Peripheral/test/hardware_counter_test.cpp
+++ b/library/L1_Peripheral/test/hardware_counter_test.cpp
@@ -10,8 +10,10 @@ namespace
 {
 auto GetLambda(sjsu::InterruptCallback & isr)
 {
-  return [&isr](sjsu::InterruptCallback callback, sjsu::Gpio::Edge) {
+  return [&isr](sjsu::InterruptCallback callback,
+                sjsu::Gpio::Edge) -> Returns<void> {
     isr = callback;
+    return {};
   };
 }
 }  // namespace
@@ -39,16 +41,15 @@ TEST_CASE("Testing L1 GpioCounter")
       test_subject.Initialize();
 
       // Verify
-      Verify(Method(mock_gpio, SetDirection)
-                 .Using(sjsu::Gpio::Direction::kInput));
+      Verify(
+          Method(mock_gpio, SetDirection).Using(sjsu::Gpio::Direction::kInput));
       Verify(Method(mock_pin, SetPull).Using(sjsu::Pin::Resistor::kPullUp));
     }
 
     SECTION("Use passed pull resistor settings")
     {
       // Setup
-      GpioCounter test_subject(mock_gpio.get(),
-                               sjsu::Gpio::Edge::kBoth,
+      GpioCounter test_subject(mock_gpio.get(), sjsu::Gpio::Edge::kBoth,
                                sjsu::Pin::Resistor::kPullDown);
 
       // Exercise

--- a/library/L1_Peripheral/test/uart_test.cpp
+++ b/library/L1_Peripheral/test/uart_test.cpp
@@ -115,9 +115,8 @@ TEST_CASE("Testing L1 uart")
     When(ConstOverloadedMethod(mock_uart, Read, size_t(void *, size_t)))
         .AlwaysDo([&read_was_called](void * data_ptr, size_t size) -> size_t {
           uint8_t * data = reinterpret_cast<uint8_t *>(data_ptr);
-          std::array<uint8_t, kPayloadLength> response = {
-            0xAA, 0xBB, 0xCC, 0xDD
-          };
+          std::array<uint8_t, kPayloadLength> response = { 0xAA, 0xBB, 0xCC,
+                                                           0xDD };
           for (size_t i = 0; i < size; i++)
           {
             data[i] = response[read_was_called++];
@@ -126,11 +125,10 @@ TEST_CASE("Testing L1 uart")
         });
 
     // Exercise
-    Status status = uart.Read(bytes.data(), bytes.size(), 10us);
+    REQUIRE(uart.Read(bytes.data(), bytes.size(), 10us));
 
     // Verify
     CHECK(kPayloadLength == read_was_called);
-    CHECK(Status::kSuccess == status);
     Verify(Method(mock_uart, HasData)).Exactly(7);
     Verify(ConstOverloadedMethod(mock_uart, Read, size_t(void *, size_t)))
         .Exactly(kPayloadLength);
@@ -157,9 +155,8 @@ TEST_CASE("Testing L1 uart")
     When(ConstOverloadedMethod(mock_uart, Read, size_t(void *, size_t)))
         .AlwaysDo([&read_was_called](void * data_ptr, size_t size) -> size_t {
           uint8_t * data = reinterpret_cast<uint8_t *>(data_ptr);
-          std::array<uint8_t, kPayloadLength> response = {
-            0xAA, 0xBB, 0xCC, 0xDD
-          };
+          std::array<uint8_t, kPayloadLength> response = { 0xAA, 0xBB, 0xCC,
+                                                           0xDD };
           for (size_t i = 0; i < size; i++)
           {
             data[i] = response[read_was_called++];
@@ -168,11 +165,11 @@ TEST_CASE("Testing L1 uart")
         });
 
     // Exercise
-    Status status = uart.Read(bytes.data(), bytes.size(), 10us);
+    auto status = uart.Read(bytes.data(), bytes.size(), 10us);
 
     // Verify
     CHECK(kPayloadLength - 1 == read_was_called);
-    CHECK(Status::kTimedOut == status);
+    CHECK(std::errc::timed_out == status);
     Verify(Method(mock_uart, HasData)).Exactly(8);
     Verify(ConstOverloadedMethod(mock_uart, Read, size_t(void *, size_t)))
         .Exactly(kPayloadLength - 1);

--- a/library/L1_Peripheral/timer.hpp
+++ b/library/L1_Peripheral/timer.hpp
@@ -48,9 +48,9 @@ class Timer
   ///        SetTimer method has occurred.
   /// @param priority - sets the Timer interrupt's priority level, defaults to
   ///        -1 which uses the platforms default priority.
-  virtual Status Initialize(units::frequency::hertz_t counter_frequency,
-                            InterruptCallback callback = nullptr,
-                            int32_t priority           = -1) const = 0;
+  virtual Returns<void> Initialize(units::frequency::hertz_t counter_frequency,
+                                   InterruptCallback callback = nullptr,
+                                   int32_t priority           = -1) const = 0;
 
   /// Set a timer to execute your timer command when the time counter equals the
   /// match register. time in ticks dependent on initialization Functionality is
@@ -62,23 +62,23 @@ class Timer
   ///        register.
   /// @param match_register - which match register should be used
   ///        for holding the count for the action.
-  virtual void SetMatchBehavior(uint32_t match_count,
-                                MatchAction action,
-                                uint8_t match_register) const = 0;
+  virtual Returns<void> SetMatchBehavior(uint32_t match_count,
+                                         MatchAction action,
+                                         uint8_t match_register) const = 0;
 
   /// @return number of available match registers
   virtual uint8_t GetAvailableMatchRegisters() const = 0;
 
   /// Get the current count in the count register
-  virtual uint32_t GetCount() const = 0;
+  virtual Returns<uint32_t> GetCount() const = 0;
 
   /// Starts the timer.
-  virtual void Start() const = 0;
+  virtual Returns<void> Start() const = 0;
 
   /// Stops the timer.
-  virtual void Stop() const = 0;
+  virtual Returns<void> Stop() const = 0;
 
   /// Resets the timer.
-  virtual void Reset() const = 0;
+  virtual Returns<void> Reset() const = 0;
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/uart.hpp
+++ b/library/L1_Peripheral/uart.hpp
@@ -23,14 +23,12 @@ class Uart
   /// method in this interface is called.
   ///
   /// @param baud_rate - set the communication speed
-  virtual Status Initialize(uint32_t baud_rate) const = 0;
+  virtual Returns<void> Initialize(uint32_t baud_rate) const = 0;
 
   /// Set UART baud rate
   ///
   /// @param baud_rate the speed of the UART transmit and receive.
-  /// @return true - if baud rate was able to be set correctly.
-  /// @return false - if baud rate is not possible to be set.
-  virtual bool SetBaudRate(uint32_t baud_rate) const = 0;
+  virtual Returns<void> SetBaudRate(uint32_t baud_rate) const = 0;
 
   /// Sends bytes via UART port via the TX line
   ///
@@ -62,6 +60,7 @@ class Uart
   {
     PollingFlush();
   }
+
   // ===========================================================================
   // Utility Methods
   // ===========================================================================
@@ -115,10 +114,9 @@ class Uart
   /// @param data - buffer to read bytes into.
   /// @param size - number of bytes to read before timeout.
   /// @param timeout - duration to wait for incoming data before timeout.
-  /// @return sjsu::Status::kSuccess if bytes were read before timeout.
-  /// @return sjsu::Status::kTimeout if bytes could not be read before before
+  /// @return std::errc::timed_out if bytes could not be read before before
   ///         timeout.
-  sjsu::Status Read(void * data,
+  Returns<void> Read(void * data,
                     size_t size,
                     std::chrono::nanoseconds timeout) const
   {

--- a/library/L1_Peripheral/watchdog.hpp
+++ b/library/L1_Peripheral/watchdog.hpp
@@ -22,11 +22,11 @@ class Watchdog
   /// @param interval - feeding interval. Not feeding the watch dog in this
   ///        time will result in the system restarting.
   /// @return status indicating the failure type for the watchdog.
-  virtual Status Initialize(std::chrono::seconds interval) const = 0;
+  virtual Returns<void> Initialize(std::chrono::seconds interval) const = 0;
 
   /// Enables the watchdog. After this point, the watch dog must be feed before
   /// the interval duration is exceeded, otherwise the system will restart.
-  virtual void Enable() const = 0;
+  virtual Returns<void> Enable() const = 0;
 
   /// Feeds the watchdog and restarts the sequence.
   virtual void FeedSequence() const = 0;

--- a/library/L2_HAL/audio/buzzer.hpp
+++ b/library/L2_HAL/audio/buzzer.hpp
@@ -21,37 +21,43 @@ class Buzzer
 {
  public:
   /// Initialize Buzzer with a pwm signal.
-  explicit constexpr Buzzer(sjsu::Pwm & pwm)
-      : pwm_(pwm)
-  {
-  }
+  explicit constexpr Buzzer(sjsu::Pwm & pwm) : pwm_(pwm) {}
+
   /// Initialize Buzzer hardware.
-  void Initialize()
+  Returns<void> Initialize()
   {
-    pwm_.Initialize(500_Hz);
-    Stop();
+    SJ2_RETURN_ON_ERROR(pwm_.Initialize(500_Hz));
+    SJ2_RETURN_ON_ERROR(Stop());
+    return {};
   }
+
   /// Turn off buzzer.
-  void Stop()
+  Returns<void> Stop()
   {
-    pwm_.SetDutyCycle(0.0f);
+    return pwm_.SetDutyCycle(0.0f);
   }
+
   /// Turn on buzzer at a specific frequency and volume.
   ///
   /// @param frequency - The frequency to set the buzzer to.
   /// @param volume - percent output power from 0.0f to 1.0f.
-  void Beep(units::frequency::hertz_t frequency = 500_Hz, float volume = 1.0f)
+  Returns<void> Beep(units::frequency::hertz_t frequency = 500_Hz,
+                     float volume                        = 1.0f)
   {
-    pwm_.SetFrequency(frequency);
+    SJ2_RETURN_ON_ERROR(pwm_.SetFrequency(frequency));
     // NOTE: Since the PWM is at its loudest at 50% duty cycle, the maximum PWM
     // is divided by 2.
-    pwm_.SetDutyCycle(volume / 2);
+    SJ2_RETURN_ON_ERROR(pwm_.SetDutyCycle(volume / 2));
+
+    return {};
   }
+
   /// @return gets the current running volume of the device.
-  float GetVolume()
+  Returns<float> GetVolume()
   {
-    return pwm_.GetDutyCycle() * 2;
+    return 2 * SJ2_RETURN_ON_ERROR(pwm_.GetDutyCycle());
   }
+
  private:
   Pwm & pwm_;
 };

--- a/library/L2_HAL/communication/infrared_receiver.hpp
+++ b/library/L2_HAL/communication/infrared_receiver.hpp
@@ -16,9 +16,11 @@ class InfraredReceiver
   /// successfully received.
   using DataReceivedHandler =
       std::function<void(const infrared::DataFrame_t *)>;
+
   /// Initialize and enable hardware. This must be called before any other
   /// method in this interface is called.
-  virtual Status Initialize() = 0;
+  virtual Returns<void> Initialize() = 0;
+
   /// Sets the callback handler that is invoked when a data frame is received.
   ///
   /// @param handler Callback handler to invoke.

--- a/library/L2_HAL/communication/internet_socket.hpp
+++ b/library/L2_HAL/communication/internet_socket.hpp
@@ -33,14 +33,10 @@ class InternetSocket
   /// @param address - URL of the device you want to connect to.
   /// @param port - The port you want to use to connect to the host.
   /// @param timeout - Amount of time before this function should gives up.
-  /// @return Status::kTimeout if this function runs out of time based on
-  ///         timeout.
-  /// @return Status::kSuccess if this function is successful.
-  /// @return Can potentially return any other status.
-  virtual Status Connect(Protocol protocol,
-                         std::string_view address,
-                         uint16_t port,
-                         std::chrono::nanoseconds timeout) = 0;
+  virtual Returns<void> Connect(Protocol protocol,
+                                std::string_view address,
+                                uint16_t port,
+                                std::chrono::nanoseconds timeout) = 0;
 
   /// Send data to the connected host. Must have used Connect() before using
   /// this.
@@ -48,13 +44,9 @@ class InternetSocket
   /// @param data - data to write to socket
   /// @param size - the number of bytes to write.
   /// @param timeout - Amount of time before this function should gives up.
-  /// @return Status::kTimeout if this function runs out of time based on
-  ///         timeout.
-  /// @return Status::kSuccess if this function is successful.
-  /// @return Can potentially return any other status.
-  virtual Status Write(const void * data,
-                       size_t size,
-                       std::chrono::nanoseconds timeout) = 0;
+  virtual Returns<void> Write(const void * data,
+                              size_t size,
+                              std::chrono::nanoseconds timeout) = 0;
 
   /// Read data received from the connected host. Must have used Connect()
   /// before using this.
@@ -62,22 +54,12 @@ class InternetSocket
   /// @param buffer - location to read information from
   /// @param size - the number of bytes to write.
   /// @param timeout - Amount of time before this function should gives up.
-  /// @return Status::kTimeout if this function runs out of time based on
-  ///         timeout.
-  /// @return Status::kSuccess if this function is successful.
-  /// @return Can potentially return any other status.
-  virtual size_t Read(void * buffer,
-                      size_t size,
-                      std::chrono::nanoseconds timeout) = 0;
+  virtual Returns<size_t> Read(void * buffer,
+                               size_t size,
+                               std::chrono::nanoseconds timeout) = 0;
 
   /// Closes the connection established by the Connect() method.
-  ///
-  /// @return Status::kTimeout if this function runs out of time based on
-  ///         timeout.
-  /// @return Status::kSuccess if this function is successful.
-  /// @return Status::kNotReadyYet if this was called before Connect was used.
-  /// @return Can potentially return any other status.
-  virtual Status Close() = 0;
+  virtual Returns<void> Close() = 0;
 };
 
 /// An interface for devices that can communicate wirelessly via the Wifi
@@ -91,9 +73,6 @@ class WiFi
   /// gateway, and mac address.
   struct NetworkConnection_t
   {
-    /// If `status` is Status::kSuccess then the fields below are correct.
-    /// Otherwise, this status holds what went wrong.
-    Status status = Status::kNotImplemented;
     /// IPv4 IP address
     std::array<uint8_t, 4> ip;
     /// IPv4 IP address netmask
@@ -105,7 +84,6 @@ class WiFi
   };
 
   /// The type of password security used for the access point.
-  /// NOTE: Used within the ESP8266 code but not in the interface
   enum class AccessPointSecurity
   {
     kOpen       = 0,
@@ -116,7 +94,6 @@ class WiFi
   };
 
   /// The type of mode to put the device into.
-  /// NOTE: Used within the ESP8266 code but not in the interface
   enum class WifiMode
   {
     kClient = 1,
@@ -126,8 +103,7 @@ class WiFi
 
   /// Initialize the WiFi hardware and necessary peripherals needed to
   /// communicate with it.
-  /// @return Any status.
-  virtual Status Initialize() = 0;
+  virtual Returns<void> Initialize() = 0;
 
   /// @return true - if this Wifi instance is connected to an access point
   /// @return false - it this Wifi instance is not connected to an access point
@@ -138,22 +114,20 @@ class WiFi
   /// @param ssid - SSID of the access point you would like to connect to.
   /// @param password - the password to the access point.
   /// @param timeout - Amount of time before this function should gives up.
-  /// @return Status - Status::kSuccess if it is successful
-  /// @return Status - Status::kTimeout if it is not successful
-  virtual Status ConnectToAccessPoint(std::string_view ssid,
-                                      std::string_view password,
-                                      std::chrono::nanoseconds timeout) = 0;
+  virtual Returns<void> ConnectToAccessPoint(
+      std::string_view ssid,
+      std::string_view password,
+      std::chrono::nanoseconds timeout) = 0;
 
   /// Disconnect from the access point.
-  /// @return Status
-  virtual Status DisconnectFromAccessPoint() = 0;
+  virtual Returns<void> DisconnectFromAccessPoint() = 0;
 
   /// @return NetworkConnection_t - Get connection information such as IP
   ///         address.
-  virtual NetworkConnection_t GetNetworkConnectionInfo() = 0;
+  virtual Returns<NetworkConnection_t> GetNetworkConnectionInfo() = 0;
 
-  /// @return InternetSocket& that can be used to connect and communicate over
-  ///         TCP or UDP.
+  /// @return Reference to InternetSocket& that can be used to connect and
+  ///         communicate over TCP or UDP.
   virtual InternetSocket & GetInternetSocket() = 0;
 };
 

--- a/library/L2_HAL/displays/pixel_display.hpp
+++ b/library/L2_HAL/displays/pixel_display.hpp
@@ -3,6 +3,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "utility/status.hpp"
+
 namespace sjsu
 {
 /// PixelDisplay is a common set of methods that all hardware display drivers
@@ -14,11 +16,11 @@ class PixelDisplay
   struct Color_t
   {
     /// Bits of the red channel
-    uint8_t red   = 0;
+    uint8_t red = 0;
     /// Bits of the green channel
     uint8_t green = 0;
     /// Bits of the blue channel
-    uint8_t blue  = 0;
+    uint8_t blue = 0;
     /// Bits of alpha (transparent) channel
     uint8_t alpha = 0;
     /// @returns true if the Color_t definitions is
@@ -36,31 +38,40 @@ class PixelDisplay
       return red == 0 && green == 0 && blue == 0 && alpha == 0;
     }
   };
+
   /// Returns the number of pixels wide the display is.
-  virtual size_t GetWidth()  = 0;
+  virtual size_t GetWidth() = 0;
+
   /// Returns the number of pixels high the display is.
   virtual size_t GetHeight() = 0;
+
   /// @returns a color object with the available colors.
   virtual Color_t AvailableColors() = 0;
+
   /// Configure hardware peripherals and initialize external display hardware
   virtual void Initialize() = 0;
+
   /// Optional method to turn on display if applicable
   virtual void Enable() {}
+
   /// Optional method to turn off display and potentially put it into a low
   /// power mode
   virtual void Disable() {}
-  /// Clear the screen of the display
+
+  /// Clear framebuffer
   virtual void Clear() = 0;
+
   /// Draw the specified pixel.
-  /// Implementations of this method should not be expected to the draw the
-  /// pixel on the display, immediately after this method has finished.
-  /// A class implementing this interface should write/manipulate a framebuffer
-  /// and update the screen after a call to the Update() method.
+  /// Implementations of this method should not draw directly to the display but
+  /// should manipulate A class implementing this interface should
+  /// write/manipulate a framebuffer and update the screen after a call to the
+  /// Update() method.
   ///
   /// @param x x coordinate position to draw the pixel
   /// @param y y coordinate position to draw the pixel
   /// @param color the color of the pixel. May be ignored on monochrome screens.
   virtual void DrawPixel(int32_t x, int32_t y, Color_t color) = 0;
+
   /// Update screen to match framebuffer.
   /// Implementations of this method that do not use a framebuffer, possibly
   /// due to memory constrains, can refrain from implementing this function.

--- a/library/L2_HAL/memory/test/sd_test.cpp
+++ b/library/L2_HAL/memory/test/sd_test.cpp
@@ -106,7 +106,7 @@ TEST_CASE("Testing SD Card Driver Class")
 
   SECTION("Disable()")
   {
-    CHECK(Status::kNotImplemented == sd.Disable().error()->status);
+    CHECK(std::errc::operation_not_supported == sd.Disable());
   }
 
   SECTION("GetBlockSize()")

--- a/library/L2_HAL/memory_access_protocol.hpp
+++ b/library/L2_HAL/memory_access_protocol.hpp
@@ -309,8 +309,6 @@ class MockProtocol<MemoryAccessProtocol::AddressWidth::kByte1>
     : public MemoryAccessProtocol
 {
  public:
-  MockProtocol() {}
-
   std::array<uint8_t, (1 << 8)> memory_map;
 
   Returns<void> Write(std::span<const uint8_t> address,
@@ -318,7 +316,7 @@ class MockProtocol<MemoryAccessProtocol::AddressWidth::kByte1>
   {
     if (error_active_)
     {
-      return DefinedError(error_);
+      return error_;
     }
 
     // Only use the first byte of the address
@@ -332,7 +330,7 @@ class MockProtocol<MemoryAccessProtocol::AddressWidth::kByte1>
   {
     if (error_active_)
     {
-      return DefinedError(error_);
+      return error_;
     }
 
     // Only use the first byte of the address
@@ -341,7 +339,7 @@ class MockProtocol<MemoryAccessProtocol::AddressWidth::kByte1>
     return {};
   }
 
-  void SetError(Error_t error)
+  void SetError(Returns<void> error)
   {
     error_        = error;
     error_active_ = true;
@@ -352,8 +350,8 @@ class MockProtocol<MemoryAccessProtocol::AddressWidth::kByte1>
     error_active_ = false;
   }
 
-  Error_t error_;
-  bool error_active_ = false;
+  Returns<void> error_ = {};
+  bool error_active_   = false;
 };
 
 // TODO(#1329) Not supported yet.
@@ -383,7 +381,7 @@ class I2cProtocol : public MemoryAccessProtocol
 
     if (address.size() + value.size() >= kBufferSize)
     {
-      return Error(Status::kOutOfBounds,
+      return Error(std::errc::not_enough_memory,
                    "I2cProtocol Object does not have enough buffer storage to "
                    "perform this write operation.");
     }

--- a/library/L2_HAL/sensors/battery/coulomb_counter.hpp
+++ b/library/L2_HAL/sensors/battery/coulomb_counter.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "utility/units.hpp"
+#include "utility/status.hpp"
 
 namespace sjsu
 {
@@ -11,10 +12,12 @@ class CoulombCounter
  public:
   /// Initialize and enable hardware. This must be called before any other
   /// method in this interface is called.
-  virtual void Initialize() = 0;
+  virtual Returns<void> Initialize() = 0;
+
   /// Returns the cumulative amount of charge that has passed through the
   /// coulomb counter.
-  virtual units::charge::milliampere_hour_t GetCharge() const = 0;
+  virtual Returns<units::charge::milliampere_hour_t> GetCharge() const = 0;
+
   /// Default virtual destructor
   virtual ~CoulombCounter() = default;
 };

--- a/library/L2_HAL/sensors/distance/distance_sensor.hpp
+++ b/library/L2_HAL/sensors/distance/distance_sensor.hpp
@@ -19,18 +19,16 @@ class DistanceSensor
  public:
   /// Initialize distance sensor hardware. Must be called before running any
   /// other methods.
-  virtual Status Initialize() = 0;
+  virtual Returns<void> Initialize() = 0;
 
   /// Trigger a capture of the current distance reading and return it.
   ///
-  /// @param distance - output parameter to contain the distance results.
-  virtual Status GetDistance(units::length::millimeter_t * distance) = 0;
+  /// @return measured distance
+  virtual Returns<units::length::millimeter_t> GetDistance() = 0;
 
   /// Get the signal strength from the distance sensor.
   ///
-  /// @param strength - output parameter to contain the strength of the system.
-  ///        The exact value
-  /// @return Status
-  virtual Status GetSignalStrengthPercent(float * strength) = 0;
+  /// @return the strength of the signal the strength of the measurement.
+  virtual Returns<float> GetSignalStrengthPercent() = 0;
 };
 }  // namespace sjsu

--- a/library/L2_HAL/sensors/environment/light/temt6000x01.hpp
+++ b/library/L2_HAL/sensors/environment/light/temt6000x01.hpp
@@ -25,13 +25,13 @@ class Temt6000x01 final : public LightSensor
   /// Initializes the ADC driver.
   ///
   /// @returns The initialization status.
-  Status Initialize() const override
+  Returns<void> Initialize() const override
   {
     return adc_.Initialize();
   }
 
   /// @returns The illuminance in units of lux ranging from 1 - 1'000.
-  units::illuminance::lux_t GetIlluminance() const override
+  Returns<units::illuminance::lux_t> GetIlluminance() const override
   {
     // current = voltage / resistance
     const units::current::microampere_t kCurrent =
@@ -62,7 +62,7 @@ class Temt6000x01 final : public LightSensor
 
   /// @returns The maximum illuminance that can be handled by the sensor.  The
   ///          device has an illumination range of 1 - 1000 lux.
-  units::illuminance::lux_t GetMaxIlluminance() const override
+  Returns<units::illuminance::lux_t> GetMaxIlluminance() const override
   {
     return 1'000_lx;
   }

--- a/library/L2_HAL/sensors/environment/light/test/temt6000x01_test.cpp
+++ b/library/L2_HAL/sensors/environment/light/test/temt6000x01_test.cpp
@@ -28,35 +28,34 @@ TEST_CASE("Testing TEMP6000X01 Light Sensor")
 
   Temt6000x01 test_subject(mock_adc.get(), kPullDownResistor);
 
-  SECTION("Initialize")
+  SECTION("Successful Initialize")
   {
     // Setup
-    Status expected_status;
-
-    SUBCASE("On Success")
-    {
-      expected_status = Status::kSuccess;
-    }
-
-    SUBCASE("On Invalid Settings")
-    {
-      expected_status = Status::kInvalidSettings;
-    }
-
-    When(Method(mock_adc, Initialize)).AlwaysReturn(expected_status);
+    When(Method(mock_adc, Initialize)).AlwaysReturn({});
 
     // Exercise
-    auto actual_status = test_subject.Initialize();
+    REQUIRE(test_subject.Initialize());
 
     // Verify
     Verify(Method(mock_adc, Initialize)).Once();
-    CHECK(actual_status == expected_status);
+  }
+
+  SECTION("Successful Initialize")
+  {
+    const auto kExpectedError = std::errc::invalid_argument;
+    When(Method(mock_adc, Initialize)).AlwaysReturn(Error(kExpectedError, ""));
+
+    // Exercise
+    REQUIRE(kExpectedError == test_subject.Initialize());
+
+    // Verify
+    Verify(Method(mock_adc, Initialize)).Once();
   }
 
   SECTION("GetIlluminance")
   {
     // Exercise
-    units::illuminance::lux_t actual_lux = test_subject.GetIlluminance();
+    auto actual_lux = test_subject.GetIlluminance().value();
 
     // Verify
     Verify(Method(mock_adc, Read)).Once();
@@ -66,7 +65,7 @@ TEST_CASE("Testing TEMP6000X01 Light Sensor")
   SECTION("GetMaxIlluminance")
   {
     // Exercise
-    units::illuminance::lux_t actual_max_lux = test_subject.GetMaxIlluminance();
+    auto actual_max_lux = test_subject.GetMaxIlluminance().value();
 
     // Verify
     CHECK(actual_max_lux == expected_max_lux);
@@ -77,7 +76,7 @@ TEST_CASE("Testing TEMP6000X01 Light Sensor")
     float expected_percentage = (expected_lux / expected_max_lux).to<float>();
 
     // Exercise
-    float actual_percentage = test_subject.GetPercentageBrightness();
+    float actual_percentage = test_subject.GetPercentageBrightness().value();
 
     // Verify
     Verify(Method(mock_adc, Read)).Once();

--- a/library/L2_HAL/sensors/environment/light_sensor.hpp
+++ b/library/L2_HAL/sensors/environment/light_sensor.hpp
@@ -13,23 +13,25 @@ class LightSensor
   /// method in this interface is called.
   ///
   /// @return The initialization status.
-  virtual Status Initialize() const = 0;
+  virtual Returns<void> Initialize() const = 0;
   /// @return The sensor reading in units of lux.
-  virtual units::illuminance::lux_t GetIlluminance() const = 0;
+  virtual Returns<units::illuminance::lux_t> GetIlluminance() const = 0;
   /// @return The maximum illuminance reading supported by the device.
-  virtual units::illuminance::lux_t GetMaxIlluminance() const = 0;
+  virtual Returns<units::illuminance::lux_t> GetMaxIlluminance() const = 0;
 
-  // ==============================
+  // ===========================================================================
   // Utility Methods
-  // ==============================
+  // ===========================================================================
 
   /// Retreive the detected brightness as a percentage where:
   /// percentage = illuminance / max_illuminance
   ///
   /// @return The illuminance percentage ranging from 0.0f to 1.0f.
-  float GetPercentageBrightness() const
+  Returns<float> GetPercentageBrightness() const
   {
-    return (GetIlluminance() / GetMaxIlluminance()).to<float>();
+    return (SJ2_RETURN_ON_ERROR(GetIlluminance()) /
+            SJ2_RETURN_ON_ERROR(GetMaxIlluminance()))
+        .to<float>();
   }
 };
 }  // namespace sjsu

--- a/library/L2_HAL/sensors/environment/temperature/si7060.hpp
+++ b/library/L2_HAL/sensors/environment/temperature/si7060.hpp
@@ -6,6 +6,7 @@
 #include "utility/units.hpp"
 #include "utility/math/limits.hpp"
 #include "utility/status.hpp"
+#include "utility/log.hpp"
 
 namespace sjsu
 {
@@ -46,10 +47,7 @@ class Si7060 final : public TemperatureSensor
 
   Returns<void> Initialize() const override
   {
-    Status status;
-
-    SJ2_RETURN_ON_ERROR(i2c_.Initialize());
-    return {};
+    return i2c_.Initialize();
   }
 
   Returns<void> Enable() const override
@@ -61,7 +59,8 @@ class Si7060 final : public TemperatureSensor
 
     if (temperature_sensor_id_register != kExpectedSensorId)
     {
-      return Error(Status::kDeviceNotFound,
+      LogDebug("ID = 0x%02X\n", temperature_sensor_id_register);
+      return Error(std::errc::no_such_device,
                    "Device ID does not match expected device ID 0x14");
     }
 

--- a/library/L2_HAL/sensors/environment/temperature/test/tmp102_test.cpp
+++ b/library/L2_HAL/sensors/environment/temperature/test/tmp102_test.cpp
@@ -25,10 +25,11 @@ TEST_CASE("Testing Tmp102 Temperature Sensor")
       CHECK(success);
       Verify(Method(mock_i2c, Initialize)).Once();
     }
+
     SECTION("Initialization failure")
     {
       // Setup
-      const auto kExpectedStatus = Error(Status::kBusError, "");
+      const auto kExpectedStatus = Error(std::errc::io_error, "");
       When(Method(mock_i2c, Initialize)).AlwaysReturn(kExpectedStatus);
 
       // Exercise
@@ -58,6 +59,7 @@ TEST_CASE("Testing Tmp102 Temperature Sensor")
       { Tmp102::RegisterAddress::kConfiguration, Tmp102::kOneShotShutdownMode },
       { Tmp102::RegisterAddress::kTemperature },
     };
+
     const std::array kExpectedTransactions = {
       I2c::Transaction_t({
           .operation  = I2c::Operation::kWrite,
@@ -70,7 +72,6 @@ TEST_CASE("Testing Tmp102 Temperature Sensor")
           .repeated   = false,
           .busy       = true,
           .timeout    = I2c::kI2cTimeout,
-          .status     = Status::kSuccess,
       }),
       I2c::Transaction_t({
           .operation  = I2c::Operation::kWrite,
@@ -83,7 +84,6 @@ TEST_CASE("Testing Tmp102 Temperature Sensor")
           .repeated   = true,
           .busy       = true,
           .timeout    = Tmp102::kConversionTimeout,
-          .status     = Status::kSuccess,
       }),
     };
 

--- a/library/L2_HAL/sensors/movement/accelerometer/mma8452q.hpp
+++ b/library/L2_HAL/sensors/movement/accelerometer/mma8452q.hpp
@@ -156,8 +156,8 @@ class Mma8452q : public Accelerometer
 
     if (kGravityScale != 2 && kGravityScale != 4 && kGravityScale != 8)
     {
-      return Error(Status::kInvalidParameters,
-                   "Invalid gravity scale. Must be 2g, 4g, or 8g.");
+      return Error(std::errc::invalid_argument,
+                   "Gravity scale must be 2g, 4g, or 8g.");
     }
 
     const uint8_t kNewGravityScale = static_cast<uint8_t>(kGravityScale >> 2);
@@ -184,9 +184,8 @@ class Mma8452q : public Accelerometer
 
     if (memory_id.value() != kExpectedDeviceID)
     {
-      sjsu::LogDebug("Invalid Device ID (0x%02X) detected!", memory_id.value());
-      return Error(Status::kDeviceNotFound,
-                   "Invalid device id from device, expected 0x2A.");
+      LogDebug("ID = 0x%02X", memory_id.value());
+      return Error(std::errc::no_such_device, "Expected Device ID: 0x2A.");
     }
 
     return {};

--- a/library/L3_Application/task_scheduler.hpp
+++ b/library/L3_Application/task_scheduler.hpp
@@ -264,12 +264,12 @@ class TaskScheduler final
                     portMAX_DELAY);
     // All PreRun() complete, each Task's Run() can now start executing...
     TickType_t last_wake_time = xTaskGetTickCount();
+
     while (true)
     {
       if (!task.Run())
       {
-        SJ2_ASSERT_WARNING(
-            false,
+        LogWarning(
             "An error occurred, the following task will be suspended: %s",
             task.GetName());
         vTaskSuspend(NULL);

--- a/library/L3_Application/test/fatfs_test.cpp
+++ b/library/L3_Application/test/fatfs_test.cpp
@@ -127,8 +127,8 @@ TEST_CASE("Testing FAT FS")
       When(Method(mock_storage, IsMediaPresent)).AlwaysReturn(true);
       // Setup: The error returned is arbitrary
       When(Method(mock_storage, Initialize))
-          .AlwaysReturn(
-              Error(Status::kDeviceNotFound, "Initialize Failed for Testing"));
+          .AlwaysReturn(Error(std::errc::no_such_device,
+                              "Initialize Failed for Testing"));
       When(Method(mock_storage, Enable)).AlwaysReturn({});
 
       // Exercise + Verify
@@ -145,7 +145,7 @@ TEST_CASE("Testing FAT FS")
       When(Method(mock_storage, Initialize)).AlwaysReturn({});
       When(Method(mock_storage, Enable))
           .AlwaysReturn(
-              Error(Status::kNotReadyYet, "Enable Failed for Testing"));
+              Error(std::errc::io_error, "Enable Failed for Testing"));
 
       // Exercise + Verify
       CHECK(STA_NOINIT == disk_initialize(0));
@@ -238,7 +238,7 @@ TEST_CASE("Testing FAT FS")
       // Setup
       uint8_t payload[] = { 1, 2, 3, 4, 5, 6 };
       When(Method(mock_storage, Erase))
-          .AlwaysReturn(Error(Status::kBusError, "Erase Failed for Testing"));
+          .AlwaysReturn(Error(std::errc::io_error, "Erase Failed for Testing"));
       When(Method(mock_storage, Write)).AlwaysReturn({});
       When(Method(mock_storage, GetBlockSize)).AlwaysReturn(512_B);
 
@@ -267,7 +267,7 @@ TEST_CASE("Testing FAT FS")
       uint8_t payload[] = { 1, 2, 3, 4, 5, 6 };
       When(Method(mock_storage, Erase)).AlwaysReturn({});
       When(Method(mock_storage, Write))
-          .AlwaysReturn(Error(Status::kBusError, "Write Failed for Testing"));
+          .AlwaysReturn(Error(std::errc::io_error, "Write Failed for Testing"));
       When(Method(mock_storage, GetBlockSize)).AlwaysReturn(512_B);
 
       uint32_t sector     = 5;
@@ -342,7 +342,7 @@ TEST_CASE("Testing FAT FS")
       // Setup
       uint8_t payload[512];
       When(Method(mock_storage, Read))
-          .AlwaysReturn(Error(Status::kBusError, "Read Failed for Testing"));
+          .AlwaysReturn(Error(std::errc::io_error, "Read Failed for Testing"));
       When(Method(mock_storage, GetBlockSize)).AlwaysReturn(512_B);
 
       uint32_t sector     = 5;

--- a/library/L4_Testing/testing_frameworks.hpp
+++ b/library/L4_Testing/testing_frameworks.hpp
@@ -204,34 +204,34 @@ struct StringMaker<std::span<T>>
 };
 
 template <>
-struct StringMaker<sjsu::Status>  // NOLINT
+struct StringMaker<std::errc>
 {
-  static String convert(const sjsu::Status & status)  // NOLINT
+  static String convert(const std::errc & error_code)  // NOLINT
   {
-    std::string str;
-
-    str += "sjsu::Status_t( ";
-    str += std::to_string(status.code);
-    str += " , ";
-    str += status.name;
-    str += " )";
-
-    String result(str.data(), str.size());
-    return result;
+    return sjsu::Stringify(error_code);
   }
+};
 
-  static String convert(const sjsu::Status && status)  // NOLINT
+template <typename T>
+struct StringMaker<sjsu::Returns<T>>
+{
+  static String convert(const sjsu::Returns<T> & result)  // NOLINT
   {
-    std::string str;
-
-    str += "sjsu::Status_t( ";
-    str += std::to_string(status.code);
-    str += " , ";
-    str += status.name;
-    str += " )";
-
-    String result(str.data(), str.size());
-    return result;
+    if (result.has_value())
+    {
+      if constexpr (std::is_void_v<T>)
+      {
+        return "";
+      }
+      else
+      {
+        return StringMaker<T>::convert(result.value());
+      }
+    }
+    else
+    {
+      return sjsu::Stringify(result.error()->code);
+    }
   }
 };
 

--- a/library/config.hpp
+++ b/library/config.hpp
@@ -213,14 +213,24 @@ static_assert(1 <= kFatDriveCount && kFatDriveCount <= 10,
               "The number of FAT drives is limited to between 1 and 10.");
 
 /// If true, will store error messages into error objects. Setting this to false
-/// will reduce your binary size when using any optimization setting above O0,
-/// as the compiler will deduce that the strings are not being used, and remove
-/// them from the binary.
-#if !defined(SJ2_STORE_ERROR_MESSAGE)
-#define SJ2_STORE_ERROR_MESSAGE true
-#endif  // !defined(SJ2_STORE_ERROR_MESSAGE)
+/// will reduce your binary size by omitting the storage of these strings (only
+/// works for optimization levels above O0).
+#if !defined(SJ2_STORE_ERROR_MESSAGES)
+#define SJ2_STORE_ERROR_MESSAGES true
+#endif  // !defined(SJ2_STORE_ERROR_MESSAGES)
 /// Delcare Constant STORE_ERROR_MESSAGE
-SJ2_DECLARE_CONSTANT(STORE_ERROR_MESSAGE, bool, kStoreErrorMessages);
+SJ2_DECLARE_CONSTANT(STORE_ERROR_MESSAGES, bool, kStoreErrorMessages);
+
+/// If true, will store the text representation of the error_code in flash
+/// memory, such that they can be printed out when the Print() method is called
+/// on an Error_t object. Setting this to false will reduce your binary size by
+/// omitting the error_codes (usually saving 2kB), and only printing out the
+/// error code numeric values.
+#if !defined(SJ2_STORE_ERROR_CODE_STRING)
+#define SJ2_STORE_ERROR_CODE_STRING true
+#endif  // !defined(SJ2_STORE_ERROR_CODE_STRING)
+/// Delcare Constant STORE_ERROR_MESSAGE
+SJ2_DECLARE_CONSTANT(STORE_ERROR_CODE_STRING, bool, kStoreErrorCodeStrings);
 
 /// Enable or disable float support in printf statements. Setting to false will
 /// reduce binary size.

--- a/library/third_party/fatfs/source/sjsu-dev2/diskio.cpp
+++ b/library/third_party/fatfs/source/sjsu-dev2/diskio.cpp
@@ -33,7 +33,7 @@ Returns<void> RegisterFatFsDrive(Storage * storage, uint8_t drive_number)
   if (drive_number >= drive.size())
   {
     return Error(
-        Status::kInvalidSettings,
+        std::errc::invalid_argument,
         "Drive number supplied is beyond the number of storage drives that "
         "can be registered as phyiscal drivers for FatFS. The limit is defined "
         "by config::kFatDriveCount. Increase that config value in order to add "

--- a/library/utility/log.hpp
+++ b/library/utility/log.hpp
@@ -234,28 +234,6 @@ template <typename... Params>
 LogError(const char * format, Params...)->LogError<Params...>;
 }  // namespace sjsu
 
-/// When the condition is false, issue a warning to the user with a warning
-/// message. Warning message format acts like printf.
-#define SJ2_ASSERT_WARNING(condition, warning_message, ...) \
-  do                                                        \
-  {                                                         \
-    if (!(condition))                                       \
-    {                                                       \
-      ::sjsu::LogWarning(warning_message, ##__VA_ARGS__);   \
-    }                                                       \
-  } while (0)
-
-/// Logs the expression if it returns any but Status::kSuccess
-#define LOG_ON_FAILURE(expression)                              \
-  do                                                            \
-  {                                                             \
-    sjsu::Status log_on_failure_status = (expression);          \
-    if (log_on_failure_status != sjsu::Status::kSuccess)        \
-    {                                                           \
-      ::sjsu::LogWarning("Expression Failed: %s", #expression); \
-    }                                                           \
-  } while (0)
-
 /// When the condition is false, issue a critical level message to the user and
 /// halt the processor.
 #define SJ2_ASSERT_FATAL_WITH_DUMP(with_dump, condition, fatal_message, ...) \
@@ -292,5 +270,5 @@ LogError(const char * format, Params...)->LogError<Params...>;
 #endif  // defined(HOST_TEST)
 /// Print a variable using the printf_specifier supplied.
 #define SJ2_PRINT_VARIABLE(variable, printf_specifier) \
-  ::sjsu::LogError(#variable " = " printf_specifier, (variable))
+  ::sjsu::LogDebug(#variable " = " printf_specifier, (variable))
 /// @}

--- a/library/utility/test/time_test.cpp
+++ b/library/utility/test/time_test.cpp
@@ -64,10 +64,10 @@ TEST_CASE("Testing Time Utility")
     // Exercise
     // Exercise: if the callback always returns false, then the waiting period
     //           will be the whole timeout.
-    Status wait_status = Wait(timeout_time, []() { return false; });
+    auto wait_status = Wait(timeout_time, []() { return false; });
 
     // Verify
-    CHECK(wait_status == Status::kTimedOut);
+    CHECK(wait_status == std::errc::timed_out);
     CHECK((current_timestamp + 1us + timeout_time) == Uptime());
   }
 
@@ -81,19 +81,17 @@ TEST_CASE("Testing Time Utility")
     auto callback_counter    = 0us;
 
     // Exercise
-    Status wait_status =
-        Wait(timeout_time, [&callback_counter, time_until_complete]() {
-          if (callback_counter > time_until_complete)
-          {
-            return true;
-          }
-          callback_counter++;
-          return false;
-        });
+    REQUIRE(Wait(timeout_time, [&callback_counter, time_until_complete]() {
+      if (callback_counter > time_until_complete)
+      {
+        return true;
+      }
+      callback_counter++;
+      return false;
+    }));
 
     // Verify
     auto final_uptime = Uptime();
-    CHECK(wait_status == Status::kSuccess);
     CHECK((current_timestamp + 4us + time_until_complete) == final_uptime);
     CHECK((current_timestamp + 4us + timeout_time) != final_uptime);
   }
@@ -115,19 +113,17 @@ TEST_CASE("Testing Time Utility")
     //           the current_time, thus the next iteration will cause a timeout.
     //           If we are actually able to iterate more then a few times the
     //           the max has been ceiled.
-    Status wait_status =
-        Wait(timeout_time, [&callback_counter, time_until_complete]() {
-          if (callback_counter > time_until_complete)
-          {
-            return true;
-          }
-          callback_counter++;
-          return false;
-        });
+    REQUIRE(Wait(timeout_time, [&callback_counter, time_until_complete]() {
+      if (callback_counter > time_until_complete)
+      {
+        return true;
+      }
+      callback_counter++;
+      return false;
+    }));
 
     // Verify
     auto final_uptime = Uptime();
-    CHECK(wait_status == Status::kSuccess);
     CHECK((current_timestamp + 3us + time_until_complete) == final_uptime);
     CHECK((current_timestamp + 3us + timeout_time) != final_uptime);
   }

--- a/library/utility/time.hpp
+++ b/library/utility/time.hpp
@@ -48,9 +48,11 @@ inline void SetUptimeFunction(UptimeFunction uptime_function)
 ///        return true.
 /// @param is_done will be run in a tight loop until it returns true or the
 ///        timeout time has elapsed.
-inline Status Wait(std::chrono::nanoseconds timeout,
-                   std::function<bool()> is_done)
+inline Returns<void> Wait(std::chrono::nanoseconds timeout,
+                          std::function<bool()> is_done)
 {
+  const auto kTimedOutError = Error(std::errc::timed_out, "");
+
   std::chrono::nanoseconds timeout_time;
 
   if (timeout == std::chrono::nanoseconds::max())
@@ -62,7 +64,7 @@ inline Status Wait(std::chrono::nanoseconds timeout,
   }
   else if (timeout == 0ns)
   {
-    return Status::kTimedOut;
+    return kTimedOutError;
   }
   else
   {
@@ -84,18 +86,18 @@ inline Status Wait(std::chrono::nanoseconds timeout,
   {
     if (is_done())
     {
-      return Status::kSuccess;
+      return {};
     }
   }
 
-  return Status::kTimedOut;
+  return kTimedOutError;
 }
 
 /// Overload of `Wait` that merely takes a timeout.
 ///
 /// @param timeout - the amount of time to wait.
 /// @return always returns std::errc::timed_out
-inline Status Wait(std::chrono::nanoseconds timeout)
+inline Returns<void> Wait(std::chrono::nanoseconds timeout)
 {
   return Wait(timeout, []() -> bool { return false; });
 }

--- a/library/utility/timeout_timer.hpp
+++ b/library/utility/timeout_timer.hpp
@@ -10,42 +10,6 @@ namespace sjsu
 /// cannot exceed a certain amount of time, and apart of this operation is
 /// calling other functions or operations that take a timeout. The idea is to
 ///
-/// Example Usage:
-///
-///   Status GetWaterLevel(std::chrono::nanoseconds timeout)
-///   {
-///     // Construct TimeoutTimer with the given timeout above. Lets assume it
-///     // is 1 second.
-///     TimeoutTimer timeout(timeout);
-///     // An example device that takes time to perform its operations.
-///     WaterLevelDevice water_level;
-///     // Reusable status variable
-///     Status status;
-///
-///     // In this case, we give the remaining time left for calibration
-///     // operation. Lets assume that the time is still around 1 second. The
-///     // `CalibrateSensor()` method now has 1s to perform its work.
-///     status = water_level.CalibrateSensor(timeout.GetTimeLeft());
-///     if (!IsOk(status))
-///     {
-///       return status;
-///     }
-///
-///     // Lets now assume that `CalibrateSensor()` took about 250ms to perform
-///     // its task. Now we pass 750ms to `MeasureWaterLevelWhenSteady()`.
-///     status = water_level.MeasureWaterLevelWhenSteady(timeout.GetTimeLeft());
-///     // If `MeasureWaterLevelWhenSteady()` reached the timeout of 750ms,
-///     // then we return with Status::kTimeout.
-///     // If we still have time left, and no other problems occurred, then
-///     // status will return Status::kSuccess.
-///     if (!IsOk(status))
-///     {
-///       return status;
-///     }
-///
-///     return Status::kSuccess;
-///   }
-///
 /// See L2_HAL/communication/esp8266.hpp for good examples of TimeoutTimer being
 /// used.
 class TimeoutTimer


### PR DESCRIPTION
- Migrate all tests and interfaces using Status_t to Error 2.0.
- Migrate demos to use Error 2.0.
- Add SJ2_STORE_ERROR_CODE_STRING config which can save 2kB by omitting
  the string versions of the std::errc enumerations.

Resolves #1236
Resolves #1238
Resolves #1239
Resolves #1240
Resolves #1241
Resolves #1242
Resolves #1250
Resolves #1243
Resolves #1245
Resolves #1246
Resolves #1133