### PR TITLE
Exclude unit tests files from coverage

### DIFF
--- a/makefile
+++ b/makefile
@@ -426,6 +426,7 @@ coverage:
 		-e "$(LIBRARY_DIR)/L0_Platform" \
 		-e "$(LIBRARY_DIR)/L4_Testing" \
 		-e "$(LIBRARY_DIR)/newlib" \
+		-e "$(LIBRARY_DIR)/.*_test.cpp" \
 		-e "$(LIBRARY_DIR)/third_party"
 
 	@printf '$(GREEN)DONE!$(RESET)\n'


### PR DESCRIPTION
This will help indicate the true coverage of SJSU-Dev2's core
software testable libraries such as L1, L2, L3, and utility.