### PR TITLE
Migrate from Travis-CI to Github Workflows

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,26 @@
+name: presubmit
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+jobs:
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+  presubmit:
+    # Name the Job
+    name: Presubmit
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Installer
+        runs: ./setup
+
+      # Runs the Super-Linter action
+      - name: Run Presubmit
+        runs: cd projects/continuous_integration/
+        runs: make presubmit


### PR DESCRIPTION
Travis-CI has changed its payment scheme for open source giving a limit
to the number of minutes that can be used for testing. There is, as far
as I know, no way to pay for more credits without subscribing to a
monthly fee. In order to get a continous integration system back, the
decision to move to Github workflows was decided.