### PR TITLE
Add std::scope_guard to 3P

### DIFF
--- a/library/third_party/scope-guard/.gitignore
+++ b/library/third_party/scope-guard/.gitignore
@@ -1,0 +1,2 @@
+build/*
+test_package/build/*

--- a/library/third_party/scope-guard/.travis.yml
+++ b/library/third_party/scope-guard/.travis.yml
@@ -1,0 +1,33 @@
+language: minimal
+
+dist: focal
+
+services:
+  - docker
+
+env:
+  global:
+    - DOCKER_IMG="registry.gitlab.com/offa/docker-images"
+
+
+jobs:
+    include:
+    - env: COMPILER=gcc-10
+    - env: COMPILER=gcc-9
+    - env: COMPILER=gcc-8
+    - env: COMPILER=gcc-7
+    - env: COMPILER=clang-10
+    - env: COMPILER=clang-9
+    - env: COMPILER=clang-8
+    - env: COMPILER=clang-7
+    - env: COMPILER=clang-6
+    - env: COMPILER=clang-5
+    - env: CONAN_GCC_VERSIONS=9
+
+
+before_install:
+  - if [[ -v COMPILER ]]; then docker pull ${DOCKER_IMG}/${COMPILER}:stable; fi
+
+script:
+  - if [[ -v COMPILER ]]; then docker run -v ${PWD}:/mnt -it ${DOCKER_IMG}/${COMPILER} /bin/bash -c "cd /mnt; script/ci_build.sh"; fi
+  - if [[ -v CONAN_GCC_VERSIONS ]]; then script/conan_build.sh; fi

--- a/library/third_party/scope-guard/CONTRIBUTING.md
+++ b/library/third_party/scope-guard/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+
+## Issues
+
+**Issues** are used to report bugs, problems, feature requests, ask questions or other kind of suggestions. An issue ***should include***:
+
+- Good and meaningful title
+- Detailed description
+
+### Problems and Bugs
+
+Problem and bug reports ***need also***:
+
+- Expected and actual behaviour
+- Used version, compiler and platform
+- Minimal example or steps to reproduce
+
+
+## Pull Requests
+
+**Pull requests** are used to submit contributions to the project. A pull request ***should include***:
+
+- Good and meaningful title
+- Detailed description
+- Descriptive commit messages
+
+If the PR is related to an *Issue*, please reference it in the description or title.
+
+### Code
+
+The contributed code should match these criteria:
+
+- Pass all Unit Tests and CI Builds
+- Proper Test Cases
+- Merge cleanly, without conflicts
+- Follow the projects code style
+- Does not introduce external dependencies
+- 4 Spaces – no Tabs
+- UTF-8 encoding
+
+
+
+## Further readings
+
+- [Github Guide: How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+

--- a/library/third_party/scope-guard/LICENSE
+++ b/library/third_party/scope-guard/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2020 offa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/library/third_party/scope-guard/README.md
+++ b/library/third_party/scope-guard/README.md
@@ -1,0 +1,59 @@
+# Scope Guard
+
+[![Build Status](https://travis-ci.org/offa/scope-guard.svg?branch=master)](https://travis-ci.org/offa/scope-guard)
+[![GitHub release](https://img.shields.io/github/release/offa/scope-guard.svg)](https://github.com/offa/scope-guard/releases)
+[![License](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
+![C++](https://img.shields.io/badge/c++-17-green.svg)
+
+Implementation of *Scope Guards* (`scope_exit`, `scope_success`, `scope_fail`) and `unique_resource` as proposed in [**P0052R10**][1].
+
+
+## Compatibility
+
+This implementation conforms to [P0052][1], except:
+
+###### Namespace
+The namespace `sr` is used instead of `std`.
+
+###### Filenames
+The filenames contain a `.h` extension. To enable the compatible header as specified in the document the CMake option `ENABLE_COMPAT_HEADER` can be used. This will generate and install an additional header named `scope` (without file extension).
+
+
+## Standardisation progress
+
+[P0052][1] has been adopted (2019-03) and is in the [*Library Fundamentals v3*][2] now.
+
+
+## Documentation
+
+- [*P0052R10 – Generic Scope Guard and RAII Wrapper for the Standard Library*][1] (P. Sommerlad, A. L. Sandoval, E. Niebler, D. Krügler)
+- [*N4853 – C++ Extensions for Library Fundamentals, Version 3*][2] (T. Köppe)
+
+
+## License
+
+**MIT License**
+
+    Copyright (c) 2017-2020 offa
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+
+[1]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0052r10.pdf
+[2]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/n4853.html

--- a/library/third_party/scope-guard/include/detail/scope_guard_base.h
+++ b/library/third_party/scope-guard/include/detail/scope_guard_base.h
@@ -1,0 +1,130 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 offa
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <utility>
+#include <type_traits>
+
+namespace sr::detail
+{
+    // From P0550
+    template<class T>
+    using remove_cvref = std::remove_cv<std::remove_reference<T>>;
+
+    template<class T>
+    using remove_cvref_t = typename remove_cvref<T>::type;
+
+
+
+    template<class F, class S>
+    struct is_noexcept_dtor : public std::true_type
+    {
+    };
+
+    template<class F, class S>
+    inline constexpr bool is_noexcept_dtor_v = is_noexcept_dtor<F, S>::value;
+
+    template<class T>
+    constexpr decltype(auto) forward_if_nothrow_move_constructible(T&& arg)
+    {
+        if constexpr( std::is_nothrow_move_constructible_v<T> == true )
+        {
+            return std::forward<T>(arg);
+        }
+        return arg;
+    }
+
+
+
+    template<class EF, class Strategy>
+    class scope_guard_base : private Strategy
+    {
+    public:
+
+        template<class EFP,
+            std::enable_if_t<std::is_constructible_v<EF, EFP>, int> = 0,
+            std::enable_if_t<(!std::is_lvalue_reference_v<EFP>)
+                                && std::is_nothrow_constructible_v<EF, EFP>, int> = 0
+            >
+        explicit scope_guard_base(EFP&& exitFunction) noexcept(std::is_nothrow_constructible_v<EF, EFP>
+                                                                || std::is_nothrow_constructible_v<EF, EFP&>)
+                                                    : exitfunction(std::forward<EFP>(exitFunction)),
+                                                    execute_on_destruction(true)
+        {
+        }
+
+        template<class EFP,
+            std::enable_if_t<std::is_constructible_v<EF, EFP>, int> = 0,
+            std::enable_if_t<std::is_lvalue_reference_v<EFP>, int> = 0
+            >
+        explicit scope_guard_base(EFP&& exitFunction) try : exitfunction(exitFunction),
+                                                        execute_on_destruction(true)
+        {
+        }
+        catch( ... )
+        {
+            exitFunction();
+            throw;
+        }
+
+        template<class EFP = EF, std::enable_if_t<(std::is_nothrow_move_constructible_v<EF>
+                                                    || std::is_copy_constructible_v<EF>), int> = 0
+                >
+        scope_guard_base(scope_guard_base&& other) noexcept(std::is_nothrow_move_constructible_v<EF>
+                                                            || std::is_nothrow_copy_constructible_v<EF>)
+                                        : Strategy(other),
+                                        exitfunction(forward_if_nothrow_move_constructible(other.exitfunction)),
+                                        execute_on_destruction(other.execute_on_destruction)
+        {
+            other.release();
+        }
+
+        scope_guard_base(const scope_guard_base&) = delete;
+
+
+        ~scope_guard_base() noexcept(is_noexcept_dtor_v<EF, Strategy>)
+        {
+            if( (execute_on_destruction == true) && (this->should_execute() == true) )
+            {
+                exitfunction();
+            }
+        }
+
+
+        void release() noexcept
+        {
+            execute_on_destruction = false;
+        }
+
+
+        scope_guard_base& operator=(const scope_guard_base&) = delete;
+        scope_guard_base& operator=(scope_guard_base&&) = delete;
+
+
+    private:
+
+        EF exitfunction;
+        bool execute_on_destruction;
+    };
+
+}

--- a/library/third_party/scope-guard/include/detail/wrapper.h
+++ b/library/third_party/scope-guard/include/detail/wrapper.h
@@ -1,0 +1,131 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 offa
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <functional>
+#include <type_traits>
+
+namespace sr::detail
+{
+    struct NoopGuard
+    {
+        constexpr void release() const
+        {
+        }
+    };
+
+
+   template<class T>
+   class Wrapper
+   {
+   public:
+
+        template<class TT, class G = NoopGuard, std::enable_if_t<std::is_constructible_v<T, TT>, int> = 0>
+        Wrapper(TT&& v, G&& g = G{}) noexcept(std::is_nothrow_constructible_v<T, TT>) : value(std::forward<TT>(v))
+        {
+            g.release();
+        }
+
+
+        T& get() noexcept
+        {
+            return value;
+        }
+
+        const T& get() const noexcept
+        {
+            return value;
+        }
+
+        void reset(Wrapper<T>&& other) noexcept
+        {
+            value = std::move(other.value);
+        }
+
+        void reset(const Wrapper<T>& other) noexcept(std::is_nothrow_assignable_v<T, const T&>)
+        {
+            value = other.value;
+        }
+
+        void reset(T&& newValue) noexcept(std::is_nothrow_assignable_v<T, decltype(std::move_if_noexcept(newValue))>)
+        {
+            value = std::forward<T>(newValue);
+        }
+
+        void reset(const T& newValue) noexcept(std::is_nothrow_assignable_v<T, const T&>)
+        {
+            value = newValue;
+        }
+
+
+        using type = T;
+
+
+    private:
+
+        T value;
+    };
+
+
+   template<class T>
+   class Wrapper<T&>
+   {
+   public:
+
+        template<class TT, class G = NoopGuard, std::enable_if_t<std::is_convertible_v<TT, T&>, int> = 0>
+        Wrapper(TT&& v, G&& g = G{}) noexcept(std::is_nothrow_constructible_v<TT, T&>) : value(static_cast<T&>(v))
+        {
+            g.release();
+        }
+
+
+        T& get() noexcept
+        {
+            return value.get();
+        }
+
+        const T& get() const noexcept
+        {
+            return value.get();
+        }
+
+        void reset(Wrapper<T>&& other) noexcept
+        {
+            value = std::move(other.value);
+        }
+
+        void reset(T& newValue) noexcept
+        {
+            value = std::ref(newValue);
+        }
+
+
+        using type = std::reference_wrapper<std::remove_reference_t<T>>;
+
+
+    private:
+
+        type value;
+   };
+
+}

--- a/library/third_party/scope-guard/include/scope
+++ b/library/third_party/scope-guard/include/scope
@@ -1,0 +1,29 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 offa
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#define sr std
+
+#include "scope.h"
+
+#undef sr

--- a/library/third_party/scope-guard/include/scope.h
+++ b/library/third_party/scope-guard/include/scope.h
@@ -1,0 +1,31 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 offa
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#define __cpp_lib_scope     201711
+
+#include "scope_exit.h"
+#include "scope_fail.h"
+#include "scope_success.h"
+#include "unique_resource.h"
+

--- a/library/third_party/scope-guard/include/scope_exit.h
+++ b/library/third_party/scope-guard/include/scope_exit.h
@@ -1,0 +1,62 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 offa
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "detail/scope_guard_base.h"
+
+namespace sr
+{
+    namespace detail
+    {
+
+        struct scope_exit_strategy
+        {
+            bool should_execute() const noexcept
+            {
+                return true;
+            }
+
+        };
+
+    }
+
+
+    template<class EF>
+    class scope_exit : public detail::scope_guard_base<EF, detail::scope_exit_strategy>
+    {
+        using ScopeGuardBase = std::enable_if_t<!std::is_same_v<detail::remove_cvref_t<EF>, scope_exit<EF>>,
+                                                detail::scope_guard_base<EF, detail::scope_exit_strategy>
+                                                >;
+
+    public:
+
+        using ScopeGuardBase::ScopeGuardBase;
+
+    };
+
+
+    template<class EF>
+    scope_exit(EF) -> scope_exit<EF>;
+
+}
+

--- a/library/third_party/scope-guard/include/scope_fail.h
+++ b/library/third_party/scope-guard/include/scope_fail.h
@@ -1,0 +1,65 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 offa
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "detail/scope_guard_base.h"
+#include <exception>
+
+namespace sr
+{
+    namespace detail
+    {
+
+        struct scope_fail_strategy
+        {
+            bool should_execute() const noexcept
+            {
+                return std::uncaught_exceptions() > uncaught_on_creation;
+            }
+
+
+            int uncaught_on_creation = std::uncaught_exceptions();
+        };
+
+    }
+
+
+    template<class EF>
+    class scope_fail : public detail::scope_guard_base<EF, detail::scope_fail_strategy>
+    {
+        using ScopeGuardBase = std::enable_if_t<!std::is_same_v<detail::remove_cvref_t<EF>, scope_fail<EF>>,
+                                                detail::scope_guard_base<EF, detail::scope_fail_strategy>
+                                                >;
+
+    public:
+
+        using ScopeGuardBase::ScopeGuardBase;
+
+    };
+
+
+    template<class EF>
+    scope_fail(EF) -> scope_fail<EF>;
+
+}
+

--- a/library/third_party/scope-guard/include/scope_success.h
+++ b/library/third_party/scope-guard/include/scope_success.h
@@ -1,0 +1,72 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 offa
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "detail/scope_guard_base.h"
+#include <exception>
+
+namespace sr
+{
+    namespace detail
+    {
+
+        struct scope_success_strategy
+        {
+            bool should_execute() const noexcept
+            {
+                return std::uncaught_exceptions() <= uncaught_on_creation;
+            }
+
+
+            int uncaught_on_creation = std::uncaught_exceptions();
+        };
+
+
+        template<class F>
+        struct is_noexcept_dtor<F, scope_success_strategy>
+            : public std::conditional_t<noexcept(std::declval<F>()()), std::true_type, std::false_type>
+        {
+        };
+
+    }
+
+
+    template<class EF>
+    class scope_success : public detail::scope_guard_base<EF, detail::scope_success_strategy>
+    {
+        using ScopeGuardBase = std::enable_if_t<!std::is_same_v<detail::remove_cvref_t<EF>, scope_success<EF>>,
+                                                detail::scope_guard_base<EF, detail::scope_success_strategy>
+                                                >;
+
+    public:
+
+        using ScopeGuardBase::ScopeGuardBase;
+
+    };
+
+
+    template<class EF>
+    scope_success(EF) -> scope_success<EF>;
+
+}
+

--- a/library/third_party/scope-guard/include/unique_resource.h
+++ b/library/third_party/scope-guard/include/unique_resource.h
@@ -1,0 +1,224 @@
+// MIT License
+//
+// Copyright (c) 2017-2020 offa
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "scope_exit.h"
+#include "detail/wrapper.h"
+#include <utility>
+#include <type_traits>
+
+namespace sr
+{
+    namespace detail
+    {
+        template<class T, class U,
+                    class R = std::conditional_t<std::is_nothrow_constructible_v<T, U>, U&&, U>
+                >
+        constexpr R forward_if_nothrow_constructible(U&& arg)
+        {
+            return std::forward<U>(arg);
+        }
+    }
+
+
+    template<class R, class D>
+    class unique_resource
+    {
+    public:
+
+        unique_resource()
+            : resource(R{}),
+            deleter(D{}),
+            execute_on_reset(false)
+        {
+        }
+
+        template<class RR, class DD,
+                std::enable_if_t<(std::is_constructible_v<R ,RR> && std::is_constructible_v<D, DD>
+                                && (std::is_nothrow_constructible_v<R, RR> || std::is_constructible_v<R, RR&>)
+                                && (std::is_nothrow_constructible_v<D, DD> || std::is_constructible_v<D, DD&>)), int> = 0
+                >
+        unique_resource(RR&& r, DD&& d) noexcept((std::is_nothrow_constructible_v<R, RR> || std::is_nothrow_constructible_v<R, RR&>)
+                                                    && (std::is_nothrow_constructible_v<D, DD> || std::is_nothrow_constructible_v<D, DD&>))
+                                        : resource(detail::forward_if_nothrow_constructible<R, RR>(std::forward<RR>(r)), scope_exit{[&r, &d] { d(r); }}),
+                                        deleter(detail::forward_if_nothrow_constructible<D, DD>(std::forward<DD>(d)), scope_exit{[this, &d] { d(get()); }}),
+                                        execute_on_reset(true)
+        {
+        }
+
+        unique_resource(unique_resource&& other) noexcept(std::is_nothrow_move_constructible_v<R>
+                                                            && std::is_nothrow_move_constructible_v<D>)
+                                                : resource(std::move_if_noexcept(other.resource.get())),
+                                                deleter(std::move_if_noexcept(other.deleter.get()), scope_exit{[&other] {
+                                                                                                            if( other.execute_on_reset == true )
+                                                                                                            {
+                                                                                                                other.get_deleter()(other.resource.get());
+                                                                                                            }
+                                                                                                            other.release(); }}),
+                                                execute_on_reset(std::exchange(other.execute_on_reset, false))
+        {
+        }
+
+        unique_resource(const unique_resource&) = delete;
+
+        ~unique_resource()
+        {
+            reset();
+        }
+
+
+        void reset() noexcept
+        {
+            if( execute_on_reset == true )
+            {
+                execute_on_reset = false;
+                get_deleter()(resource.get());
+            }
+        }
+
+        template<class RR>
+        void reset(RR&& r)
+        {
+            reset();
+
+            using R1 = typename detail::Wrapper<R>::type;
+            auto se = scope_exit{[this, &r] { get_deleter()(r); }};
+
+            if constexpr( std::is_nothrow_assignable_v<R1&, RR> == true )
+            {
+                resource.reset(std::forward<RR>(r));
+            }
+            else
+            {
+                resource.reset(std::as_const(r));
+            }
+
+            execute_on_reset = true;
+            se.release();
+        }
+
+        void release() noexcept
+        {
+            execute_on_reset = false;
+        }
+
+        const R& get() const noexcept
+        {
+            return resource.get();
+        }
+
+        template<class RR = R, std::enable_if_t<std::is_pointer_v<RR>, int> = 0>
+        RR operator->() const noexcept
+        {
+            return resource.get();
+        }
+
+        template<class RR = R,
+            std::enable_if_t<( std::is_pointer_v<RR>
+                            && !std::is_void_v<std::remove_pointer_t<RR>>), int> = 0>
+        std::add_lvalue_reference_t<std::remove_pointer_t<RR>> operator*() const noexcept
+        {
+            return *get();
+        }
+
+        const D& get_deleter() const noexcept
+        {
+            return deleter.get();
+        }
+
+
+        template<class RR = R, class DD = D,
+            std::enable_if_t<(std::is_nothrow_move_assignable_v<RR>
+                                || std::is_copy_assignable_v<RR>)
+                            && (std::is_nothrow_move_assignable_v<DD>
+                                || std::is_copy_assignable_v<DD>), int> = 0>
+        unique_resource& operator=(unique_resource&& other) noexcept(std::is_nothrow_assignable_v<R&, R>
+                                                                    && std::is_nothrow_assignable_v<D&, D>)
+        {
+            if( this != &other )
+            {
+                reset();
+
+                if constexpr( std::is_nothrow_move_assignable_v<RR> == true )
+                {
+                    if constexpr( std::is_nothrow_move_assignable_v<DD> == true )
+                    {
+                        resource.reset(std::move(other.resource));
+                        deleter.reset(std::move(other.deleter));
+                    }
+                    else
+                    {
+                        deleter.reset(other.deleter);
+                        resource.reset(std::move(other.resource));
+                    }
+                }
+                else
+                {
+                    if constexpr( std::is_nothrow_move_assignable_v<DD> == true )
+                    {
+                        resource.reset(other.resource);
+                        deleter.reset(std::move(other.deleter));
+                    }
+                    else
+                    {
+                        resource.reset(other.resource);
+                        deleter.reset(other.deleter);
+                    }
+                }
+
+                execute_on_reset = std::exchange(other.execute_on_reset, false);
+            }
+            return *this;
+        }
+
+        unique_resource& operator=(const unique_resource&) = delete;
+
+
+    private:
+
+        detail::Wrapper<R> resource;
+        detail::Wrapper<D> deleter;
+        bool execute_on_reset;
+    };
+
+
+    template<class R, class D>
+    unique_resource(R, D) -> unique_resource<R, D>;
+
+
+    template<class R, class D, class S = std::decay_t<R>>
+    unique_resource<std::decay_t<R>, std::decay_t<D>> make_unique_resource_checked(R&& r, const S& invalid, D&& d)
+                                                            noexcept(std::is_nothrow_constructible_v<std::decay_t<R>, R>
+                                                                    && std::is_nothrow_constructible_v<std::decay_t<D>, D>)
+    {
+        unique_resource<std::decay_t<R>, std::decay_t<D>> ur{std::forward<R>(r), std::forward<D>(d)};
+
+        if( bool(r == invalid) == true )
+        {
+            ur.release();
+        }
+
+        return ur;
+    }
+
+}

--- a/library/third_party/scope-guard/scope-guard.mk
+++ b/library/third_party/scope-guard/scope-guard.mk
@@ -1,0 +1,1 @@
+SYSTEM_INCLUDES += $(LIBRARY_DIR)/third_party/scope-guard/include

--- a/library/third_party/third_party.mk
+++ b/library/third_party/third_party.mk
@@ -3,6 +3,7 @@ include $(LIBRARY_DIR)/third_party/printf/printf.mk
 include $(LIBRARY_DIR)/third_party/semihost/semihost.mk
 include $(LIBRARY_DIR)/third_party/fatfs/fatfs.mk
 include $(LIBRARY_DIR)/third_party/span/span.mk
+include $(LIBRARY_DIR)/third_party/scope-guard/scope-guard.mk
 
 LIBRARY_3P += $(LIBRARY_DIR)/third_party/unity.c
 LIBRARY_3P += $(LIBRARY_DIR)/third_party/unity.cpp


### PR DESCRIPTION
This feature is a C++20 that is not available yet in our compiler.
This 3P implementation follows the <scope> library.

See the following link for more information:

   https://en.cppreference.com/w/cpp/experimental/scope_exit