### PR TITLE
[WIP] Make all interfaces adopt Returns<>

### DIFF
--- a/library/L1_Peripheral/adc.hpp
+++ b/library/L1_Peripheral/adc.hpp
@@ -22,22 +22,22 @@ class Adc
   /// running the GetActiveBits().
   ///
   /// @returns The digital representation of the analog.
-  virtual uint32_t Read() const = 0;
+  virtual Returns<uint32_t> Read() const = 0;
 
   /// @returns The number of active bits for the ADC.
-  virtual uint8_t GetActiveBits() const = 0;
+  virtual Returns<uint8_t> GetActiveBits() const = 0;
 
   /// @returns The ADC reference voltage.
-  virtual units::voltage::microvolt_t ReferenceVoltage() const = 0;
+  virtual Returns<units::voltage::microvolt_t> ReferenceVoltage() const = 0;
 
   // ===========================================================================
   // Utility Methods
   // ===========================================================================
 
   /// @returns The ADC resolution based on the active bits.
-  uint32_t GetMaximumValue() const
+  Returns<uint32_t> GetMaximumValue() const
   {
-    return (1 << GetActiveBits()) - 1;
+    return (1 << SJ2_RETURN_ON_ERROR(GetActiveBits())) - 1;
   }
 
   /// Utility method to convert and return the ADC result in voltage using the
@@ -46,9 +46,11 @@ class Adc
   /// voltage = adc_output * adc_reference_voltage / adc_resolution
   ///
   /// @returns The measured voltage.
-  units::voltage::microvolt_t Voltage() const
+  Returns<units::voltage::microvolt_t> Voltage() const
   {
-    return Read() * ReferenceVoltage() / GetMaximumValue();
+    return SJ2_RETURN_ON_ERROR(Read()) *
+           SJ2_RETURN_ON_ERROR(ReferenceVoltage()) /
+           SJ2_RETURN_ON_ERROR(GetMaximumValue());
   }
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/can.hpp
+++ b/library/L1_Peripheral/can.hpp
@@ -77,7 +77,7 @@ class Can
   /// Checks if there is a message available for this channel.
   ///
   /// @returns true a message was received.
-  virtual bool HasData() const = 0;
+  virtual Returns<bool> HasData() const = 0;
 
   /// Determine if you can communicate over the bus.
   ///
@@ -85,11 +85,11 @@ class Can
   ///             the bus.
   /// @return true - on success
   /// @return false - on failure
-  virtual bool SelfTest(uint32_t id) const = 0;
+  virtual Returns<bool> SelfTest(uint32_t id) const = 0;
 
   /// @return true - if the device is "bus Off"
   /// @return false - if the device is NOT "bus off"
-  virtual bool IsBusOff() const = 0;
+  virtual Returns<bool> IsBusOff() const = 0;
 
   /// @param baud - baud rate to configure the CANBUS to
   virtual Returns<void> SetBaudRate(

--- a/library/L1_Peripheral/cortex/interrupt.hpp
+++ b/library/L1_Peripheral/cortex/interrupt.hpp
@@ -56,13 +56,14 @@ class InterruptController final : public sjsu::InterruptController
     handler();
   }
 
