### PR TITLE
Install Homebrew Before Git

### DIFF
--- a/setup
+++ b/setup
@@ -107,12 +107,6 @@ function install_mac_osx_prerequisites() {
   echo ""
   echo "└────────────────────────────────────────────────── "
   echo " ───────────────────────────────────────────────────┐"
-  echo "          Prompt Git installer by invoking it        "
-  echo "└─────────────────────────────────────────────────── "
-  git --version
-  local git_status=$?
-  print_status_nl $git_status
-  echo " ───────────────────────────────────────────────────┐"
   echo "               Installing Homebrew                   "
   echo "└─────────────────────────────────────────────────── "
   which -s brew
@@ -122,7 +116,12 @@ function install_mac_osx_prerequisites() {
     local brew_install=$?
   fi
   print_status_nl $brew_install
-
+  echo " ───────────────────────────────────────────────────┐"
+  echo "          Prompt Git installer by invoking it        "
+  echo "└─────────────────────────────────────────────────── "
+  git --version
+  local git_status=$?
+  print_status_nl $git_status
   echo " ───────────────────────────────────────────────────┐"
   echo "               Brew Install Python@3                 "
   echo "└─────────────────────────────────────────────────── "


### PR DESCRIPTION
Setup can fail if the OS has been upgraded as it could respond with
"invalid active developer path" when git, or any other command is
invoked.

Homebrew's installer will handle installing the developer kit and will
ensure that git is installed, preventing git and the dev tools from
preventing the setup from working.