### PR TITLE
Fix always succeeding brew install

### DIFF
--- a/setup
+++ b/setup
@@ -114,8 +114,8 @@ function install_mac_osx_prerequisites() {
   echo " ───────────────────────────────────────────────────┐"
   echo "               Installing Homebrew                   "
   echo "└─────────────────────────────────────────────────── "
-  which -s brew
   local brew_install=0
+  which -s brew
   if [[ $? -ne "0" ]]; then
     # Install Homebrew
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"


### PR DESCRIPTION
A misplaced assignment of a local variable, in this case brew_install=0,
will always result in $? returning 0 which will always succeed. This
needs to be fixed to make sure that $? is referring to `which -s brew`.