-  void Initialize(
+  Returns<void> Initialize(
       InterruptHandler unregistered_handler = UnregisteredHandler) override
   {
     std::fill(table.begin(), table.end(), unregistered_handler);
+    return {};
   }
 
-  void Enable(RegistrationInfo_t register_info) override
+  Returns<void> Enable(RegistrationInfo_t register_info) override
   {
     int irq                = register_info.interrupt_request_number;
     table[IRQToIndex(irq)] = register_info.interrupt_handler;
@@ -75,15 +76,19 @@ class InterruptController final : public sjsu::InterruptController
     {
       NvicSetPriority(irq, register_info.priority);
     }
+
+    return {};
   }
 
-  void Disable(int interrupt_request_number) override
+  Returns<void> Disable(int interrupt_request_number) override
   {
     if (interrupt_request_number >= 0)
     {
       NvicDisableIRQ(interrupt_request_number);
     }
     table[IRQToIndex(interrupt_request_number)] = UnregisteredHandler;
+
+    return {};
   }
 
  private:

--- a/library/L1_Peripheral/dac.hpp
+++ b/library/L1_Peripheral/dac.hpp
@@ -29,6 +29,6 @@ class Dac
   virtual Returns<void> SetVoltage(float voltage) const = 0;
 
   /// @return number of active bits for the DAC.
-  virtual uint8_t GetActiveBits() const = 0;
+  virtual Returns<uint8_t> GetActiveBits() const = 0;
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/gpio.hpp
+++ b/library/L1_Peripheral/gpio.hpp
@@ -49,19 +49,19 @@ class Gpio
   ///       first before calling any other method
   ///
   /// @param direction - which direction to set the pin to.
-  virtual void SetDirection(Direction direction) const = 0;
+  virtual Returns<void> SetDirection(Direction direction) const = 0;
 
   /// Set the pin state as HIGH voltage or LOW voltage
-  virtual void Set(State output) const = 0;
+  virtual Returns<void> Set(State output) const = 0;
 
   /// Toggles pin state. If the pin is HIGH, after this call it will be LOW
   /// and vise versa.
-  virtual void Toggle() const = 0;
+  virtual Returns<void> Toggle() const = 0;
 
   /// @return the state of the pin, note that this method does not consider
   ///         whether or not the active level is high or low. Simply returns the
   ///         state as depicted in memory
-  virtual bool Read() const = 0;
+  virtual Returns<bool> Read() const = 0;
 
   /// @return underlying pin object
   virtual const sjsu::Pin & GetPin() const = 0;
@@ -82,27 +82,27 @@ class Gpio
   // ===========================================================================
 
   /// Set pin to HIGH voltage
-  void SetHigh() const
+  Returns<void> SetHigh() const
   {
-    Set(State::kHigh);
+    return Set(State::kHigh);
   }
 
   /// Set pin to LOW voltage
-  void SetLow() const
+  Returns<void> SetLow() const
   {
-    Set(State::kLow);
+    return Set(State::kLow);
   }
 
   /// Set pin direction as input
-  void SetAsInput() const
+  Returns<void> SetAsInput() const
   {
-    SetDirection(Direction::kInput);
+    return SetDirection(Direction::kInput);
   }
 
   /// Set pin direction as output
-  void SetAsOutput() const
+  Returns<void> SetAsOutput() const
   {
-    SetDirection(Direction::kOutput);
+    return SetDirection(Direction::kOutput);
   }
 
   /// Set pin to run callback when the pin sees a rising edge

--- a/library/L1_Peripheral/hardware_counter.hpp
+++ b/library/L1_Peripheral/hardware_counter.hpp
@@ -72,8 +72,8 @@ class GpioCounter : public HardwareCounter
 
   Returns<void> Initialize() override
   {
-    gpio_.GetPin().SetPull(pull_);
-    gpio_.SetAsInput();
+    SJ2_RETURN_ON_ERROR(gpio_.GetPin().SetPull(pull_));
+    SJ2_RETURN_ON_ERROR(gpio_.SetAsInput());
     return {};
   }
   Returns<void> Set(int32_t new_count_value) override

--- a/library/L1_Peripheral/inactive.hpp
+++ b/library/L1_Peripheral/inactive.hpp
@@ -93,15 +93,15 @@ inline sjsu::Adc & GetInactive<sjsu::Adc>()
     {
       return {};
     }
-    uint32_t Read() const override
+    Returns<uint32_t> Read() const override
     {
       return 0;
     }
-    uint8_t GetActiveBits() const override
+    Returns<uint8_t> GetActiveBits() const override
     {
       return 12;
     }
-    units::voltage::microvolt_t ReferenceVoltage() const override
+    Returns<units::voltage::microvolt_t> ReferenceVoltage() const override
     {
       return 0_V;
     }
@@ -130,7 +130,7 @@ inline sjsu::Dac & GetInactive<sjsu::Dac>()
     {
       return {};
     }
-    uint8_t GetActiveBits() const override
+    Returns<uint8_t> GetActiveBits() const override
     {
       return 12;
     }
@@ -147,10 +147,19 @@ inline sjsu::Gpio & GetInactive<sjsu::Gpio>()
   class InactiveGpio : public sjsu::Gpio
   {
    public:
-    void SetDirection(Direction) const override {}
-    void Set(State) const override {}
-    void Toggle() const override {}
-    bool Read() const override
+    Returns<void> SetDirection(Direction) const override
+    {
+      return {};
+    }
+    Returns<void> Set(State) const override
+    {
+      return {};
+    }
+    Returns<void> Toggle() const override
+    {
+      return {};
+    }
+    Returns<bool> Read() const override
     {
       return false;
     }
@@ -236,11 +245,14 @@ inline sjsu::Spi & GetInactive<sjsu::Spi>()
     {
       return {};
     }
-    uint16_t Transfer(uint16_t) const override
+    Returns<uint16_t> Transfer(uint16_t) const override
     {
       return 0xFF;
     }
-    void SetDataSize(DataSize) const override {}
+    Returns<void> SetDataSize(DataSize) const override
+    {
+      return {};
+    }
     Returns<void> SetClock(units::frequency::hertz_t, bool, bool) const override
     {
       return {};
@@ -258,21 +270,30 @@ inline sjsu::SystemController & GetInactive<sjsu::SystemController>()
   class InactiveSystemController : public sjsu::SystemController
   {
    public:
-    void Initialize() override {}
+    Returns<void> Initialize() override
+    {
+      return {};
+    }
     void * GetClockConfiguration() override
     {
       return nullptr;
     }
-    units::frequency::hertz_t GetClockRate(ResourceID) const override
+    Returns<units::frequency::hertz_t> GetClockRate(ResourceID) const override
     {
       return 0_Hz;
     }
-    bool IsPeripheralPoweredUp(ResourceID) const override
+    Returns<bool> IsPeripheralPoweredUp(ResourceID) const override
     {
       return false;
     }
-    void PowerUpPeripheral(ResourceID) const override {}
-    void PowerDownPeripheral(ResourceID) const override {}
+    Returns<void> PowerUpPeripheral(ResourceID) const override
+    {
+      return {};
+    }
+    Returns<void> PowerDownPeripheral(ResourceID) const override
+    {
+      return {};
+    }
   };
 
   static InactiveSystemController inactive;
@@ -286,9 +307,18 @@ inline sjsu::InterruptController & GetInactive<sjsu::InterruptController>()
   class InactiveInterruptController : public sjsu::InterruptController
   {
    public:
-    void Initialize(InterruptHandler) override {}
-    void Enable(RegistrationInfo_t) override {}
-    void Disable(int) override {}
+    Returns<void> Initialize(InterruptHandler) override
+    {
+      return {};
+    }
+    Returns<void> Enable(RegistrationInfo_t) override
+    {
+      return {};
+    }
+    Returns<void> Disable(int) override
+    {
+      return {};
+    }
   };
 
   static InactiveInterruptController inactive;
@@ -302,13 +332,19 @@ inline sjsu::SystemTimer & GetInactive<sjsu::SystemTimer>()
   class InactiveSystemTimer : public sjsu::SystemTimer
   {
    public:
-    void Initialize() const override {}
-    void SetCallback(InterruptCallback) const override {}
+    Returns<void> Initialize() const override
+    {
+      return {};
+    }
+    Returns<void> SetCallback(InterruptCallback) const override
+    {
+      return {};
+    }
     Returns<void> StartTimer() const override
     {
       return {};
     }
-    int32_t SetTickFrequency(units::frequency::hertz_t) const override
+    Returns<int32_t> SetTickFrequency(units::frequency::hertz_t) const override
     {
       return 0;
     }
@@ -378,12 +414,15 @@ inline sjsu::Uart & GetInactive<sjsu::Uart>()
     {
       return {};
     }
-    void Write(const void *, size_t) const override {}
-    size_t Read(void *, size_t) const override
+    Returns<void> Write(const void *, size_t) const override
+    {
+      return {};
+    }
+    Returns<size_t> Read(void *, size_t) const override
     {
       return 0;
     }
-    bool HasData() const override
+    Returns<bool> HasData() const override
     {
       return false;
     }
@@ -407,7 +446,7 @@ inline sjsu::Storage & GetInactive<sjsu::Storage>()
     {
       return {};
     }
-    bool IsMediaPresent() override
+    Returns<bool> IsMediaPresent() override
     {
       return {};
     }
@@ -415,15 +454,15 @@ inline sjsu::Storage & GetInactive<sjsu::Storage>()
     {
       return {};
     }
-    bool IsReadOnly() override
+    Returns<bool> IsReadOnly() override
     {
       return {};
     }
-    units::data::byte_t GetCapacity() override
+    Returns<units::data::byte_t> GetCapacity() override
     {
       return 0_B;
     }
-    units::data::byte_t GetBlockSize() override
+    Returns<units::data::byte_t> GetBlockSize() override
     {
       return 0_B;
     }

--- a/library/L1_Peripheral/interrupt.hpp
+++ b/library/L1_Peripheral/interrupt.hpp
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <functional>
 
+#include "utility/status.hpp"
+
 namespace sjsu
 {
 /// Used specifically for defining an interrupt vector table of addresses.
@@ -60,7 +62,8 @@ class InterruptController
   /// @note This MUST NOT be called by application code. This for use only in
   /// the platform's startup. Doing this typically overwrites the interrupt
   /// handlers with the unregistered_handler.
-  virtual void Initialize(InterruptHandler unregistered_handler = nullptr) = 0;
+  virtual Returns<void> Initialize(
+      InterruptHandler unregistered_handler = nullptr) = 0;
 
   /// Configures and enables the interrupt on the platform and also registers
   /// the interrupt handler.
@@ -68,13 +71,13 @@ class InterruptController
   /// @param register_info - the needed information to setup the interrupt, such
   ///        as its vector number, priority, if it should be enabled with this
   ///        call, etc. See RegistrationInfo_t documentation for more details.
-  virtual void Enable(RegistrationInfo_t register_info) = 0;
+  virtual Returns<void> Enable(RegistrationInfo_t register_info) = 0;
 
   /// Disables and interrupt based on its interrupt request number
   ///
   /// @param interrupt_request_number - the interrupt request number to be
   ///        disabled.
-  virtual void Disable(int interrupt_request_number) = 0;
+  virtual Returns<void> Disable(int interrupt_request_number) = 0;
 };
 
 /// Compare operator between two InterruptController::RegistrationInfo_t

--- a/library/L1_Peripheral/lpc40xx/uart.hpp
+++ b/library/L1_Peripheral/lpc40xx/uart.hpp
@@ -318,7 +318,8 @@ class Uart final : public sjsu::Uart
   {
     auto & system = sjsu::SystemController::GetPlatformController();
 
-    auto peripheral_frequency = system.GetClockRate(port_.power_on_id);
+    auto peripheral_frequency =
+        SJ2_RETURN_ON_ERROR(system.GetClockRate(port_.power_on_id));
 
     uart::UartCalibration_t calibration =
         uart::GenerateUartCalibration(baud_rate, peripheral_frequency);
@@ -339,7 +340,7 @@ class Uart final : public sjsu::Uart
     return {};
   }
 
-  void Write(const void * data, size_t size) const override
+  Returns<void> Write(const void * data, size_t size) const override
   {
     const uint8_t * data_buffer = reinterpret_cast<const uint8_t *>(data);
     for (size_t i = 0; i < size; i++)
@@ -350,9 +351,10 @@ class Uart final : public sjsu::Uart
         continue;
       }
     }
+    return {};
   }
 
-  size_t Read(void * data, size_t size) const override
+  Returns<size_t> Read(void * data, size_t size) const override
   {
     uint8_t * data_buffer = reinterpret_cast<uint8_t *>(data);
     size_t index          = 0;
@@ -367,7 +369,7 @@ class Uart final : public sjsu::Uart
     return index;
   }
 
-  bool HasData() const override
+  Returns<bool> HasData() const override
   {
     return FifoHasData();
   }
@@ -378,11 +380,13 @@ class Uart final : public sjsu::Uart
   {
     return bit::Read(port_.registers->LSR, 5);
   }
+
   /// @return true if fifo contains receive data.
   bool FifoHasData() const
   {
     return bit::Read(port_.registers->LSR, 0);
   }
+
   /// const reference to lpc40xx::Uart::Port_t definition
   const Port_t & port_;
 };  // namespace lpc40xx

--- a/library/L1_Peripheral/pulse_capture.hpp
+++ b/library/L1_Peripheral/pulse_capture.hpp
@@ -39,10 +39,10 @@ class PulseCapture
                                    int32_t interrupt_priority = -1) const = 0;
 
   /// Select edge type to capture on
