### PR TITLE
Change -idirafter to -isystem for Clang Tidy

### DIFF
--- a/makefile
+++ b/makefile
@@ -197,13 +197,15 @@ ifeq ($(UNAME_S),Darwin)
 	OS := osx
 endif
 
-TOOLCHAIN_DIR  = $(SJSU_DEV2_BASE)/tools/gcc-arm-none-eabi-nano-exceptions/$(OS)
-OS_TOOLS_DIR     =
-SJCLANG          = $(shell cd $(OS_TOOLS_DIR)/clang+llvm-*/ ; pwd)
-SJARMGCC         = $(shell cd $(TOOLCHAIN_DIR)/gcc-arm-none-eabi-*/ ; pwd)
-SJ2_OPENOCD_DIR  = $(SJSU_DEV2_BASE)/tools/$(OS)/openocd
-OPENOCD          = $(SJ2_OPENOCD_DIR)/bin/openocd
-GDBINIT_PATH     = $(SJSU_DEV2_BASE)/tools/gdb_dashboard/gdbinit
+OS_TOOLS_DIR    = $(SJ2_TOOLS_DIR)/$(OS)
+SJCLANG         = $(shell cd $(OS_TOOLS_DIR)/clang+llvm-*/ ; pwd)
+
+GCC_ROOT_DIR    = $(SJ2_TOOLS_DIR)/gcc-arm-none-eabi-nano-*/$(OS)
+SJARMGCC        = $(shell cd $(GCC_ROOT_DIR)/gcc-arm-none-eabi-*/ ; pwd)
+
+SJ2_OPENOCD_DIR = $(SJ2_TOOLS_DIR)/$(OS)/openocd
+OPENOCD         = $(SJ2_OPENOCD_DIR)/bin/openocd
+GDBINIT_PATH    = $(SJ2_TOOLS_DIR)/gdb_dashboard/gdbinit
 
 # ==============================================================================
 # Macro for building static library files
@@ -267,7 +269,7 @@ HOST_SYMBOLIZER    = $(SJCLANG)/bin/llvm-symbolizer
 LINKER_SCRIPT   ?= $(LIBRARY_DIR)/L0_Platform/$(PLATFORM)/linker.ld
 
 INCLUDES        := $(addsuffix ", $(addprefix -I", $(INCLUDES)))
-SYSTEM_INCLUDES := $(addsuffix ", $(addprefix -idirafter", $(SYSTEM_INCLUDES)))
+SYSTEM_INCLUDES := $(addsuffix ", $(addprefix -isystem", $(SYSTEM_INCLUDES)))
 OBJECTS         := $(addprefix $(SJ2_OBJECT_DIR)/, $(SOURCES:=.o))
 
 CFLAGS          := -O$(OPTIMIZE) -D PLATFORM=$(PLATFORM) \

--- a/projects/continuous_integration/post_library.mk
+++ b/projects/continuous_integration/post_library.mk
@@ -24,6 +24,7 @@ MAC_TIDY_INCLUDES = \
 		-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
 		-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/
 
+
 # ==============================================================================
 # Targets
 # ==============================================================================


### PR DESCRIPTION
-isystem works across clang and gcc, but -idirafter only works for gcc
which result in clang tidy missing the span and other include
directories resulting in a quick failure of `make tidy` target.