### PR TITLE
Add OPTIMIZE to build path

### DIFF
--- a/documentation/introduction/flashing.md
+++ b/documentation/introduction/flashing.md
@@ -104,3 +104,12 @@ Other options for `JTAG` are available such as `JTAG=jlink` or `JTAG=buspirate`.
 `make flash` supports all debug devices that OpenOCD supports. `stlink` is the
 preferred choice for SJSU-Dev2 users as it is cheaper and more widely available
 on Amazon, Ebay, AliExpress and other online stores.
+
+```bash
+make flash JTAG=stlink OPTIMIZE=s
+```
+
+Note the usage of `OPTIMIZE=s` here. This specifies that you want to flash the
+firmware with the optimization level `s` which stands for size optimized. If you
+want to compile a binary to the smallest size, like in this example, and flash
+that same binary to the MCU, you must include this flag.

--- a/makefile
+++ b/makefile
@@ -11,6 +11,7 @@ CYAN    = $(shell echo "\x1B[36;1m")
 WHITE   = $(shell echo "\x1B[37;1m")
 RESET   = $(shell echo "\x1B[0m")
 DIVIDER = ======================================================================
+DIVIDER2 = ---------------------------------------------------------------------
 
 # ==============================================================================
 # Report an error if SJSU_DEV2_BASE does not exist
@@ -56,6 +57,16 @@ MAKECMDGOALS = help
 endif
 
 # ==============================================================================
+# Programming Parameters
+#
+# Variables used program and flash devices.
+# ==============================================================================
+OPTIMIZE        ?= g
+# JTAG          ?= stlink
+# PORT          ?=
+# OPENOCD_CONFIG
+
+# ==============================================================================
 # Directories
 # ==============================================================================
 
@@ -64,7 +75,7 @@ SJ2_SOURCE_DIR           = source
 SJ2_LOCAL_LIBRARY_DIR    = library
 SJ2_CURRENT_DIRECTORY    = $(shell pwd)
 SJ2_TOOLS_DIR            = $(SJSU_DEV2_BASE)/tools
-SJ2_BUILD_DIR            = $(SJ2_BUILD_DIRECTORY_NAME)/$(PLATFORM)
+SJ2_BUILD_DIR            = $(SJ2_BUILD_DIRECTORY_NAME)/$(PLATFORM)/$(OPTIMIZE)
 SJ2_OBJECT_DIR           = $(SJ2_BUILD_DIR)/objects
 SJ2_TEST_EXECUTABLE_DIR  = $(SJ2_BUILD_DIRECTORY_NAME)/test
 SJ2_TEST_OBJECT_DIR      = $(SJ2_TEST_EXECUTABLE_DIR)/objects
@@ -110,23 +121,6 @@ SJ2_DEFAULT_LDFLAGS  = -fexceptions -Wl,--gc-sections -Wl,-Map,"$(MAP)" \
                        --specs=nano.specs --specs=rdimon.specs \
                        -Wl,--wrap=snprintf \
 
-											# -Wl,--wrap=__cxa_get_globals \
-                       -Wl,--wrap=__cxa_allocate_exception \
-                       -Wl,--wrap=__cxa_free_exception \
-											-Wl,--wrap=__cxa_get_globals_fast \
-											-Wl,--wrap=__cxa_atexit \
-											-Wl,--wrap=__cxa_call_terminate \
-											-Wl,--wrap=__cxa_begin_cleanup \
-											-Wl,--wrap=__cxa_end_catch \
-											-Wl,--wrap=__cxa_begin_catch \
-											-Wl,--wrap=__cxa_rethrow \
-											-Wl,--wrap=__cxa_type_match \
-											-Wl,--wrap=__cxa_call_unexpected \
-											-Wl,--wrap=__cxa_throw \
-											-Wl,--wrap=__gnu_unwind_execute \
-											-Wl,--wrap=_Unwind_VRS_Pop \
-											-Wl,--wrap=__gnu_unwind_pr_common
-
 SJ2_DEFAULT_SOURCES  = source/main.cpp
 
 # ==============================================================================
@@ -163,7 +157,6 @@ SJ2_DEFAULT_TEST_FLAGS := \
 WARNING_BECOME_ERRORS ?=
 
 PLATFORM        ?= $(SJ2_DEFAULT_PLATFORM)
-OPTIMIZE        ?= g
 INCLUDES        ?= $(SJ2_DEFAULT_INCLUDES)
 SYSTEM_INCLUDES ?=
 SOURCES         ?= $(SJ2_DEFAULT_SOURCES)
@@ -173,15 +166,6 @@ LDFLAGS         ?= $(SJ2_DEFAULT_LDFLAGS)
 SOURCES         ?= $(SJ2_DEFAULT_SOURCES)
 TESTS           ?= $(SJ2_DEFAULT_TESTS)
 TEST_ARGUMENTS  ?=
-
-# ==============================================================================
-# Programming Parameters
-#
-# Variables used program and flash devices.
-# ==============================================================================
-# JTAG            ?= stlink
-# PORT            ?= /dev/ttyUSB0
-# OPENOCD_CONFIG
 
 # ==============================================================================
 # Tool chain paths