-  virtual void ConfigureCapture(CaptureEdgeMode mode) const = 0;
+  virtual Returns<void> ConfigureCapture(CaptureEdgeMode mode) const = 0;
 
   /// Enable or disable capture interrupts
-  virtual void EnableCaptureInterrupt(bool enabled) const = 0;
+  virtual Returns<void> EnableCaptureInterrupt(bool enabled) const = 0;
 };
 
 }  // namespace sjsu

--- a/library/L1_Peripheral/spi.hpp
+++ b/library/L1_Peripheral/spi.hpp
@@ -49,12 +49,12 @@ class Spi
   /// @param data - transfer data to external device via spi port
   ///
   /// @return byte read from the external device.
-  virtual uint16_t Transfer(uint16_t data) const = 0;
+  virtual Returns<uint16_t> Transfer(uint16_t data) const = 0;
 
   /// Set the number of bits to transmit over SPI
   ///
   /// @param size - number of bits to transmit over spi
-  virtual void SetDataSize(DataSize size) const = 0;
+  virtual Returns<void> SetDataSize(DataSize size) const = 0;
 
   /// Set the clock frequency
   ///
@@ -83,7 +83,7 @@ class Spi
   ///         ellision, preventing a memcpy from occuring when the result is
   ///         returned.
   template <typename T, size_t length>
