### PR TITLE
Set adapter speed to 1MHz for stm31f10x

### DIFF
--- a/library/L0_Platform/stm32f10x/stm32f10x.cfg
+++ b/library/L0_Platform/stm32f10x/stm32f10x.cfg
@@ -3,6 +3,6 @@ source [find target/stm32f1x.cfg]
 
 # JTAG Clock rate in kHz
 # lower this if you are getting glitches
-adapter_khz 4000
+adapter_khz 1000
 
 # $_TARGETNAME configure -rtos FreeRTOS


### PR DESCRIPTION
Although 4Mhz does in fact work, it does result in problem with older
host computers and some stlink hardware.