### PR TITLE
Fix locking in stm32f10x system controller test

### DIFF
--- a/library/L1_Peripheral/stm32f10x/system_controller.hpp
+++ b/library/L1_Peripheral/stm32f10x/system_controller.hpp
@@ -400,6 +400,7 @@ class SystemController : public sjsu::SystemController
 
     // Step 1.4 Reset RTC clock registers
     RtcRegisters::Register().Set(RtcRegisters::kBackupDomainReset).Save();
+
     // Manually clear the RTC reset bit
     RtcRegisters::Register().Clear(RtcRegisters::kBackupDomainReset).Save();
 

--- a/library/L1_Peripheral/test/unity_test.cpp
+++ b/library/L1_Peripheral/test/unity_test.cpp
@@ -18,7 +18,7 @@
 // =============================================================================
 // stm32f10x implemenation test
 // =============================================================================
-// #include "L1_Peripheral/stm32f10x/test/system_controller_test.cpp"  // NOLINT
+#include "L1_Peripheral/stm32f10x/test/system_controller_test.cpp"  // NOLINT
 #include "L1_Peripheral/stm32f10x/test/gpio_test.cpp"               // NOLINT
 #include "L1_Peripheral/stm32f10x/test/pin_test.cpp"                // NOLINT
 #include "L1_Peripheral/stm32f10x/test/uart_test.cpp"               // NOLINT


### PR DESCRIPTION
Convert the usage of std::thread in the stm32f10x system controller test
to VerifyPolling() in order to prevent it from locking up as it has done
in the past, resulting in longer continuous integration times and random
failures of tests.

Resolves #1269
Resolves #1211