-  std::array<T, length> Transfer(const std::array<T, length> & data)
+  std::array<uint8_t, length> Transfer(const std::array<T, length> & data)
   {
     // Compile time check that the datatype used is equal to or smaller than
     // datatype for Transfer. This will produce a better error message than the
@@ -94,7 +94,7 @@ class Spi
     std::array<T, length> result = { 0 };
     for (uint16_t i = 0; i < length; i++)
     {
-      result[i] = static_cast<T>(Transfer(data[i]));
+      result[i] = static_cast<T>(SJ2_RETURN_ON_ERROR(Transfer(data[i])));
     }
     return result;
   }

--- a/library/L1_Peripheral/storage.hpp
+++ b/library/L1_Peripheral/storage.hpp
@@ -64,20 +64,20 @@ class Storage
   ///         be removed or is physically located within a device, this should
   ///         always return true.
   /// @return false if storage media is not present.
-  virtual bool IsMediaPresent() = 0;
+  virtual Returns<bool> IsMediaPresent() = 0;
 
   /// @return true if device is not writable.
-  virtual bool IsReadOnly() = 0;
+  virtual Returns<bool> IsReadOnly() = 0;
 
   /// @return the maximum capacity of this storage media. This includes areas
   ///         that have already been written to. This does not include sections
   ///         of the memory that are not accessible. For example, if the first
   ///         2kB of the memory cannot be accessed via this driver, then it
   ///         should not be considered as apart of the capacity.