@@ -209,9 +193,9 @@ GDBINIT_PATH    = $(SJ2_TOOLS_DIR)/gdb_dashboard/gdbinit
 # Macro for building static library files
 # ==============================================================================
 
-SJ2_CORE_STATIC_LIBRARY = $(SJ2_OBJECT_DIR)/libsjsudev2.a
+SJ2_CORE_STATIC_LIBRARY = $(SJ2_OBJECT_DIR)/$(OPTIMIZE)/libsjsudev2.a
 SJ2_STATIC_LIBRARY_ROOT = $(LIBRARY_DIR)/static_libraries
-SJ2_STATIC_LIBRARY_DIR  = $(LIBRARY_DIR)/static_libraries/$(PLATFORM)
+SJ2_STATIC_LIBRARY_DIR  = $(SJ2_STATIC_LIBRARY_ROOT)/$(PLATFORM)/$(OPTIMIZE)
 
 define BUILD_LIBRARY
 
@@ -311,9 +295,9 @@ endif
 # Rebuild source files if header file dependencies changes
 # ==============================================================================
 
--include       $(OBJECTS:.o=.d)
--include       $(SJ2_TEST_OBJECTS:.o=.d)
--include       $(LINKER_SCRIPT:.ld=.d)
+-include $(OBJECTS:.o=.d)
+-include $(SJ2_TEST_OBJECTS:.o=.d)
+-include $(LINKER_SCRIPT:.ld=.d)
 
 # ==============================================================================
 # Phony Targets Declaration
@@ -335,12 +319,20 @@ help:
 	GREP_COLOR='1;34' grep --color=always -e "==" -e '**'
 
 
+start-message:
+	@printf "$(BLUE)$(DIVIDER2)$(RESET)\n"
+	@printf "$(BLUE)PLATFORM = $(RESET)'$(PLATFORM)' "
+	@printf "$(BLUE)OPTIMIZE = $(RESET)'$(OPTIMIZE)' "
+	@printf "$(BLUE)JTAG = $(RESET)'$(JTAG)'\n"
+	@printf "$(BLUE)$(DIVIDER2)$(RESET)\n"
+
+
 # ==============================================================================
 # Application Build Targets
 # ==============================================================================
 
 
-application: | $(HEX) $(BINARY) $(LIST) $(SRC_LIST) $(SIZE)
+application: | start-message $(HEX) $(BINARY) $(LIST) $(SRC_LIST) $(SIZE)
 
 
 # ==============================================================================
@@ -355,14 +347,14 @@ jtag-flash: application
 			-c "program \"$(EXECUTABLE)\" reset exit"
 
 
-flash: | application $(FLASHING_RECIPE)
+flash: | start-message application $(FLASHING_RECIPE)
 
 
 program: jtag-flash
 execute: flash
 
 
-debug:
+debug: start-message
 	@printf '$(MAGENTA)Starting firmware debug...$(RESET)\n'
 	@$(SJ2_TOOLS_DIR)/launch_openocd_gdb.sh \
 			"$(DEVICE_GDB)" \
@@ -374,7 +366,7 @@ debug:
 			"$(OPENOCD_CONFIG)" \
 
 
-debug-test:
+debug-test: start-message
 	gdb -ex "source $(GDBINIT_PATH)" $(TEST_EXECUTABLE)
 
 
@@ -387,12 +379,12 @@ stacktrace:
 # ==============================================================================
 
 
-clean:
+clean: start-message
 	rm -fr $(SJ2_BUILD_DIRECTORY_NAME)
 	@mkdir -p $(SJ2_BUILD_DIRECTORY_NAME)
 
 
-library-clean:
+library-clean: start-message
 	rm -fr $(SJ2_STATIC_LIBRARY_ROOT)
 	@mkdir -p $(SJ2_STATIC_LIBRARY_ROOT)
 
@@ -407,9 +399,6 @@ purge: | clean library-clean
 
 clean-coverage:
 	@rm -f $(SJ2_COVERAGE_FILES) 2> /dev/null
-
-
-
 
 
 coverage:


### PR DESCRIPTION
Adding OPTIMIZE to the build path has the sole benefit of removing the
need for users to run `purge` everytime they want to build their
application with a different optimization level. This results in
a quality of life improvement due to:

1. Reduced compile times (can reuse previously generated libraries that
   fit the platform and the optimization level)
2. Improved expectations regarding debugging (compiling with 'g' but
   previously compiled library files were compiled with 3 making
   debugging an unexpected disaster between code that was highly
   optimized and code that is optimized for debugging).

This change does, consume more space user's disk based on the
permutation of platforms and optimization levels used.

Additional Updates:

- At the start of the targets application, flash, and debug a
  "start-message" prompt will appear to give information about the
  target settings such as which PLATFORM, OPTIMIZE, and JTAG used.
- A bit of cleanup
- Documentation updated to reflect these changes to the makefile