### PR TITLE
Combine make flash & program

### DIFF
--- a/documentation/introduction/flashing.md
+++ b/documentation/introduction/flashing.md
@@ -82,24 +82,25 @@ make application PLATFORM=stm32f10x OPTIMIZE=s
 
 ## Step 2. Programming Devices
 
-There are 2 ways to program a device, using `make flash` and using
-`make program`. `make flash` will tend to use serial, USB or some other specific
-protocol for the device. This currently only works for the SJTwo and SJOne
-boards. `make program` is used to program devices using a debugger and is the
-standard choice for programming devices that are not the SJTwo or SJOne boards.
-
-Programming a device is nearly the same command as build an application but you
-remove the "application" target name with "flash" or "program. Like so:
+Programming a device is nearly the same command as build an application but
+replace the "application" target name with "flash". Like so:
 
 ```bash
 make flash
 ```
 
+The above command only works for the LPC series of microcontrollers which are
+used for the SJTwo and SJOne boards.
+
+In general, you will want to program a device using a JTAG or SWD debugger
+such as an `stlink` debugger. To flash using a JTAG device, you need to supply
+the `JTAG` parameter in the command like so:
+
 ```bash
-make program PLATFORM=stm32f10x JTAG=stlink
+make flash JTAG=stlink
 ```
 
-Notice that we need to supply a `JTAG=stlink` field here in order to select
-which debugger we are using. Another option would be the `JTAG=jlink` option, if
-you are using a Segger JLink debugger. `stlink` is more commonly used, as it is
-cheaper.
+Other options for `JTAG` are available such as `JTAG=jlink` or `JTAG=buspirate`.
+`make flash` supports all debug devices that OpenOCD supports. `stlink` is the
+preferred choice for SJSU-Dev2 users as it is cheaper and more widely available
+on Amazon, Ebay, AliExpress and other online stores.

--- a/library/L0_Platform/msp432p401r/msp432p401r.mk
+++ b/library/L0_Platform/msp432p401r/msp432p401r.mk
@@ -8,7 +8,4 @@ $(eval $(call BUILD_LIBRARY,libmsp432p401r,LIBRARY_MSP432P401R))
 
 include $(LIBRARY_DIR)/L0_Platform/arm_cortex/m4/m4.mk
 
-platform-flash:
-	echo -n "Factory bootloader flashing support is not currently supported for "
-	echo "msp432p401r."
-	echo "Please use 'make jtag-flash' instead"
+$(eval $(call DEFAULT_PLATFORM_FLASH))

--- a/library/L0_Platform/stm32f10x/stm32f10x.mk
+++ b/library/L0_Platform/stm32f10x/stm32f10x.mk
@@ -8,7 +8,4 @@ $(eval $(call BUILD_LIBRARY,libstm32f10x,LIBRARY_STM32F10X))
 
 include $(LIBRARY_DIR)/L0_Platform/arm_cortex/m3/m3.mk
 
-platform-flash:
-	echo -n "Factory bootloader flashing support is not currently supported for "
-	echo "stm32f10x"
-	echo "Please use 'make jtag-flash' instead"
+$(eval $(call DEFAULT_PLATFORM_FLASH))

--- a/library/L0_Platform/stm32f4xx/stm32f4xx.mk
+++ b/library/L0_Platform/stm32f4xx/stm32f4xx.mk
@@ -8,7 +8,4 @@ $(eval $(call BUILD_LIBRARY,libstm32f4xx,LIBRARY_STM32F4XX))
 
 include $(LIBRARY_DIR)/L0_Platform/arm_cortex/m4/m4.mk
 
-platform-flash:
-	echo -n "Factory bootloader flashing support is not currently supported for "
-	echo "stm32f4xx."
-	echo "Please use 'make jtag-flash' instead"
+$(eval $(call DEFAULT_PLATFORM_FLASH))


### PR DESCRIPTION
Although these two targets will still be supported seperately for direct
control, make flash will be the defacto target for flashing devices.

The `make flash` command will either utilize OpenOCD JTAG/SWD
programming if the `JTAG=...` argument is supplied.

If JTAG is not present then `platform-flash` will be used.

Documentation has been updated to reflect this new stance.