-  virtual units::data::byte_t GetCapacity() = 0;
+  virtual Returns<units::data::byte_t> GetCapacity() = 0;
 
   /// @return the number of bytes per block.
-  virtual units::data::byte_t GetBlockSize() = 0;
+  virtual Returns<units::data::byte_t> GetBlockSize() = 0;
 
   /// Must be called before a `Write()` operation. Erases the contents of the
   /// storage media in the location specified, the number of bytes given. Some

--- a/library/L1_Peripheral/system_controller.hpp
+++ b/library/L1_Peripheral/system_controller.hpp
@@ -135,32 +135,32 @@ class SystemController
   ///            clock system based on configurations in the ClockConfiguration.
   ///            Incorrect configurations may result in a hard fault or cause
   ///            the clock system(s) to supply incorrect clock rate(s).
-  virtual void Initialize() = 0;
+  virtual Returns<void> Initialize() = 0;
 
   /// @returns A pointer to the clock configuration object used to configure
   ///          this system controller.
   virtual void * GetClockConfiguration() = 0;
 
   /// @returns The clock rate frequency of a clock resource.
-  /// @returns 0 MHz when a unknown/invalid ResourceID is specified.
-  virtual units::frequency::hertz_t GetClockRate(ResourceID resource) const = 0;
+  virtual Returns<units::frequency::hertz_t> GetClockRate(
+      ResourceID resource) const = 0;
 
   /// Checks hardware and determines if the peripheral is powered up.
   ///
   /// @param peripheral The peripheral to check.
   /// @returns true if the peripheral is currently powered up.
   /// @returns false if the peripheral is currently powered down.
