### PR TITLE
Remove Log Macros

### DIFF
--- a/demos/msp432p401r/system_controller/source/main.cpp
+++ b/demos/msp432p401r/system_controller/source/main.cpp
@@ -54,7 +54,7 @@ void ConfigureClockOutPins()
 
 int main()
 {
-  LOG_INFO("Starting MSP432P401R System Controller Demo...");
+  sjsu::LogInfo("Starting MSP432P401R System Controller Demo...");
 
   // Configure the on-board P1.0 LED to be initially turned on.
   sjsu::msp432p401r::Gpio p1_0(1, 0);

--- a/library/L1_Peripheral/lpc40xx/pwm.hpp
+++ b/library/L1_Peripheral/lpc40xx/pwm.hpp
@@ -263,9 +263,11 @@ class Pwm final : public sjsu::Pwm
 
   void SetFrequency(units::frequency::hertz_t frequency_hz) const override
   {
-    SJ2_RETURN_IF(
-        frequency_hz == 0_Hz,
-        "Cannot set frequency to 0Hz! This call will have no effect!");
+    if (frequency_hz <= 0_Hz)
+    {
+      LogDebug("Cannot set frequency to 0Hz! This call will have no effect!");
+      return;
+    }
 
     auto & system = sjsu::SystemController::GetPlatformController();
 

--- a/library/L2_HAL/communication/esp8266.hpp
+++ b/library/L2_HAL/communication/esp8266.hpp
@@ -291,7 +291,7 @@ class Esp8266 : public InternetSocket, public WiFi
     // Wait for an OK!
     if (ReadUntil(kOk, timer.GetTimeLeft()) == -1)
     {
-      LOG_ERROR("CIPSEND");
+      LogDebug("CIPSEND");
       return Status::kBusError;
     }
 
@@ -301,7 +301,7 @@ class Esp8266 : public InternetSocket, public WiFi
     // Wait for an OK!
     if (ReadUntil("\r\nSEND OK\r\n\r\n", timer.GetTimeLeft()) == -1)
     {
-      LOG_ERROR("SEND OK");
+      LogDebug("SEND OK");
       return Status::kBusError;
     }
 

--- a/library/utility/log.hpp
+++ b/library/utility/log.hpp
@@ -234,18 +234,6 @@ template <typename... Params>
 LogError(const char * format, Params...)->LogError<Params...>;
 }  // namespace sjsu
 
-/// Deprecated log macro with the DEBUG level of log message.
-#define LOG_DEBUG(format, ...) ::sjsu::LogDebug(format, ##__VA_ARGS__)
-
-/// Deprecated log macro with the INFO level of log message.
-#define LOG_INFO(format, ...) ::sjsu::LogInfo(format, ##__VA_ARGS__)
-
-/// Deprecated log macro with the WARNING level of log message.
-#define LOG_WARNING(format, ...) ::sjsu::LogWarning(format, ##__VA_ARGS__)
-
-/// Deprecated log macro with the ERROR level of log message.
-#define LOG_ERROR(format, ...) ::sjsu::LogError(format, ##__VA_ARGS__)
-
 /// When the condition is false, issue a warning to the user with a warning
 /// message. Warning message format acts like printf.
 #define SJ2_ASSERT_WARNING(condition, warning_message, ...) \
@@ -255,16 +243,6 @@ LogError(const char * format, Params...)->LogError<Params...>;
     {                                                       \
       ::sjsu::LogWarning(warning_message, ##__VA_ARGS__);   \
     }                                                       \
-  } while (0)
-
-/// Returns and prinparams statement if condition returns true
-#define SJ2_RETURN_IF(condition, warning_message, ...)                    \
-  do                                                                      \
-  {                                                                       \
-    if ((condition))                                                      \
-    {                                                                     \
-      ::sjsu::LogWarning(warning_message SJ2_COLOR_RESET, ##__VA_ARGS__); \
-    }                                                                     \
   } while (0)
 
 /// Logs the expression if it returns any but Status::kSuccess


### PR DESCRIPTION
- The Log Macros are no longer needed.
- Logging types such as LogInfo, LogDebug, LogError can be used instead.