### PR TITLE
Add back make stacktrace target

### DIFF
--- a/library/utility/debug.hpp
+++ b/library/utility/debug.hpp
@@ -155,12 +155,13 @@ inline _Unwind_Reason_Code PrintAddressAsList(_Unwind_Context * context,
   (*depth)++;
   return _URC_NO_REASON;
 }
+
 inline _Unwind_Reason_Code PrintAddressInRow(_Unwind_Context * context,
                                              void * depth_pointer)
 {
   int * depth      = static_cast<int *>(depth_pointer);
   intptr_t address = static_cast<intptr_t>(_Unwind_GetIP(context));
-  printf(" 0x%08" PRIXPTR, address - config::kBacktraceAddressOffset);
+  printf("0x%08" PRIXPTR " ", address - config::kBacktraceAddressOffset);
   (*depth)++;
   return _URC_NO_REASON;
 }
@@ -193,12 +194,13 @@ inline void PrintBacktrace(bool show_make_command = false,
     {
       printf("\nRun: the following command in your project directory");
       printf("\n\n  " SJ2_BOLD_WHITE);
-      printf("make stacktrace TRACES=\"");
+      printf("make stacktrace PLATFORM=%s TRACES=\"",
+             build::Stringify(build::kPlatform));
 
       _Unwind_Backtrace(&PrintAddressInRow, &depth);
       if (final_address)
       {
-        printf("0x%p ", final_address);
+        printf("0x%p", final_address);
       }
 
       printf("\"\n\n" SJ2_COLOR_RESET);

--- a/makefile
+++ b/makefile
@@ -318,6 +318,10 @@ flash: | application platform-flash
 execute: flash
 
 
+stacktrace:
+	addr2line -e $(EXECUTABLE) $(TRACES)
+
+
 # ==============================================================================
 # Project cleaning targets
 # ==============================================================================


### PR DESCRIPTION
The makefile refactor accidentially removed the stacktrace target which
is useful when the backtrace function is called.