-  virtual bool IsPeripheralPoweredUp(ResourceID peripheral) const = 0;
+  virtual Returns<bool> IsPeripheralPoweredUp(ResourceID peripheral) const = 0;
 
   /// Powers up the selected peripheral.
   ///
   /// @param peripheral The peripheral to power up.
-  virtual void PowerUpPeripheral(ResourceID peripheral) const = 0;
+  virtual Returns<void> PowerUpPeripheral(ResourceID peripheral) const = 0;
 
   /// Powers down the selected peripheral.
   ///
   /// @param peripheral The peripheral to power down.
-  virtual void PowerDownPeripheral(ResourceID peripheral) const = 0;
+  virtual Returns<void> PowerDownPeripheral(ResourceID peripheral) const = 0;
 
   // ===========================================================================
   // Utility Methods

--- a/library/L1_Peripheral/system_timer.hpp
+++ b/library/L1_Peripheral/system_timer.hpp
@@ -22,12 +22,12 @@ class SystemTimer
   // Interface Methods
   // ===========================================================================
   /// Initialize system timer hardware.
-  virtual void Initialize() const = 0;
+  virtual Returns<void> Initialize() const = 0;
 
   /// Set the function to be called when the System Timer interrupt fires.
   ///
   /// @param callback - function to be called on system timer event.
-  virtual void SetCallback(InterruptCallback callback) const = 0;
+  virtual Returns<void> SetCallback(InterruptCallback callback) const = 0;
 
   /// Set frequency of the timer.
   ///
@@ -35,7 +35,7 @@ class SystemTimer
   ///         interrupt be called.
   /// @return the difference between the frequency that was achieved vs the
   ///         input frequency.
