### PR TITLE
Add PollingVerification() test function

### DIFF
--- a/library/L1_Peripheral/lpc40xx/can.hpp
+++ b/library/L1_Peripheral/lpc40xx/can.hpp
@@ -494,13 +494,6 @@ class Can final : public sjsu::Can
 
   bool SelfTest(uint32_t id) override
   {
-    std::scope_exit on_failure_routine([this]() {
-      // Disable self-test mode
-      SetMode(Mode::kReset, true);
-      SetMode(Mode::kSelfTest, false);
-      SetMode(Mode::kReset, false);
-    });
-
     Message_t test_message;
     test_message.id = id;
 
@@ -531,8 +524,6 @@ class Can final : public sjsu::Can
     }
 
     // Allow time for RX to fire
-    sjsu::Delay(2ms);
-
     Wait(100ms, [this]() { return HasData(); });
 
     // Read the message from the rx buffer and enqueue it into the rx queue.
@@ -544,7 +535,10 @@ class Can final : public sjsu::Can
       return false;
     }
 
-    on_failure_routine.release();
+    // Disable self-test mode
+    SetMode(Mode::kReset, true);
+    SetMode(Mode::kSelfTest, false);
+    SetMode(Mode::kReset, false);
 
     return true;
   }

--- a/library/L1_Peripheral/test/unity_test.cpp
+++ b/library/L1_Peripheral/test/unity_test.cpp
@@ -40,7 +40,7 @@
 // lpc40xx implemenation test
 // =============================================================================
 #include "L1_Peripheral/lpc40xx/test/adc_test.cpp"  // NOLINT
-// #include "L1_Peripheral/lpc40xx/test/can_test.cpp"                // NOLINT
+#include "L1_Peripheral/lpc40xx/test/can_test.cpp"                // NOLINT
 #include "L1_Peripheral/lpc40xx/test/dac_test.cpp"                // NOLINT
 #include "L1_Peripheral/lpc40xx/test/eeprom_test.cpp"             // NOLINT
 #include "L1_Peripheral/lpc40xx/test/gpio_test.cpp"               // NOLINT


### PR DESCRIPTION
PollingVerification() is a helper function designed to make testing
systems that poll easier to test by abstracting the std::thread work
and ensuring that unit test code cannot lockup with a lock safe
function.

Resolves #1288
Supports Issue #1211