-  virtual int32_t SetTickFrequency(
+  virtual Returns<int32_t> SetTickFrequency(
       units::frequency::hertz_t frequency) const = 0;
 
   /// Start the system timer. Should be done after SetInterrupt and

--- a/library/L1_Peripheral/uart.hpp
+++ b/library/L1_Peripheral/uart.hpp
@@ -34,7 +34,7 @@ class Uart
   ///
   /// @param data - buffer to data to write to the uart serial port
   /// @param size - the number of bytes to write to the uart serial port
-  virtual void Write(const void * data, size_t size) const = 0;
+  virtual Returns<void> Write(const void * data, size_t size) const = 0;
 
   /// Retrieve bytes from the RX line. If no data is available, this method
   /// should return early.
@@ -45,20 +45,21 @@ class Uart
   /// @returns number of bytes actually read into the data buffer. Will be less
   /// than or equal to the number of bytes passed by size. More bytes can exist
   /// in the uart's buffer if the returned size is equal to the passed size.
-  virtual size_t Read(void * data, size_t size) const = 0;
+  virtual Returns<size_t> Read(void * data, size_t size) const = 0;
 
   /// Checks if there is data available for this port.
   /// @returns true if the UART port has received some data.
-  virtual bool HasData() const = 0;
+  virtual Returns<bool> HasData() const = 0;
 
   /// Will flush all bytes currently head with the UART peripherals buffers.
   ///
   /// The default implementation reads out all of the bytes by checking
   /// HasData() repeatedly and use Read() to read each. Some implementations may
   /// have more efficient methods of clearing their buffers.
-  virtual void Flush() const
+  virtual Returns<void> Flush() const
   {
     PollingFlush();
+    return {};
   }
 
   // ===========================================================================
@@ -67,9 +68,9 @@ class Uart
 
   /// Transmit just 1 byte
   /// @param byte - Write a single byte to the UART line.
-  void Write(uint8_t byte) const
+  Returns<void> Write(uint8_t byte) const
   {
-    Write(&byte, 1);
+    return Write(&byte, 1);
   }
 
   /// Transmit bytes using an array literal
@@ -78,34 +79,37 @@ class Uart
   ///    uart.Write({ 0x01, 0xAA, 0x33, 0x55 });
   ///
   /// @param data - initializer list of bytes to send.
-  void Write(std::initializer_list<uint8_t> data) const
+  Returns<void> Write(std::initializer_list<uint8_t> data) const
   {
-    Write(data.begin(), data.size());
+    return Write(data.begin(), data.size());
   }
 
   /// @return Retrieves a single byte from UART RX line. Users must ensure that
   /// HasData() is true before reading using this method. Otherwise contents of
   /// read data will not be correct and the returned byte will be 0xFF.
-  uint8_t Read() const
+  Returns<uint8_t> Read() const
   {
     uint8_t byte;
-    if (Read(&byte, sizeof(byte)) == 0)
+    if (SJ2_RETURN_ON_ERROR(HasData()))
     {
-      byte = 0xFF;
+      SJ2_RETURN_ON_ERROR(Read(&byte, sizeof(byte)));
+      return byte;
     }
-    return byte;
+    return Error(std::errc::resource_unavailable_try_again,
+                 "This UART port does not have any data.");
   }
 
   /// Will flush all bytes currently head with the UART peripherals buffers.
   ///
   /// by checking HasData() repeatedly and use Read() to read each. Some
   /// implementations may have more efficient methods of clearing their buffers.
-  void PollingFlush() const
+  Returns<void> PollingFlush() const
   {
-    while (HasData())
+    while (SJ2_RETURN_ON_ERROR(HasData()))
     {
-      Read();
+      SJ2_RETURN_ON_ERROR(Read());
     }
+    return {};
   }
 
   /// This method will handle waiting for bytes to be received via UART for the
@@ -116,23 +120,52 @@ class Uart
   /// @param timeout - duration to wait for incoming data before timeout.
   /// @return std::errc::timed_out if bytes could not be read before before
   ///         timeout.
-  Returns<void> Read(void * data,
-                    size_t size,
-                    std::chrono::nanoseconds timeout) const
+  Returns<size_t> Read(void * data,
+                       size_t size,
+                       std::chrono::nanoseconds timeout) const
   {
     size_t position       = 0;
     uint8_t * data_buffer = reinterpret_cast<uint8_t *>(data);
-    return Wait(timeout, [this, &data_buffer, size, &position]() -> bool {
-      if (HasData())
-      {
-        data_buffer[position++] = Read();
-        if (position >= size)
-        {
-          return true;
-        }
-      }
-      return false;
-    });
+
+    SJ2_RETURN_ON_ERROR(
+        Wait(timeout, [this, &data_buffer, size, &position]() -> Returns<bool> {
+          // Read byte from UART port (HadData() check occurs within the byte
+          // Read())
+          auto read_result = Read();
+
+          // If we get a TRY-AGAIN error, then we will return false and try
+          // again.
+          if (std::errc::resource_unavailable_try_again == read_result)
+          {
+            return false;
+          }
+
+          // If read_result contains some other error, then we should probagate
+          // that up.
+          else if (!read_result)
+          {
+            return tl::unexpected(read_result.error());
+          }
+
+          // Now we know that read_result has a value, thus we can write it to
+          // the buffer.
+          else
+          {
+            data_buffer[position++] = read_result.value();
+          }
+
+          // If position is above the buffer size supplied, then we are finished
+          // and its time to return true.
+          if (position >= size)
+          {
+            return true;
+          }
+
+          // We are not done yet, return false.
+          return false;
+        }));
+
+    return position;
   }
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/watchdog.hpp
+++ b/library/L1_Peripheral/watchdog.hpp
@@ -29,9 +29,9 @@ class Watchdog
   virtual Returns<void> Enable() const = 0;
 
   /// Feeds the watchdog and restarts the sequence.
-  virtual void FeedSequence() const = 0;
+  virtual Returns<void> FeedSequence() const = 0;
 
   /// Reads the current counter value of the watchdog timer.
-  virtual uint32_t CheckTimeout() const = 0;
+  virtual Returns<uint32_t> CheckTimeout() const = 0;
 };
 }  // namespace sjsu

--- a/library/third_party/fatfs/source/sjsu-dev2/diskio.cpp
+++ b/library/third_party/fatfs/source/sjsu-dev2/diskio.cpp
@@ -144,7 +144,8 @@ extern "C" DRESULT disk_read(BYTE drive_number,
   auto & storage = drive[drive_number];
 
   // Get the number of bytes per block for this media.
-  units::data::byte_t block_size = storage.media->GetBlockSize();
+  units::data::byte_t block_size =
+      SJ2_RETURN_VALUE_ON_ERROR(storage.media->GetBlockSize(), RES_ERROR);
 
   auto location = CorrectedLocation(block_size.to<uint32_t>(), sector, count);
   uint32_t location_block = std::get<0>(location);
@@ -172,7 +173,8 @@ extern "C" DRESULT disk_write(BYTE drive_number,
   auto & storage = drive[drive_number];
 
   // Get the number of bytes per block for this media.
-  units::data::byte_t block_size = storage.media->GetBlockSize();
+  units::data::byte_t block_size =
+      SJ2_RETURN_VALUE_ON_ERROR(storage.media->GetBlockSize(), RES_ERROR);
 
   auto location = CorrectedLocation(block_size.to<uint32_t>(), sector, count);
   uint32_t location_block = std::get<0>(location);

--- a/library/utility/time.hpp
+++ b/library/utility/time.hpp
@@ -49,7 +49,7 @@ inline void SetUptimeFunction(UptimeFunction uptime_function)
 /// @param is_done will be run in a tight loop until it returns true or the
 ///        timeout time has elapsed.
 inline Returns<void> Wait(std::chrono::nanoseconds timeout,
-                          std::function<bool()> is_done)
+                          std::function<Returns<bool>()> is_done)
 {
   const auto kTimedOutError = Error(std::errc::timed_out, "");
 
@@ -84,7 +84,7 @@ inline Returns<void> Wait(std::chrono::nanoseconds timeout,
 
   while (Uptime() <= timeout_time)
   {
-    if (is_done())
+    if (SJ2_RETURN_ON_ERROR(is_done()))
     {
       return {};
     }


### PR DESCRIPTION
It can not be determined that that any particular implementation of a
hardware driver will or will not throw an error, thus every interface
must be equip to return an error if need be.