### PR TITLE
API 4

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,6 +11,7 @@
         "aclk",
         "ACMD",
         "ADCR",
+        "ADCs",
         "ADGDR",
         "ADINTEN",
         "ADRMATCH",

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: 🧹 Lint
         working-directory: projects/continuous_integration
-        run: make lint
+        run: make lint 1> /dev/null
 
       - name: 🔤 Spellcheck
         working-directory: projects/continuous_integration

--- a/api/sjsu-dev2-doxygen.conf
+++ b/api/sjsu-dev2-doxygen.conf
@@ -59,10 +59,10 @@ LOOKUP_CACHE_SIZE      = 0
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
-EXTRACT_ALL            = YES
+EXTRACT_ALL            = NO
 EXTRACT_PRIVATE        = NO
 EXTRACT_PACKAGE        = NO
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 EXTRACT_LOCAL_CLASSES  = YES
 EXTRACT_LOCAL_METHODS  = NO
 EXTRACT_ANON_NSPACES   = NO
@@ -191,7 +191,6 @@ CLANG_OPTIONS          =
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = YES
-COLS_IN_ALPHA_INDEX    = 5
 IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output

--- a/demos/arm_cortex/system_timer/source/main.cpp
+++ b/demos/arm_cortex/system_timer/source/main.cpp
@@ -1,13 +1,13 @@
 #include "L1_Peripheral/cortex/system_timer.hpp"
 #include "L1_Peripheral/inactive.hpp"
-#include "L1_Peripheral/system_controller.hpp"
 #include "L1_Peripheral/lpc17xx/system_controller.hpp"
 #include "L1_Peripheral/lpc40xx/system_controller.hpp"
 #include "L1_Peripheral/msp432p401r/system_controller.hpp"
 #include "L1_Peripheral/stm32f10x/system_controller.hpp"
 #include "L1_Peripheral/stm32f4xx/system_controller.hpp"
-#include "utility/log.hpp"
+#include "L1_Peripheral/system_controller.hpp"
 #include "utility/build_info.hpp"
+#include "utility/log.hpp"
 
 void DemoSystemIsr()
 {
@@ -54,10 +54,9 @@ int main()
   sjsu::SystemController::ResourceID system_timer_id = GetSystemTimerID();
   sjsu::cortex::SystemTimer system_timer(system_timer_id);
 
+  system_timer.settings.callback  = DemoSystemIsr;
+  system_timer.settings.frequency = 10_Hz;
   system_timer.Initialize();
-  system_timer.ConfigureCallback(DemoSystemIsr);
-  system_timer.ConfigureTickFrequency(10_Hz);
-  system_timer.Enable();
 
   sjsu::LogInfo("Halting any action.");
   return 0;

--- a/demos/msp432p401r/blinker/source/main.cpp
+++ b/demos/msp432p401r/blinker/source/main.cpp
@@ -10,9 +10,8 @@ int main()
   sjsu::LogInfo("Starting MSP432P401R LED Blinker Demo...");
 
   // Configure the on-board P1.0 LED to be initially turned on.
-  sjsu::msp432p401r::Gpio p1_0(1, 0);
+  sjsu::msp432p401r::Gpio & p1_0 = sjsu::msp432p401r::GetGpio<1, 0>();
   p1_0.Initialize();
-  p1_0.Enable();
   p1_0.SetAsOutput();
   p1_0.SetHigh();
 

--- a/demos/msp432p401r/system_controller/source/main.cpp
+++ b/demos/msp432p401r/system_controller/source/main.cpp
@@ -1,7 +1,7 @@
 #include <cstdio>
 
-#include "L0_Platform/startup.hpp"
 #include "L0_Platform/msp432p401r/msp432p401r.h"
+#include "L0_Platform/startup.hpp"
 #include "L1_Peripheral/cortex/system_timer.hpp"
 #include "L1_Peripheral/msp432p401r/gpio.hpp"
 #include "L1_Peripheral/msp432p401r/pin.hpp"
@@ -13,7 +13,7 @@ namespace
 {
 void ConfigureSystemClocks()
 {
-  auto & system_controller    = sjsu::SystemController::GetPlatformController();
+  auto & system_controller   = sjsu::SystemController::GetPlatformController();
   auto & clock_configuration = system_controller.GetClockConfiguration<
       sjsu::msp432p401r::SystemController::ClockConfiguration_t>();
   clock_configuration.dco.frequency = 12_MHz;
@@ -35,20 +35,24 @@ void ConfigureClockOutPins()
   constexpr uint8_t kClockOutFunction = 0b101;
 
   // Configure P4.2 to output ACLK
-  sjsu::msp432p401r::Pin aclk_out_pin(4, 2);
-  aclk_out_pin.ConfigureFunction(kClockOutFunction);
+  sjsu::msp432p401r::Pin & aclk_out_pin = sjsu::msp432p401r::GetPin<4, 2>();
+  aclk_out_pin.settings.function        = kClockOutFunction;
+  aclk_out_pin.Initialize();
 
   // Configure P4.3 to output MCLK
-  sjsu::msp432p401r::Pin mclk_out_pin(4, 3);
-  mclk_out_pin.ConfigureFunction(kClockOutFunction);
+  sjsu::msp432p401r::Pin & mclk_out_pin = sjsu::msp432p401r::GetPin<4, 3>();
+  mclk_out_pin.settings.function        = kClockOutFunction;
+  mclk_out_pin.Initialize();
 
   // Configure P4.4 to output HSMCLK
-  sjsu::msp432p401r::Pin hsmclk_out_pin(4, 4);
-  hsmclk_out_pin.ConfigureFunction(kClockOutFunction);
+  sjsu::msp432p401r::Pin & hsmclk_out_pin = sjsu::msp432p401r::GetPin<4, 4>();
+  hsmclk_out_pin.settings.function        = kClockOutFunction;
+  hsmclk_out_pin.Initialize();
 
   // Configure P7.0 to output SMCLK
-  sjsu::msp432p401r::Pin smclk_out_pin(7, 0);
-  smclk_out_pin.ConfigureFunction(kClockOutFunction);
+  sjsu::msp432p401r::Pin & smclk_out_pin = sjsu::msp432p401r::GetPin<7, 0>();
+  smclk_out_pin.settings.function        = kClockOutFunction;
+  smclk_out_pin.Initialize();
 }
 }  // namespace
 
@@ -57,7 +61,8 @@ int main()
   sjsu::LogInfo("Starting MSP432P401R System Controller Demo...");
 
   // Configure the on-board P1.0 LED to be initially turned on.
-  sjsu::msp432p401r::Gpio p1_0(1, 0);
+  sjsu::msp432p401r::Gpio & p1_0 = sjsu::msp432p401r::GetGpio<1, 0>();
+  p1_0.Initialize();
   p1_0.SetAsOutput();
   p1_0.SetHigh();
 

--- a/demos/multiplatform/dual_platforms/source/main.cpp
+++ b/demos/multiplatform/dual_platforms/source/main.cpp
@@ -67,10 +67,6 @@ int main()
   button.Initialize();
   led_gpio->Initialize();
 
-  sjsu::LogInfo("Enable...");
-  button.Enable();
-  led_gpio->Enable();
-
   sjsu::LogInfo("Use...");
   led_gpio->SetAsOutput();
 

--- a/demos/multiplatform/esp8266/source/main.cpp
+++ b/demos/multiplatform/esp8266/source/main.cpp
@@ -29,15 +29,14 @@ int main()
   {
     sjsu::LogInfo("Current Platform STM32F10x...");
     // Giving UART a massive 1kB receive buffer to make we don't lose any data.
-    static sjsu::stm32f10x::Uart<1024> uart2(
-        sjsu::stm32f10x::UartBase::Port::kUart2);
-    uart = &uart2;
+    static auto & uart2 = sjsu::stm32f10x::GetUart<2, 1024>();
+    uart                = &uart2;
   }
   else if constexpr (sjsu::build::kPlatform == sjsu::build::Platform::lpc40xx)
   {
     sjsu::LogInfo("Current Platform LPC40xx...");
-    static sjsu::lpc40xx::Uart uart3(sjsu::lpc40xx::Uart::Port::kUart3);
-    uart = &uart3;
+    static auto & uart3 = sjsu::lpc40xx::GetUart<3>();
+    uart                = &uart3;
   }
   else
   {
@@ -54,9 +53,6 @@ int main()
   // initialize and enable the ESP module.
   sjsu::LogInfo("Initializing Esp8266 module...");
   esp.Initialize();
-
-  sjsu::LogInfo("Enabling Esp8266 module...");
-  esp.Enable();
 
   while (true)
   {

--- a/demos/sjone/light_sensor/source/main.cpp
+++ b/demos/sjone/light_sensor/source/main.cpp
@@ -11,18 +11,18 @@ int main()
   constexpr units::impedance::ohm_t kPullDownResistance = 10'000_Ohm;
 
   // The SJOne board uses ADC Channel 0.2, P0.25 for the light sensor
-  sjsu::lpc17xx::Adc adc2(sjsu::lpc17xx::AdcChannel::kChannel2);
+  sjsu::lpc17xx::Adc & adc2 = sjsu::lpc17xx::GetAdc<2>();
 
   sjsu::Temt6000x01 light_sensor(adc2, kPullDownResistance);
   light_sensor.Initialize();
-  light_sensor.Enable();
 
   while (true)
   {
     auto lux     = light_sensor.GetIlluminance();
     auto percent = light_sensor.GetPercentageBrightness() * 100;
 
-    sjsu::LogInfo("Lux: %.4f, Brightness Percentage: %.2f%%", lux.to<double>(),
+    sjsu::LogInfo("Lux: %.4f, Brightness Percentage: %.2f%%",
+                  lux.to<double>(),
                   static_cast<double>(percent));
 
     sjsu::Delay(1s);

--- a/demos/sjone/parallel_lcd/source/main.cpp
+++ b/demos/sjone/parallel_lcd/source/main.cpp
@@ -10,17 +10,21 @@ int main()
   sjsu::LogInfo("Starting Parallel LCD Demo");
 
   // set up control pins for lcd
-  sjsu::lpc17xx::Gpio rs(0, 29);  // RS:    Register Select
-  sjsu::lpc17xx::Gpio rw(0, 30);  // RW:    Read / Write
-  sjsu::lpc17xx::Gpio e(1, 19);   // E:     Chip Enable
-  sjsu::lpc17xx::Gpio d7(2, 0);   // D7-D0: Parallel Data Pins
-  sjsu::lpc17xx::Gpio d6(2, 1);
-  sjsu::lpc17xx::Gpio d5(2, 2);
-  sjsu::lpc17xx::Gpio d4(2, 3);
-  sjsu::lpc17xx::Gpio d3(2, 4);
-  sjsu::lpc17xx::Gpio d2(2, 5);
-  sjsu::lpc17xx::Gpio d1(2, 6);
-  sjsu::lpc17xx::Gpio d0(2, 7);
+  // RS: Register Select
+  sjsu::lpc17xx::Gpio & rs = sjsu::lpc17xx::GetGpio<0, 29>();
+  // RW: Read / Write
+  sjsu::lpc17xx::Gpio & rw = sjsu::lpc17xx::GetGpio<0, 30>();
+  // E: Chip Enable
+  sjsu::lpc17xx::Gpio & e = sjsu::lpc17xx::GetGpio<1, 19>();
+  // D7-D0: Parallel Data Pins
+  sjsu::lpc17xx::Gpio & d7 = sjsu::lpc17xx::GetGpio<2, 0>();
+  sjsu::lpc17xx::Gpio & d6 = sjsu::lpc17xx::GetGpio<2, 1>();
+  sjsu::lpc17xx::Gpio & d5 = sjsu::lpc17xx::GetGpio<2, 2>();
+  sjsu::lpc17xx::Gpio & d4 = sjsu::lpc17xx::GetGpio<2, 3>();
+  sjsu::lpc17xx::Gpio & d3 = sjsu::lpc17xx::GetGpio<2, 4>();
+  sjsu::lpc17xx::Gpio & d2 = sjsu::lpc17xx::GetGpio<2, 5>();
+  sjsu::lpc17xx::Gpio & d1 = sjsu::lpc17xx::GetGpio<2, 6>();
+  sjsu::lpc17xx::Gpio & d0 = sjsu::lpc17xx::GetGpio<2, 7>();
 
   std::array<sjsu::Gpio *, 8> data_pins = {
     &d0, &d1, &d2, &d3, &d4, &d5, &d6, &d7,
@@ -40,7 +44,6 @@ int main()
                     data_bus);
 
   lcd.Initialize();
-  lcd.Enable();
 
   sjsu::LogInfo("Drawing text to screen at different locations...");
   lcd.DrawText("Parallel LCD Demo", sjsu::St7066u::CursorPosition_t{ 1, 4 });

--- a/demos/sjone/system_controller/source/main.cpp
+++ b/demos/sjone/system_controller/source/main.cpp
@@ -42,10 +42,11 @@ int main()
   //
   // NOTE: P1.27 may not be available for the 80-pin package option of the MCU.
   constexpr uint8_t kClockOutFunction = 0b01;
-  sjsu::lpc17xx::Pin clock_pin(1, 27);
-  clock_pin.ConfigureFunction(kClockOutFunction);
-  clock_pin.ConfigureFloating();
-  clock_pin.ConfigureAsOpenDrain(false);
+  sjsu::lpc17xx::Pin & clock_pin = sjsu::lpc17xx::GetPin<1, 27>();
+  clock_pin.settings.function = kClockOutFunction;
+  clock_pin.settings.Floating();
+  clock_pin.settings.open_drain = false;
+  clock_pin.Initialize();
 
   // Clockout Configuration register (CLKOUTCFG) bit masks,
   constexpr uint8_t kClockOutEnableBit = 8;

--- a/demos/sjone/temperature_sensor/source/main.cpp
+++ b/demos/sjone/temperature_sensor/source/main.cpp
@@ -7,11 +7,10 @@ int main()
 {
   sjsu::LogInfo("Starting LPC176x/5x Temperature Sensor Example...");
 
-  sjsu::lpc17xx::I2c i2c2(sjsu::lpc17xx::I2cBus::kI2c2);
-  sjsu::Tmp102 temperature_sensor(i2c2);
+  sjsu::lpc40xx::I2c & i2c = sjsu::lpc40xx::GetI2c<2>();
+  sjsu::Tmp102 temperature_sensor(i2c);
 
   temperature_sensor.Initialize();
-  temperature_sensor.Enable();
 
   while (true)
   {

--- a/demos/sjtwo/adc/source/main.cpp
+++ b/demos/sjtwo/adc/source/main.cpp
@@ -12,25 +12,20 @@ int main()
 
   sjsu::LogInfo("Creating ADC object and selecting ADC channel 4 & 5");
   sjsu::LogInfo("ADC channel 4 is connected to pin P1.30");
-  sjsu::lpc40xx::Adc adc4(sjsu::lpc40xx::Adc::Channel::kChannel4);
+  sjsu::lpc40xx::Adc & adc4 = sjsu::lpc40xx::GetAdc<4>();
 
   sjsu::LogInfo("ADC channel 5 is connected to pin P1.31");
-  sjsu::lpc40xx::Adc adc5(sjsu::lpc40xx::Adc::Channel::kChannel5);
+  sjsu::lpc40xx::Adc & adc5 = sjsu::lpc40xx::GetAdc<5>();
 
   sjsu::LogInfo(
       "If you leave a channel disconnected, then the pin will be in a floating "
       "state, and in this state, the voltage read from this pin will be "
       "random.");
 
-  sjsu::LogInfo("Initializing ADCs ...");
+  sjsu::LogInfo("Initializing ADC4 and ADC5 ...");
   adc5.Initialize();
   adc4.Initialize();
-  sjsu::LogInfo("Initializing ADCs Complete!");
-
-  sjsu::LogInfo("Enabling ADCs ...");
-  adc5.Enable();
-  adc4.Enable();
-  sjsu::LogInfo("Enabling ADCs Complete!");
+  sjsu::LogInfo("Initializing ADC4 and ADC5 Complete!");
 
   sjsu::LogInfo("Apply voltage from 0 to 3.3V. DO NOT GO BEYOND THIS LIMIT!");
 

--- a/demos/sjtwo/button/source/main.cpp
+++ b/demos/sjtwo/button/source/main.cpp
@@ -13,15 +13,12 @@ int main()
   sjsu::lpc40xx::Gpio button_gpio2(0, 30);
   sjsu::lpc40xx::Gpio button_gpio3(0, 29);
 
+  button_gpio0.GetPin().settings.PullDown();
+  button_gpio1.GetPin().settings.PullDown();
+
   // Early initialization of gpio2 and gpio3 to set their pull up resistors
   button_gpio0.Initialize();
   button_gpio1.Initialize();
-
-  button_gpio0.GetPin().ConfigurePullDown();
-  button_gpio1.GetPin().ConfigurePullDown();
-
-  button_gpio0.Enable();
-  button_gpio1.Enable();
 
   sjsu::Button button0(button_gpio0);
   sjsu::Button button1(button_gpio1);
@@ -38,17 +35,6 @@ int main()
   button1.Initialize();
   button2.Initialize();
   button3.Initialize();
-
-  sjsu::LogInfo("Enabling LEDs and Buttons...");
-  sjtwo::led0.Enable();
-  sjtwo::led1.Enable();
-  sjtwo::led2.Enable();
-  sjtwo::led3.Enable();
-
-  button0.Enable();
-  button1.Enable();
-  button2.Enable();
-  button3.Enable();
 
   sjsu::LogInfo("Set LEDs as outputs...");
 

--- a/demos/sjtwo/buzzer/source/main.cpp
+++ b/demos/sjtwo/buzzer/source/main.cpp
@@ -11,12 +11,11 @@ int main()
   sjsu::LogInfo("and a volume of 10 percent i.e. 0.1f");
   sjsu::LogInfo("==================================================");
 
-  sjsu::lpc40xx::Pwm pwm_pin(sjsu::lpc40xx::Pwm::Channel::kPwm1);
+  sjsu::lpc40xx::Pwm & pwm_pin = sjsu::lpc40xx::GetPwm<1, 1>();
   sjsu::Buzzer buzzer(pwm_pin);
 
   sjsu::LogInfo("Initializing & Enabling the buzzer...");
   buzzer.Initialize();
-  buzzer.Enable();
 
   sjsu::Delay(1s);
 

--- a/demos/sjtwo/can/source/main.cpp
+++ b/demos/sjtwo/can/source/main.cpp
@@ -5,8 +5,8 @@
 
 int main(void)
 {
-  sjsu::lpc40xx::Can can1(sjsu::lpc40xx::Can::Channel::kCan1);
-  sjsu::lpc40xx::Can can2(sjsu::lpc40xx::Can::Channel::kCan2);
+  sjsu::lpc40xx::Can & can1 = sjsu::lpc40xx::GetCan<1>();
+  sjsu::lpc40xx::Can & can2 = sjsu::lpc40xx::GetCan<2>();
 
   sjsu::LogInfo("CAN application starting...");
   sjsu::LogInfo(
@@ -30,14 +30,6 @@ int main(void)
   sjsu::LogInfo("Initializing CAN 2 with default bit rate of 100 kBit/s...");
   can2.Initialize();
 
-  sjsu::LogInfo("Enabling CAN 1 & CAN 2...");
-  can1.Enable();
-  can2.Enable();
-
-  sjsu::LogInfo("Configuring CAN 1 & CAN 2 baud rates (setting to 100kHz)...");
-  can1.ConfigureBaudRate(100_kHz);
-  can1.ConfigureBaudRate(100_kHz);
-
   sjsu::LogInfo("Starting local self-test for CAN 1...");
   if (can1.SelfTest(146))
   {
@@ -49,7 +41,7 @@ int main(void)
   }
 
   sjsu::LogInfo("Starting local self-test for CAN 2...");
-  if (can1.SelfTest(244))
+  if (can2.SelfTest(244))
   {
     sjsu::LogInfo("CAN 2 self-test" SJ2_HI_BOLD_GREEN " passed!");
   }
@@ -105,14 +97,14 @@ int main(void)
     {
       sjsu::LogInfo("CAN 1 is in a BUS-OFF error state and is disabled!");
       sjsu::LogInfo("Re-enabling CAN 1...");
-      can1.Enable();
+      can1.Initialize();
     }
 
     if (can2.IsBusOff())
     {
       sjsu::LogInfo("CAN 2 is in a BUS-OFF error state and is disabled!");
       sjsu::LogInfo("Re-enabling CAN 2...");
-      can2.Enable();
+      can2.Initialize();
     }
 
     sjsu::Delay(1s);

--- a/demos/sjtwo/clock_configuration/source/main.cpp
+++ b/demos/sjtwo/clock_configuration/source/main.cpp
@@ -17,16 +17,18 @@ int main()
   // Set the function of the pin to output the clock signal
   // This is NOT needed to change the clock rate, but is used to inspect and
   // verify that the clock rate change did work.
-  sjsu::lpc40xx::Pin clock_pin(1, 25);
+  sjsu::lpc40xx::Pin & clock_pin      = sjsu::lpc40xx::GetPin<1, 25>();
   constexpr uint8_t kClockOutFunction = 0b101;
+
+  clock_pin.settings.function   = kClockOutFunction;
+  clock_pin.settings.open_drain = false;
+  clock_pin.settings.Floating();
+
   clock_pin.Initialize();
-  clock_pin.ConfigureFunction(kClockOutFunction);
-  clock_pin.ConfigureFloating();
+
   clock_pin.EnableHysteresis(false);
   clock_pin.SetAsActiveLow(false);
   clock_pin.EnableFastMode(false);
-  clock_pin.ConfigureAsOpenDrain(false);
-  clock_pin.Enable();
   sjsu::LogInfo("Connect a probe to pin P1[25] to measure the clock rate");
 
   constexpr sjsu::bit::Mask kClockSelect = sjsu::bit::MaskFromRange(0, 3);
@@ -73,18 +75,16 @@ int main()
 
     // Change function back to GPIO and pull the signal low to show a transition
     // between clock signals.
-    clock_pin.Enable(false);
-    clock_pin.ConfigureFunction(0);
-    clock_pin.ConfigurePullResistor(sjsu::Pin::Resistor::kPullDown);
-    clock_pin.Enable(true);
+    clock_pin.settings.function = 0;
+    clock_pin.settings.PullDown();
+    clock_pin.Initialize();
 
     sjsu::Delay(1000ms);
 
     // Change the signal back to the CLKOUT signal.
-    clock_pin.Enable(false);
-    clock_pin.ConfigureFunction(kClockOutFunction);
-    clock_pin.ConfigureFloating();
-    clock_pin.Enable(true);
+    clock_pin.settings.function = kClockOutFunction;
+    clock_pin.settings.Floating();
+    clock_pin.Initialize();
 
     config.cpu.clock = SystemController::CpuClockSelect::kSystemClock;
     sjsu::InitializePlatform();

--- a/demos/sjtwo/command_line/source/main.cpp
+++ b/demos/sjtwo/command_line/source/main.cpp
@@ -26,7 +26,7 @@ namespace
 sjsu::CommandList_t<32> command_list;
 // This is an i2c command object which can be added to a CommandLine object and
 // become apart of the list of commands you can run.
-sjsu::lpc40xx::I2c i2c2(sjsu::lpc40xx::I2c::Bus::kI2c2);
+sjsu::lpc40xx::I2c & i2c2 = sjsu::lpc40xx::GetI2c<2>();
 sjsu::I2cCommand i2c_command(i2c2);
 sjsu::RtosCommand rtos_command;
 sjsu::ArmSystemInfoCommand system_command;

--- a/demos/sjtwo/dac/source/main.cpp
+++ b/demos/sjtwo/dac/source/main.cpp
@@ -121,10 +121,9 @@ void StartDemo(sjsu::Dac & dac, std::chrono::nanoseconds input_cycles)
 
 int main()
 {
-  sjsu::lpc40xx::Dac dac;
+  sjsu::lpc40xx::Dac & dac = sjsu::lpc40xx::GetDac<0>();
 
   dac.Initialize();
-  dac.Enable();
 
   sjsu::LogInfo("Hook up pin p0.26 to an oscilloscope to test if it works!");
   sjsu::LogInfo("Starting Output of waves...");

--- a/demos/sjtwo/eeprom/source/main.cpp
+++ b/demos/sjtwo/eeprom/source/main.cpp
@@ -12,9 +12,8 @@ int main(void)
   constexpr uint32_t kAddress   = 0b0110'0011'1000;
 
   sjsu::LogInfo("Initializing & Enabling EEPROM");
-  sjsu::lpc40xx::Eeprom eeprom;
+  sjsu::lpc40xx::Eeprom & eeprom = sjsu::lpc40xx::GetEeprom<0>();
   eeprom.Initialize();
-  eeprom.Enable();
 
   // Payload array
   std::array<uint8_t, kPayloadSize> list;

--- a/demos/sjtwo/factory_test/source/main.cpp
+++ b/demos/sjtwo/factory_test/source/main.cpp
@@ -19,7 +19,6 @@ class FactoryTest
   int RunFactoryTest()
   {
     i2c_.Initialize();
-    i2c_.Enable();
 
     printf("\n=========== STARTING FACTORY TEST ===========\n\n");
 
@@ -49,11 +48,6 @@ class FactoryTest
     sjtwo::led1.Initialize();
     sjtwo::led2.Initialize();
     sjtwo::led3.Initialize();
-
-    sjtwo::led0.Enable();
-    sjtwo::led1.Enable();
-    sjtwo::led2.Enable();
-    sjtwo::led3.Enable();
 
     // Turn on all LEDs if all tests pass else none.
     // LED Test
@@ -98,22 +92,18 @@ class FactoryTest
 
   void OledTest()
   {
-    sjsu::lpc40xx::Spi ssp1(sjsu::lpc40xx::Spi::Bus::kSpi1);
-    sjsu::lpc40xx::Gpio cs(1, 22);
-    sjsu::lpc40xx::Gpio dc(1, 25);
-    sjsu::Gpio & reset = sjsu::GetInactive<sjsu::Gpio>();
+    sjsu::lpc40xx::Spi & spi = sjsu::lpc40xx::GetSpi<1>();
+    sjsu::lpc40xx::Gpio & cs = sjsu::lpc40xx::GetGpio<1, 22>();
+    sjsu::lpc40xx::Gpio & dc = sjsu::lpc40xx::GetGpio<1, 25>();
+    sjsu::Gpio & reset       = sjsu::GetInactive<sjsu::Gpio>();
 
-    Spi spi1(Spi::Bus::kSpi1);
-    Ssd1306 display(spi1, cs, dc, reset);
+    Ssd1306 display(spi, cs, dc, reset);
 
     printf("++++++++++++++++++++++++++++++++++++++\n\n");
     printf("Starting OLED Hardware Test...\n\n");
 
     printf("  Initializing OLED Hardware Test...\n\n");
     display.Initialize();
-
-    printf("  Enabling OLED Hardware Test...\n\n");
-    display.Enable();
 
     printf("  Filling internal screen bitmap...\n\n");
     display.Fill();
@@ -142,17 +132,15 @@ class FactoryTest
   {
     printf("++++++++++++++++++++++++++++++++++++++\n\n");
     printf("Starting External Flash Test...\n\n");
-    Spi spi2(Spi::Bus::kSpi2);
+    sjsu::lpc40xx::Spi & spi2 = sjsu::lpc40xx::GetSpi<2>();
     Gpio cs(1, 10);
 
     cs.SetAsOutput();
     cs.SetHigh();
 
+    spi2.settings.frame_size = SpiSettings_t::FrameSize::kEightBits;
+    spi2.settings.clock_rate = 100_kHz;
     spi2.Initialize();
-    spi2.ConfigureFrameSize(Spi::FrameSize::kEightBits);
-    spi2.ConfigureFrequency(100_kHz);
-    spi2.ConfigureClockMode();
-    spi2.Enable();
 
     cs.SetLow();
     sjsu::Delay(1ms);
@@ -192,7 +180,6 @@ class FactoryTest
     bool result2 = CheckDeviceId(kGestureAddress, kIdAddress, 0xAB);
 
     printf("End of Gesture Sensor Test...\n\n");
-
     return result1 || result2;
   }
 
@@ -205,11 +192,7 @@ class FactoryTest
     // Verify that initialization of peripherals works
     accelerometer.Initialize();
 
-    // Will check the ID and valid state of the device.
-    accelerometer.Enable();
-
     printf("End of Accelerometer Test...\n\n");
-
     return true;
   }
 
@@ -267,7 +250,7 @@ class FactoryTest
   }
 
  private:
-  I2c i2c_ = I2c(I2c::Bus::kI2c2);
+  sjsu::lpc40xx::I2c & i2c_ = sjsu::lpc40xx::GetI2c<2>();
 };
 }  // namespace sjsu::lpc40xx
 

--- a/demos/sjtwo/fatfs/source/main.cpp
+++ b/demos/sjtwo/fatfs/source/main.cpp
@@ -57,7 +57,7 @@ int main()
 
   // Before we can use a storage device, we need to create the storage device we
   // want to use. In this case we want to use the SD card on the SJTwo board.
-  sjsu::lpc40xx::Spi spi2(sjsu::lpc40xx::Spi::Bus::kSpi2);
+  sjsu::lpc40xx::Spi & spi2 = sjsu::lpc40xx::GetSpi<2>();
   sjsu::lpc40xx::Gpio sd_chip_select(1, 8);
   sjsu::lpc40xx::Gpio sd_card_detect(1, 9);
   sjsu::Sd card(spi2, sd_chip_select, sd_card_detect);

--- a/demos/sjtwo/freertos_blinker/source/main.cpp
+++ b/demos/sjtwo/freertos_blinker/source/main.cpp
@@ -27,9 +27,6 @@ void LedToggle(void * parameters)
   sjtwo::led0.Initialize();
   sjtwo::led1.Initialize();
 
-  sjtwo::led0.Enable();
-  sjtwo::led1.Enable();
-
   sjtwo::led0.SetAsOutput();
   sjtwo::led1.SetAsOutput();
 
@@ -56,14 +53,11 @@ void ButtonReader([[maybe_unused]] void * parameters)
   sjsu::LogInfo("Setting up task...");
   sjsu::LogInfo("Initializing SW3...");
 
-  sjsu::lpc40xx::Gpio button_gpio3(0, 29);
+  sjsu::lpc40xx::Gpio & button_gpio3 = sjsu::lpc40xx::GetGpio<0, 29>();
   sjsu::Button switch3(button_gpio3);
 
   sjtwo::led3.Initialize();
   switch3.Initialize();
-
-  sjtwo::led3.Enable();
-  switch3.Enable();
 
   sjtwo::led3.SetAsOutput();
   sjtwo::led3.SetLow();

--- a/demos/sjtwo/gpio/source/main.cpp
+++ b/demos/sjtwo/gpio/source/main.cpp
@@ -8,16 +8,14 @@ int main()
   // pdf labled "SW&LED_Ckts", showing how the circuits that are being used
   // are constructed.
   sjsu::LogInfo("Gpio application starting...");
-  sjsu::lpc40xx::Gpio p1_19(1, 19);
-  sjsu::lpc40xx::Gpio p2_03(2, 3);
+  sjsu::lpc40xx::Gpio & p1_19 = sjsu::lpc40xx::GetGpio<1, 19>();
+  sjsu::lpc40xx::Gpio & p2_03 = sjsu::lpc40xx::GetGpio<2, 3>();
+
+  p1_19.GetPin().settings.PullDown();
 
   p1_19.Initialize();
   p2_03.Initialize();
 
-  p1_19.Enable();
-  p2_03.Enable();
-
-  p1_19.GetPin().ConfigurePullDown();
   p1_19.SetAsInput();
   sjsu::LogInfo("Configured port 1, pin 19 as input");
 

--- a/demos/sjtwo/gpio_frequency_counter/source/main.cpp
+++ b/demos/sjtwo/gpio_frequency_counter/source/main.cpp
@@ -15,7 +15,7 @@ int main()
   // other gpio port and pin number. The best option is a pin connected to a
   // function generator or PWM signal to verify that the frequency counter is
   // operating as expected.
-  sjsu::lpc40xx::Gpio gpio(0, 29);
+  sjsu::lpc40xx::Gpio & gpio = sjsu::lpc40xx::GetGpio<0, 29>();
 
   // Pass the GPIO above into the gpio counter to be controlled by it.
   // The second parameter allows you to change which event triggers a count.
@@ -29,9 +29,6 @@ int main()
 
   // Initialize the hardware.
   frequency_counter.Initialize();
-
-  // Enable the counter.
-  frequency_counter.Enable();
 
   sjsu::LogInfo(
       "With every rising edge of pin P%u.%u, the counter will increase and its "

--- a/demos/sjtwo/gpio_hardware_counter/source/main.cpp
+++ b/demos/sjtwo/gpio_hardware_counter/source/main.cpp
@@ -13,7 +13,7 @@ int main()
   // other gpio port and pin number. The best option is a pin connected to a
   // function generator or PWM signal to verify that the counter is operating as
   // expected.
-  sjsu::lpc40xx::Gpio gpio(0, 29);
+  sjsu::lpc40xx::Gpio & gpio = sjsu::lpc40xx::GetGpio<0, 29>();
 
   // Pass the GPIO above into the gpio counter to be controlled by it.
   // The second parameter allows you to change which event triggers a count.
@@ -23,9 +23,6 @@ int main()
 
   // Initialize the hardware.
   counter.Initialize();
-
-  // Enable the counter.
-  counter.Enable();
 
   sjsu::LogInfo(
       "With every rising edge of pin P%u.%u, the counter will increase and its "

--- a/demos/sjtwo/gpio_interrupts/source/main.cpp
+++ b/demos/sjtwo/gpio_interrupts/source/main.cpp
@@ -5,10 +5,16 @@ int main()
 {
   sjsu::LogInfo("Staring GPIO Interrupt Application...\n");
 
-  sjsu::lpc40xx::Gpio pin0(0, 15);
-  sjsu::lpc40xx::Gpio pin1(2, 9);
-  sjsu::lpc40xx::Gpio pin2(0, 29);
-  sjsu::lpc40xx::Gpio pin3(0, 30);
+  sjsu::lpc40xx::Gpio & pin0 = sjsu::lpc40xx::GetGpio<0, 15>();
+  sjsu::lpc40xx::Gpio & pin1 = sjsu::lpc40xx::GetGpio<2, 9>();
+  sjsu::lpc40xx::Gpio & pin2 = sjsu::lpc40xx::GetGpio<0, 29>();
+  sjsu::lpc40xx::Gpio & pin3 = sjsu::lpc40xx::GetGpio<0, 30>();
+
+  // Connect internal pull up for each pin
+  pin0.GetPin().settings.PullUp();
+  pin1.GetPin().settings.PullUp();
+  pin2.GetPin().settings.PullUp();
+  pin3.GetPin().settings.PullUp();
 
   // Initialize all pins
   pin0.Initialize();
@@ -16,23 +22,12 @@ int main()
   pin2.Initialize();
   pin3.Initialize();
 
-  // Enable all pins
-  pin0.Enable();
-  pin1.Enable();
-  pin2.Enable();
-  pin3.Enable();
-
   // Set as an input
   pin0.SetAsInput();
   pin1.SetAsInput();
   pin2.SetAsInput();
   pin3.SetAsInput();
 
-  // Connect internal pull up for each pin
-  pin0.GetPin().ConfigurePullUp();
-  pin1.GetPin().ConfigurePullUp();
-  pin2.GetPin().ConfigurePullUp();
-  pin3.GetPin().ConfigurePullUp();
 
   sjsu::LogInfo("Setup P0[15] to interrupt on only Falling edges...");
   pin0.AttachInterrupt([]() { sjsu::LogInfo("P0[15] interrupt!"); },

--- a/demos/sjtwo/i2c/source/main.cpp
+++ b/demos/sjtwo/i2c/source/main.cpp
@@ -12,16 +12,8 @@ int main()
   sjsu::LogInfo("I2C Application Starting...");
   sjsu::LogInfo("This example will scan for devices on the I2C Bus 2.");
 
-  sjsu::lpc40xx::I2c i2c(sjsu::lpc40xx::I2c::Bus::kI2c2);
-
-  // Initialize I2C hardware
+  sjsu::lpc40xx::I2c & i2c = sjsu::lpc40xx::GetI2c<2>();
   i2c.Initialize();
-
-  // Set the default 100kHz clock rate.
-  i2c.ConfigureClockRate();
-
-  // Enable i2c hardware
-  i2c.Enable();
 
   sjsu::LogInfo("Starting Scan...");
 

--- a/demos/sjtwo/ltc4150/source/main.cpp
+++ b/demos/sjtwo/ltc4150/source/main.cpp
@@ -14,7 +14,7 @@ int main()
       "that have passed through the sense resistor.");
 
   // Creating GPIO on pin 2.0
-  sjsu::lpc40xx::Gpio tick_pin(2, 0);
+  sjsu::lpc40xx::Gpio & tick_pin = sjsu::lpc40xx::GetGpio<2, 0>();
 
   // Pass the tick_pin GPIO to the gpio counter. We want to keep
   // track of a tick for a falling edge interrupt from the tick_pin.
@@ -33,9 +33,6 @@ int main()
   // Initialize the LTC4150 class, setting two GPIO pins to be outputs and
   // attaching interrupts.
   counter.Initialize();
-
-  // Enable counter
-  counter.Enable();
 
   while (true)
   {

--- a/demos/sjtwo/mma8452q/source/main.cpp
+++ b/demos/sjtwo/mma8452q/source/main.cpp
@@ -8,14 +8,11 @@ int main()
 {
   sjsu::LogInfo("MMA8452q Application Starting...");
 
-  sjsu::lpc40xx::I2c i2c(sjsu::lpc40xx::I2c::Bus::kI2c2);
+  sjsu::lpc40xx::I2c & i2c = sjsu::lpc40xx::GetI2c<2>();
   sjsu::Mma8452q sensor(i2c);
 
-  sjsu::LogInfo("Initializing accelerometer peripherals...");
+  sjsu::LogInfo("Initializing accelerometer...");
   sensor.Initialize();
-
-  sjsu::LogInfo("Enabling accelerometer...");
-  sensor.Enable();
 
   while (true)
   {

--- a/demos/sjtwo/mpu6050/source/main.cpp
+++ b/demos/sjtwo/mpu6050/source/main.cpp
@@ -12,14 +12,11 @@ int main()
       "the accelerometer is accesable, then it will print out the accerometer "
       "readings for each axis");
 
-  sjsu::lpc40xx::I2c i2c(sjsu::lpc40xx::I2c::Bus::kI2c2);
+  sjsu::lpc40xx::I2c & i2c = sjsu::lpc40xx::GetI2c<2>();
   sjsu::Mpu6050 sensor(i2c);
 
-  sjsu::LogInfo("Initializing accelerometer peripherals...");
+  sjsu::LogInfo("Initializing accelerometer...");
   sensor.Initialize();
-
-  sjsu::LogInfo("Enabling accelerometer...");
-  sensor.Enable();
 
   while (true)
   {

--- a/demos/sjtwo/oled/source/main.cpp
+++ b/demos/sjtwo/oled/source/main.cpp
@@ -8,21 +8,18 @@
 int main()
 {
   sjsu::LogInfo("Starting OLED Application...");
-  sjsu::lpc40xx::Spi ssp1(sjsu::lpc40xx::Spi::Bus::kSpi1);
-  sjsu::lpc40xx::Gpio cs_gpio(1, 22);
-  sjsu::lpc40xx::Gpio dc_gpio(1, 25);
+  sjsu::lpc40xx::Spi & ssp1     = sjsu::lpc40xx::GetSpi<1>();
+  sjsu::lpc40xx::Gpio & cs_gpio = sjsu::lpc40xx::GetGpio<1, 22>();
+  sjsu::lpc40xx::Gpio & dc_gpio = sjsu::lpc40xx::GetGpio<1, 25>();
 
   // Using an Inactive GPIO for the reset, as it is not needed for the SJTwo
   // board.
-  sjsu::Ssd1306 oled_display(ssp1, cs_gpio, dc_gpio,
-                             sjsu::GetInactive<sjsu::Gpio>());
+  sjsu::Ssd1306 oled_display(
+      ssp1, cs_gpio, dc_gpio, sjsu::GetInactive<sjsu::Gpio>());
   sjsu::Graphics graphics(oled_display);
 
   // Initialize OLED display and all of the peripherals it uses
   graphics.Initialize();
-
-  // Enable OLED display
-  graphics.Enable();
 
   sjsu::LogInfo("Clearing Screen...");
   graphics.Clear();
@@ -30,20 +27,20 @@ int main()
 
   sjsu::LogInfo("Drawing Some Shapes...");
 
-  graphics.DrawHorizontalLine(0, sjsu::Ssd1306::kHeight / 2,
-                              sjsu::Ssd1306::kWidth);
+  graphics.DrawHorizontalLine(
+      0, sjsu::Ssd1306::kHeight / 2, sjsu::Ssd1306::kWidth);
   graphics.Update();
 
-  graphics.DrawVerticalLine(sjsu::Ssd1306::kWidth / 2, 0,
-                            sjsu::Ssd1306::kHeight);
+  graphics.DrawVerticalLine(
+      sjsu::Ssd1306::kWidth / 2, 0, sjsu::Ssd1306::kHeight);
   graphics.Update();
 
-  graphics.DrawRectangle(sjsu::Ssd1306::kWidth / 2 - 10,
-                         sjsu::Ssd1306::kHeight / 2 - 10, 20, 20);
+  graphics.DrawRectangle(
+      sjsu::Ssd1306::kWidth / 2 - 10, sjsu::Ssd1306::kHeight / 2 - 10, 20, 20);
   graphics.Update();
 
-  graphics.DrawRectangle(sjsu::Ssd1306::kWidth / 2 - 20,
-                         sjsu::Ssd1306::kHeight / 2 - 20, 40, 40);
+  graphics.DrawRectangle(
+      sjsu::Ssd1306::kWidth / 2 - 20, sjsu::Ssd1306::kHeight / 2 - 20, 40, 40);
   graphics.Update();
 
   graphics.DrawLine(0, 0, sjsu::Ssd1306::kWidth, sjsu::Ssd1306::kHeight);
@@ -52,20 +49,20 @@ int main()
   graphics.DrawLine(0, sjsu::Ssd1306::kHeight, sjsu::Ssd1306::kWidth, 0);
   graphics.Update();
 
-  graphics.DrawCircle(sjsu::Ssd1306::kWidth / 2, sjsu::Ssd1306::kHeight / 2,
-                      20);
+  graphics.DrawCircle(
+      sjsu::Ssd1306::kWidth / 2, sjsu::Ssd1306::kHeight / 2, 20);
   graphics.Update();
 
-  graphics.DrawCircle(sjsu::Ssd1306::kWidth / 2, sjsu::Ssd1306::kHeight / 2,
-                      30);
+  graphics.DrawCircle(
+      sjsu::Ssd1306::kWidth / 2, sjsu::Ssd1306::kHeight / 2, 30);
   graphics.Update();
 
-  graphics.DrawCircle(sjsu::Ssd1306::kWidth / 2, sjsu::Ssd1306::kHeight / 2,
-                      40);
+  graphics.DrawCircle(
+      sjsu::Ssd1306::kWidth / 2, sjsu::Ssd1306::kHeight / 2, 40);
   graphics.Update();
 
-  graphics.DrawCircle(sjsu::Ssd1306::kWidth / 2, sjsu::Ssd1306::kHeight / 2,
-                      60);
+  graphics.DrawCircle(
+      sjsu::Ssd1306::kWidth / 2, sjsu::Ssd1306::kHeight / 2, 60);
   graphics.Update();
 
   sjsu::LogInfo("Drawing Some names...");

--- a/demos/sjtwo/oled_printf/source/main.cpp
+++ b/demos/sjtwo/oled_printf/source/main.cpp
@@ -18,7 +18,6 @@ int main()
   sjsu::GraphicalTerminal oled_terminal(&oled_graphics, &cache);
 
   oled_terminal.Initialize();
-  oled_terminal.Enable();
 
   sjsu::LogInfo("Demonstrating printf capabilities...");
   oled_terminal.printf("Float: %.1f\nInteger: %d", 234.5, 15);

--- a/demos/sjtwo/parallel_gpio/source/main.cpp
+++ b/demos/sjtwo/parallel_gpio/source/main.cpp
@@ -13,16 +13,15 @@ int main()
 
   sjsu::LogInfo("Creating ParallelGpio object using led Gpios...");
 
-  sjsu::lpc40xx::Gpio led0(2, 3);
-  sjsu::lpc40xx::Gpio led1(1, 26);
-  sjsu::lpc40xx::Gpio led2(1, 24);
-  sjsu::lpc40xx::Gpio led3(1, 18);
+  sjsu::lpc40xx::Gpio & led0 = sjsu::lpc40xx::GetGpio<2, 3>();
+  sjsu::lpc40xx::Gpio & led1 = sjsu::lpc40xx::GetGpio<1, 26>();
+  sjsu::lpc40xx::Gpio & led2 = sjsu::lpc40xx::GetGpio<1, 24>();
+  sjsu::lpc40xx::Gpio & led3 = sjsu::lpc40xx::GetGpio<1, 18>();
   std::array<sjsu::Gpio *, 4> leds = { &led0, &led1, &led2, &led3 };
 
   sjsu::ParallelGpio parallel_leds(leds);
 
   parallel_leds.Initialize();
-  parallel_leds.Enable();
 
   while (true)
   {

--- a/demos/sjtwo/parallel_lcd/source/main.cpp
+++ b/demos/sjtwo/parallel_lcd/source/main.cpp
@@ -10,17 +10,21 @@ int main()
   sjsu::LogInfo("Starting Parallel LCD Demo");
 
   // set up control pins for lcd
-  sjsu::lpc40xx::Gpio rs(0, 15);  // RS:    Register Select
-  sjsu::lpc40xx::Gpio rw(0, 16);  // RW:    Read / Write
-  sjsu::lpc40xx::Gpio e(0, 17);   // E:     Chip Enable
-  sjsu::lpc40xx::Gpio d7(2, 2);   // D7-D0: Parallel Data Pins
-  sjsu::lpc40xx::Gpio d6(2, 1);
-  sjsu::lpc40xx::Gpio d5(2, 3);
-  sjsu::lpc40xx::Gpio d4(2, 4);
-  sjsu::lpc40xx::Gpio d3(2, 5);
-  sjsu::lpc40xx::Gpio d2(2, 6);
-  sjsu::lpc40xx::Gpio d1(2, 7);
-  sjsu::lpc40xx::Gpio d0(2, 8);
+  sjsu::lpc40xx::Gpio & rs = sjsu::lpc40xx::GetGpio<0, 15>();
+  // RS:    Register Select
+  sjsu::lpc40xx::Gpio & rw = sjsu::lpc40xx::GetGpio<0, 16>();
+  // RW:    Read / Write
+  sjsu::lpc40xx::Gpio & e = sjsu::lpc40xx::GetGpio<0, 17>();
+  // E:     Chip Enable
+  sjsu::lpc40xx::Gpio & d7 = sjsu::lpc40xx::GetGpio<2, 2>();
+  // D7-D0: Parallel Data Pins
+  sjsu::lpc40xx::Gpio & d6 = sjsu::lpc40xx::GetGpio<2, 1>();
+  sjsu::lpc40xx::Gpio & d5 = sjsu::lpc40xx::GetGpio<2, 3>();
+  sjsu::lpc40xx::Gpio & d4 = sjsu::lpc40xx::GetGpio<2, 4>();
+  sjsu::lpc40xx::Gpio & d3 = sjsu::lpc40xx::GetGpio<2, 5>();
+  sjsu::lpc40xx::Gpio & d2 = sjsu::lpc40xx::GetGpio<2, 6>();
+  sjsu::lpc40xx::Gpio & d1 = sjsu::lpc40xx::GetGpio<2, 7>();
+  sjsu::lpc40xx::Gpio & d0 = sjsu::lpc40xx::GetGpio<2, 8>();
 
   std::array<sjsu::Gpio *, 8> data_pins = { &d0, &d1, &d2, &d3,
                                             &d4, &d5, &d6, &d7 };
@@ -38,7 +42,6 @@ int main()
                     data_bus);
 
   lcd.Initialize();
-  lcd.Enable();
 
   sjsu::LogInfo("Drawing text to screen at different locations...");
   lcd.DrawText("Parallel LCD Demo", sjsu::St7066u::CursorPosition_t{ 1, 4 });

--- a/demos/sjtwo/pin_configuration/source/main.cpp
+++ b/demos/sjtwo/pin_configuration/source/main.cpp
@@ -12,29 +12,20 @@ int main()
   sjsu::LogInfo("Pin Configure Application Starting...");
 
   // Set P0[7] to floating (LPC40xx defaults pins to pull up)
-  sjsu::lpc40xx::Pin p0_0(0, 7);
+  sjsu::lpc40xx::Pin & p0_0 = sjsu::lpc40xx::GetPin<0, 7>();
+  p0_0.settings.Floating();
   p0_0.Initialize();
-  p0_0.Enable();
-  p0_0.ConfigureFloating();
 
   sjsu::LogInfo("Disabling both pull up and down resistors for P0.0...");
-  sjsu::lpc40xx::Pin p1_24(1, 24);
-  p1_24.ConfigurePullDown();
+  sjsu::lpc40xx::Pin & p1_24 = sjsu::lpc40xx::GetPin<1, 24>();
+  p1_24.settings.PullDown();
   p1_24.Initialize();
-  p1_24.Enable();
   sjsu::LogInfo("Enabling P1.24 pull down resistor...");
 
-  sjsu::lpc40xx::Pin p2_0(2, 0);
+  sjsu::lpc40xx::Pin & p2_0 = sjsu::lpc40xx::GetPin<2, 0>();
+  p2_0.settings.PullUp();
   p2_0.Initialize();
-  p2_0.Enable();
-  p2_0.ConfigurePullUp();
   sjsu::LogInfo("Enabling P2.0 pull up resistor...");
-
-  sjsu::lpc40xx::Pin p4_28(4, 29);
-  p4_28.Initialize();
-  p4_28.Enable();
-  p4_28.ConfigurePullResistor(sjsu::Pin::Resistor::kRepeater);
-  sjsu::LogInfo("Setting P4.29 to repeater mode...");
 
   sjsu::LogInfo(
       "Use some jumpers and a multimeter to test each pin to see if the "

--- a/demos/sjtwo/pulse_capture/source/main.cpp
+++ b/demos/sjtwo/pulse_capture/source/main.cpp
@@ -40,10 +40,9 @@ int main()
 
   // Create 60 Hz square wave on P2.0, that we can capture
   sjsu::LogInfo("Creating PWM output on P2.0");
-  sjsu::lpc40xx::Pwm signal_generator(sjsu::lpc40xx::Pwm::Channel::kPwm0);
+  sjsu::lpc40xx::Pwm & signal_generator = sjsu::lpc40xx::GetPwm<1, 0>();
+  signal_generator.settings.frequency   = kGeneratorFrequency;
   signal_generator.Initialize();
-  signal_generator.ConfigureFrequency(kGeneratorFrequency);
-  signal_generator.Enable();
   signal_generator.SetDutyCycle(kGeneratorDutyCycle);
 
   // Enable capture interrupt for both edges

--- a/demos/sjtwo/pwm/source/main.cpp
+++ b/demos/sjtwo/pwm/source/main.cpp
@@ -8,13 +8,9 @@ int main()
   sjsu::LogInfo("Pwm Application Starting...");
 
   sjsu::LogInfo("Creating PWM signal on P2.0 (Pwm0).");
-  sjsu::lpc40xx::Pwm pwm(sjsu::lpc40xx::Pwm::Channel::kPwm0);
+  sjsu::lpc40xx::Pwm & pwm = sjsu::lpc40xx::GetPwm<1, 0>();
+  pwm.settings.frequency   = 10_kHz;
   pwm.Initialize();
-
-  // Initialize Pwm at 10 kHz
-  pwm.ConfigureFrequency(10_kHz);
-
-  pwm.Enable();
 
   sjsu::LogInfo(
       "Hookup an oscilloscope to see the signal change frequency and duty "
@@ -25,11 +21,6 @@ int main()
 
   while (true)
   {
-    // NOTE: You must disable PWM before configuring its frequency.
-    pwm.Enable(false);
-    pwm.ConfigureFrequency(10_kHz);
-    pwm.Enable(true);
-
     sjsu::LogInfo("Iterate from 0%% to 100%% duty cycle");
     for (float i = 0; i <= 100; i++)
     {
@@ -51,9 +42,9 @@ int main()
     {
       frequency *= 2;
 
-      pwm.Enable(false);
-      pwm.ConfigureFrequency(frequency);
-      pwm.Enable(true);
+      pwm.settings.frequency = frequency;
+      pwm.Initialize();
+      pwm.SetDutyCycle(0.5f);
 
       sjsu::LogInfo("Freq = %f", frequency.to<double>());
       sjsu::Delay(500ms);
@@ -64,9 +55,9 @@ int main()
     {
       frequency /= 2;
 
-      pwm.Enable(false);
-      pwm.ConfigureFrequency(frequency);
-      pwm.Enable(true);
+      pwm.settings.frequency = frequency;
+      pwm.Initialize();
+      pwm.SetDutyCycle(0.5f);
 
       sjsu::LogInfo("Freq = %f", frequency.to<double>());
 

--- a/demos/sjtwo/rmd_x/source/main.cpp
+++ b/demos/sjtwo/rmd_x/source/main.cpp
@@ -10,19 +10,15 @@ int main(void)
   constexpr auto kTimeDelay  = 1s;
 
   sjsu::LogInfo("Starting RMD-X demo in 5s...");
-  sjsu::lpc40xx::Can can(sjsu::lpc40xx::Can::Channel::kCan2);
+  sjsu::lpc40xx::Can & can = sjsu::lpc40xx::GetCan<2>();
   sjsu::StaticAllocator<1024> memory_resource;
   sjsu::CanNetwork can_network(can, &memory_resource);
   sjsu::RmdX rmd_x7(can_network, 0x148);
 
   sjsu::Delay(5s);
 
-  sjsu::LogInfo("RMD-X initializing and enabling...");
-
+  sjsu::LogInfo("RMD-X initializing...");
   rmd_x7.Initialize();
-  rmd_x7.Enable();
-
-  sjsu::LogInfo("RMD-X initialized and enabled!");
 
   sjsu::LogInfo("Setting motor speed to +%f RPM...", kSpeedLimit.to<double>());
   rmd_x7.SetSpeed(kSpeedLimit);

--- a/demos/sjtwo/sd_card/source/main.cpp
+++ b/demos/sjtwo/sd_card/source/main.cpp
@@ -33,12 +33,6 @@ class DualGpios : public sjsu::Gpio
     lead_.Initialize();
   }
 
-  void ModuleEnable(bool enable = true) override
-  {
-    lead_.Enable(enable);
-    lead_.Enable(enable);
-  }
-
   void SetDirection(Direction direction) override
   {
     lead_.SetDirection(direction);
@@ -87,10 +81,10 @@ int main()
 {
   sjsu::LogInfo("BEGIN SD Card Driver Example...");
 
-  sjsu::lpc40xx::Spi spi2(sjsu::lpc40xx::Spi::Bus::kSpi2);
-  sjsu::lpc40xx::Gpio sd_card_detect(1, 9);
-  sjsu::lpc40xx::Gpio sd_chip_select_actual(1, 8);
-  sjsu::lpc40xx::Gpio sd_chip_select_mirror(0, 6);
+  sjsu::lpc40xx::Spi & spi2                   = sjsu::lpc40xx::GetSpi<2>();
+  sjsu::lpc40xx::Gpio & sd_card_detect        = sjsu::lpc40xx::GetGpio<1, 9>();
+  sjsu::lpc40xx::Gpio & sd_chip_select_actual = sjsu::lpc40xx::GetGpio<1, 8>();
+  sjsu::lpc40xx::Gpio & sd_chip_select_mirror = sjsu::lpc40xx::GetGpio<0, 6>();
 
   // This pin is not necessary for operation, but because the SD card's chip
   // select not accessable, it is useful for debugging the SD card to have an
@@ -112,10 +106,6 @@ int main()
     sjsu::LogInfo("Please insert an SD card and restart the system.");
     return -1;
   }
-
-  sjsu::LogInfo("Attempting to mount (Enable) SD card...");
-
-  card.Enable();
 
   sjsu::LogInfo("Mounting of SD Card was" SJ2_HI_BOLD_GREEN " successful!");
 

--- a/demos/sjtwo/servo/project.mk
+++ b/demos/sjtwo/servo/project.mk
@@ -1,1 +1,3 @@
+TESTS += $(LIBRARY_DIR)/L2_HAL/actuators/servo/test/servo_test.cpp
+
 PLATFORM = lpc40xx

--- a/demos/sjtwo/servo/source/main.cpp
+++ b/demos/sjtwo/servo/source/main.cpp
@@ -8,13 +8,10 @@ int main()
   sjsu::LogInfo("Servo application starting...");
 
   // Creating PWM on pin 2.0
-  sjsu::lpc40xx::Pwm pwm(sjsu::lpc40xx::Pwm::Channel::kPwm0);
+  sjsu::lpc40xx::Pwm & pwm = sjsu::lpc40xx::GetPwm<1, 0>();
 
   // Create servo class and and give it the PWM.
   sjsu::Servo servo(pwm);
-
-  sjsu::LogInfo("Initalizing Servo");
-  servo.Initialize();
 
   // When all of the bounds of the servo class are set, the servo class will
   // map your degrees to microseconds. With the below example, 0 degrees will
@@ -22,18 +19,20 @@ int main()
   // 90 degrees will representation 1500 us.
 
   // Set RC servo PWM frequency to default (50 Hz)
-  servo.ConfigureFrequency();
+  servo.settings.frequency = 50_Hz;
 
   // Set the pulse wideth bounds to be 500 us and 2500 us.
   sjsu::LogInfo("Setting Servo pulse width bounds from 500us to 2500us.");
-  servo.ConfigurePulseBounds(500us, 2500us);
+  servo.settings.min_pulse = 500us;
+  servo.settings.max_pulse = 2500us;
 
   // Set the angle bounds of the servo to be 0 degrees and 180 degrees
   sjsu::LogInfo("Setting Servo angle bounds from 0 deg to 180 deg.");
-  servo.ConfigureAngleBounds(0_deg, 180_deg);
+  servo.settings.min_angle = 0_deg;
+  servo.settings.max_angle = 180_deg;
 
-  sjsu::LogInfo("Enabling Servo!");
-  servo.Enable();
+  sjsu::LogInfo("Initalizing Servo");
+  servo.Initialize();
 
   while (true)
   {

--- a/demos/sjtwo/spi/source/main.cpp
+++ b/demos/sjtwo/spi/source/main.cpp
@@ -11,29 +11,17 @@ int main()
   // to SPI2. Device ID (part 1) = 40h; Manufacturer ID = 1Fh.
   sjsu::LogInfo("SPI Application Starting...");
   sjsu::LogInfo("Pins for SPI2 are: MOSI = P1[1], MISO = P1[4], SCK = P1[0]");
+  sjsu::lpc40xx::Spi & spi2 = sjsu::lpc40xx::GetSpi<2>();
 
-  sjsu::lpc40xx::Spi spi2(sjsu::lpc40xx::Spi::Bus::kSpi2);
+  sjsu::LogInfo("Set clock frequency to 1 MHz");
+  spi2.settings.clock_rate = 1_MHz;
 
   sjsu::LogInfo("SPI initialization");
   spi2.Initialize();
 
-  sjsu::LogInfo("Set clock mode to the standard defaults for SPI.");
-  spi2.ConfigureClockMode();
-
-  sjsu::LogInfo("Set frame size to 8-bits (standard)");
-  spi2.ConfigureFrameSize(sjsu::Spi::FrameSize::kEightBits);
-
-  // Set up SPI clock polarity and phase
-  sjsu::LogInfo("Set clock frequency to 1 MHz");
-  spi2.ConfigureFrequency(1_MHz);
-
-  sjsu::LogInfo("Enabling SPI2");
-  spi2.Enable();
-
   // Set up chip select as GPIO pin
-  sjsu::lpc40xx::Gpio chip_select(1, 10);
+  sjsu::lpc40xx::Gpio & chip_select = sjsu::lpc40xx::GetGpio<1, 10>();
   chip_select.Initialize();
-  chip_select.Enable();
   chip_select.SetAsOutput();
   chip_select.SetHigh();
   sjsu::LogInfo("Chip select on Port 1.10 and initialized high.");

--- a/demos/sjtwo/temperature/source/main.cpp
+++ b/demos/sjtwo/temperature/source/main.cpp
@@ -6,12 +6,10 @@
 int main()
 {
   sjsu::LogInfo("Starting Si7060 Temperature Sensor Demonstration...");
-  sjsu::lpc40xx::I2c i2c2(sjsu::lpc40xx::I2c::Bus::kI2c2);
+  sjsu::lpc40xx::I2c & i2c2 = sjsu::lpc40xx::GetI2c<2>();
   sjsu::Si7060 temperature_sensor(i2c2);
 
   temperature_sensor.Initialize();
-  temperature_sensor.Enable();
-
   sjsu::LogInfo("Si7060 Initialized!");
 
   while (true)

--- a/demos/sjtwo/uart/source/main.cpp
+++ b/demos/sjtwo/uart/source/main.cpp
@@ -9,19 +9,12 @@ int main()
 {
   sjsu::LogInfo("Uart Loopback Application starting...");
   sjsu::LogInfo("Connect jumper between P2[8] and P2[9].");
-  sjsu::lpc40xx::Uart uart2(sjsu::lpc40xx::Uart::Port::kUart2);
-
-  sjsu::LogInfo("Initializing UART port 2");
-  uart2.Initialize();
-
-  sjsu::LogInfo("Setting standard uart frame format.");
-  uart2.ConfigureFormat();
+  sjsu::lpc40xx::Uart & uart2 = sjsu::lpc40xx::GetUart<2>();
 
   sjsu::LogInfo("Setting Baud rate to 38400");
-  uart2.ConfigureBaudRate(38400);
-
-  sjsu::LogInfo("Enabling UART!");
-  uart2.Enable();
+  uart2.settings.baud_rate = 38400;
+  sjsu::LogInfo("Initializing UART port 2");
+  uart2.Initialize();
 
   while (true)
   {

--- a/demos/sjtwo/watchdog/source/main.cpp
+++ b/demos/sjtwo/watchdog/source/main.cpp
@@ -58,16 +58,12 @@ int main()
   button3.Initialize();
   led3.Initialize();
 
-  button3.Enable();
-  led3.Enable();
-
   button3.SetAsInput();
   led3.SetDirection(sjsu::Gpio::Direction::kOutput);
 
   // The parameter for this function is in seconds.
   // The first parameter is the value stored in the watchdog counter.
   watchdog.Initialize(1s);
-  watchdog.Enable();
 
   // The watchdog is fed for the first time to start the watchdog timer.
   watchdog.FeedSequence();

--- a/demos/stm32f10x/adc/source/main.cpp
+++ b/demos/stm32f10x/adc/source/main.cpp
@@ -7,9 +7,8 @@ int main()
   sjsu::LogInfo("Starting ADC Application...");
   sjsu::LogInfo("Read voltage between 0.0V and 3.3V by connecting it to PA0.");
 
-  sjsu::stm32f10x::Adc adc0(sjsu::stm32f10x::Adc::Channel::kChannel0);
+  sjsu::stm32f10x::Adc & adc0 = sjsu::stm32f10x::GetAdc<0>();
   adc0.Initialize();
-  adc0.Enable();
 
   while (true)
   {

--- a/demos/stm32f10x/clock_configuration/source/main.cpp
+++ b/demos/stm32f10x/clock_configuration/source/main.cpp
@@ -3,9 +3,9 @@
 
 #include "L0_Platform/startup.hpp"
 #include "L1_Peripheral/stm32f10x/gpio.hpp"
-#include "utility/time.hpp"
-#include "utility/log.hpp"
 #include "L2_HAL/switches/button.hpp"
+#include "utility/log.hpp"
+#include "utility/time.hpp"
 
 int main()
 {
@@ -73,8 +73,9 @@ int main()
 
   // Set pin to its alternative mode which is MCU CLOCK OUTPUT (MCO) mode.
   sjsu::LogInfo("Clock output on PA[8]");
-  sjsu::stm32f10x::Gpio mco_pin('A', 8);
-  mco_pin.GetPin().ConfigureFunction(1);
+  sjsu::stm32f10x::Gpio & mco_pin    = sjsu::stm32f10x::GetGpio<'A', 8>();
+  mco_pin.GetPin().settings.function = (1);
+  mco_pin.Initialize();
 
   struct McoOptions_t
   {

--- a/demos/stm32f10x/gpio/source/main.cpp
+++ b/demos/stm32f10x/gpio/source/main.cpp
@@ -8,21 +8,19 @@ int main()
 {
   sjsu::LogInfo(
       "Starting GPIO Application (targeted for Super Bluepill board)...");
-  sjsu::stm32f10x::Gpio key_button('A', 8);
-  sjsu::stm32f10x::Gpio led('A', 1);
+  sjsu::stm32f10x::Gpio & key_button = sjsu::stm32f10x::GetGpio<'A', 8>();
+  sjsu::stm32f10x::Gpio & led        = sjsu::stm32f10x::GetGpio<'A', 1>();
 
-  key_button.Initialize();
-  key_button.Enable();
-  key_button.SetAsInput();
   // The STM32F10x has an interesting binding between input/output and pin
   // configuration, so this must happen after enable.
-  key_button.GetPin().ConfigurePullUp();
+  key_button.GetPin().settings.PullUp();
+  key_button.Initialize();
+  key_button.SetAsInput();
   sjsu::LogInfo("Configured PA8 as input with internal pull up resistor");
 
   // Another way to configure the input or output of a pin is to use the
   // method, SetDirection.
   led.Initialize();
-  led.Enable();
   led.SetAsOutput();
   led.SetHigh();
 

--- a/demos/stm32f10x/gpio_interrupts/source/main.cpp
+++ b/demos/stm32f10x/gpio_interrupts/source/main.cpp
@@ -9,20 +9,17 @@ int main()
   sjsu::stm32f10x::Gpio pin1('B', 10);
   sjsu::stm32f10x::Gpio pin2('B', 12);
 
+  pin0.GetPin().settings.PullUp();
+  pin1.GetPin().settings.PullUp();
+  pin2.GetPin().settings.PullUp();
+
   pin0.Initialize();
   pin1.Initialize();
   pin2.Initialize();
 
-  pin0.Enable();
-  pin1.Enable();
-  pin2.Enable();
-
   pin0.SetAsInput();
-  pin0.GetPin().ConfigurePullUp();
   pin1.SetAsInput();
-  pin1.GetPin().ConfigurePullUp();
   pin2.SetAsInput();
-  pin2.GetPin().ConfigurePullUp();
 
   sjsu::LogInfo("Setup PA8 to interrupt on only Falling edges...");
   pin0.AttachInterrupt([]() { sjsu::LogInfo("PA8 interrupt!"); },

--- a/demos/stm32f10x/pwm/source/main.cpp
+++ b/demos/stm32f10x/pwm/source/main.cpp
@@ -3,12 +3,10 @@
 
 int main()
 {
-  sjsu::stm32f10x::Pwm pwm(sjsu::stm32f10x::Pwm::Channel_t::kA8);
+  sjsu::stm32f10x::Pwm & pwm = sjsu::stm32f10x::GetPwmFromPin<'A', 0>();
 
+  pwm.settings.frequency = 10_kHz;
   pwm.Initialize();
-  pwm.Enable();
-  pwm.ConfigureFrequency(500_Hz);
-  pwm.Enable();
   pwm.SetDutyCycle(0.78f);
 
   return 0;

--- a/demos/stm32f10x/spi/source/main.cpp
+++ b/demos/stm32f10x/spi/source/main.cpp
@@ -8,23 +8,14 @@ int main()
   sjsu::LogInfo("To perform a loopback test connect MISO and MOSI together");
   sjsu::LogInfo("using a jumper. This will make the SPI response match the");
   sjsu::LogInfo("sent payload of \"Hello, World\"");
-  sjsu::stm32f10x::Spi spi(sjsu::stm32f10x::Spi::Port::kSpi1);
-
-  sjsu::LogInfo("SPI initialization...");
-  spi.Initialize();
-
-  sjsu::LogInfo("Set clock mode to the standard defaults for SPI...");
-  spi.ConfigureClockMode();
-
-  sjsu::LogInfo("Set frame size to 8-bits (standard)...");
-  spi.ConfigureFrameSize(sjsu::Spi::FrameSize::kEightBits);
+  sjsu::stm32f10x::Spi & spi = sjsu::stm32f10x::GetSpi<1>();
 
   // Set up SPI clock polarity and phase
-  sjsu::LogInfo("Set clock frequency to 1 MHz...");
-  spi.ConfigureFrequency(1_MHz);
+  sjsu::LogInfo("Set clock frequency to 100 kHz...");
+  spi.settings.clock_rate = 100_kHz;
 
-  sjsu::LogInfo("Enabling SPI...");
-  spi.Enable();
+  sjsu::LogInfo("Initializing SPI...");
+  spi.Initialize();
 
   std::array<uint8_t, 12> payload = { 'H', 'e', 'l', 'l', 'o', ' ',
                                       'W', 'o', 'r', 'l', 'd', '\0' };

--- a/demos/stm32f10x/super_bluepill_oled/source/main.cpp
+++ b/demos/stm32f10x/super_bluepill_oled/source/main.cpp
@@ -19,16 +19,11 @@ class BitBangSpi : public sjsu::Spi
     mosi_.Initialize();
     sck_.Initialize();
 
-    mosi_.Enable();
-    sck_.Enable();
-
     mosi_.SetAsOutput();
     sck_.SetAsOutput();
     sck_.SetLow();
     mosi_.SetLow();
   }
-
-  void ModuleEnable(bool = true) override {}
 
   void Transfer(std::span<uint8_t> buffer) override
   {
@@ -51,13 +46,6 @@ class BitBangSpi : public sjsu::Spi
   {
     sjsu::LogInfo("NOT SUPPORTED!");
   }
-
-  void ConfigureClockMode(Polarity = Polarity::kIdleLow,
-                          Phase    = Phase::kSampleLeading) override
-  {
-  }
-  void ConfigureFrameSize(FrameSize = FrameSize::kEightBits) override {}
-  void ConfigureFrequency(units::frequency::hertz_t) override {}
 
  private:
   sjsu::Gpio & sck_;
@@ -90,7 +78,6 @@ int main()
 
   sjsu::LogInfo("Starting OLED Display Initialized...");
   oled_display.Initialize();
-  oled_display.Enable();
 
   while (true)
   {

--- a/demos/stm32f10x/test_demos/adc/source/main.cpp
+++ b/demos/stm32f10x/test_demos/adc/source/main.cpp
@@ -6,33 +6,27 @@ int main()
 {
   sjsu::LogInfo("Starting ADC Application...");
 
-  std::array<sjsu::stm32f10x::Adc, 10> adc_channel = {
-    sjsu::stm32f10x::Adc(sjsu::stm32f10x::Adc::Channel::kChannel0),
-    sjsu::stm32f10x::Adc(sjsu::stm32f10x::Adc::Channel::kChannel1),
-    sjsu::stm32f10x::Adc(sjsu::stm32f10x::Adc::Channel::kChannel2),
-    sjsu::stm32f10x::Adc(sjsu::stm32f10x::Adc::Channel::kChannel3),
-    sjsu::stm32f10x::Adc(sjsu::stm32f10x::Adc::Channel::kChannel4),
-    sjsu::stm32f10x::Adc(sjsu::stm32f10x::Adc::Channel::kChannel5),
-    sjsu::stm32f10x::Adc(sjsu::stm32f10x::Adc::Channel::kChannel6),
-    sjsu::stm32f10x::Adc(sjsu::stm32f10x::Adc::Channel::kChannel7),
-    sjsu::stm32f10x::Adc(sjsu::stm32f10x::Adc::Channel::kChannel8),
-    sjsu::stm32f10x::Adc(sjsu::stm32f10x::Adc::Channel::kChannel9),
+  std::array<sjsu::stm32f10x::Adc *, 10> adc_channel = {
+    &sjsu::stm32f10x::GetAdc<0>(), &sjsu::stm32f10x::GetAdc<1>(),
+    &sjsu::stm32f10x::GetAdc<2>(), &sjsu::stm32f10x::GetAdc<3>(),
+    &sjsu::stm32f10x::GetAdc<4>(), &sjsu::stm32f10x::GetAdc<5>(),
+    &sjsu::stm32f10x::GetAdc<6>(), &sjsu::stm32f10x::GetAdc<7>(),
+    &sjsu::stm32f10x::GetAdc<8>(), &sjsu::stm32f10x::GetAdc<9>(),
   };
 
   for (auto & adc : adc_channel)
   {
-    adc.Initialize();
-    adc.Enable();
+    adc->Initialize();
   }
 
   while (true)
   {
     std::array<units::voltage::volt_t, 10> volt_array = {
-      adc_channel[0].Voltage(), adc_channel[1].Voltage(),
-      adc_channel[2].Voltage(), adc_channel[3].Voltage(),
-      adc_channel[4].Voltage(), adc_channel[5].Voltage(),
-      adc_channel[6].Voltage(), adc_channel[7].Voltage(),
-      adc_channel[8].Voltage(), adc_channel[9].Voltage(),
+      adc_channel[0]->Voltage(), adc_channel[1]->Voltage(),
+      adc_channel[2]->Voltage(), adc_channel[3]->Voltage(),
+      adc_channel[4]->Voltage(), adc_channel[5]->Voltage(),
+      adc_channel[6]->Voltage(), adc_channel[7]->Voltage(),
+      adc_channel[8]->Voltage(), adc_channel[9]->Voltage(),
     };
 
     for (int i = 0; auto & volt : volt_array)

--- a/demos/stm32f10x/uart/source/main.cpp
+++ b/demos/stm32f10x/uart/source/main.cpp
@@ -1,16 +1,14 @@
 #include "L1_Peripheral/stm32f10x/uart.hpp"
-#include "utility/time.hpp"
 #include "utility/log.hpp"
+#include "utility/time.hpp"
 
 int main()
 {
   sjsu::LogInfo("Starting Uart Application...");
 
-  sjsu::stm32f10x::Uart<128> uart1(sjsu::stm32f10x::UartBase::Port::kUart1);
+  sjsu::stm32f10x::Uart<32> & uart1 = sjsu::stm32f10x::GetUart<1>();
+  uart1.settings.baud_rate          = 38400;
   uart1.Initialize();
-  uart1.ConfigureFormat();
-  uart1.ConfigureBaudRate(38400);
-  uart1.Enable();
 
   sjsu::LogInfo(
       "Connect the TX (PA9) RX (PA10) and pins to a USB to serial converter "

--- a/demos/stm32f4xx/fk407m1_gpio/source/main.cpp
+++ b/demos/stm32f4xx/fk407m1_gpio/source/main.cpp
@@ -8,16 +8,14 @@ int main()
 {
   sjsu::LogInfo("Starting FK407M1 Gpio Application...");
   ///////////// Setup LED GPIO /////////////
-  sjsu::stm32f4xx::Gpio led('C', 13);
+  sjsu::stm32f4xx::Gpio & led = sjsu::stm32f4xx::GetGpio<'C', 13>();
   led.Initialize();
-  led.Enable();
   led.SetAsOutput();
 
-  sjsu::stm32f4xx::Gpio button('A', 15);
+  sjsu::stm32f4xx::Gpio & button = sjsu::stm32f4xx::GetGpio<'A', 15>();
+  button.GetPin().settings.PullUp();
   button.Initialize();
-  button.Enable();
   button.SetAsInput();
-  button.GetPin().ConfigurePullUp();
 
   while (true)
   {

--- a/documentation/contributing/style.md
+++ b/documentation/contributing/style.md
@@ -225,7 +225,7 @@ class DistanceSensor
   virtual Status GetSignalStrengthPercent(float * strength) const = 0;
 
   // ===============
-  // Utility Methods
+  // Helper Functions
   // ===============
   Status GetDistanceCm(float * distance) const
   {

--- a/documentation/design_docs/L3/task_interface.md
+++ b/documentation/design_docs/L3/task_interface.md
@@ -23,7 +23,7 @@
   - [Configuring Execution Frequency](#configuring-execution-frequency)
     - [void SetDelayTime(uint32_t time) override](#void-setdelaytimeuint32t-time-override)
     - [const uint32_t GetDelayTime() const override](#const-uint32t-getdelaytime-const-override)
-  - [Additional Utility Methods](#additional-utility-methods)
+  - [Additional Helper Functions](#additional-utility-methods)
     - [const char * GetName() const override](#const-char--getname-const-override)
     - [Priority GetPriority() const override](#priority-getpriority-const-override)
     - [size_t GetStackSize() const override](#sizet-getstacksize-const-override)
@@ -212,7 +212,7 @@ period is 1ms, then `Run()` will be invoked every 1 second.
 ### const uint32_t GetDelayTime() const override
 Returns the delay time that was set by SetDelayTime() in milliseconds.
 
-## Additional Utility Methods
+## Additional Helper Functions
 ### const char * GetName() const override
 Returns the name used to identify the task.
 

--- a/library/L0_Platform/lpc40xx/startup.cpp
+++ b/library/L0_Platform/lpc40xx/startup.cpp
@@ -32,7 +32,7 @@ sjsu::lpc40xx::SystemController system_controller(clock_configuration);
 sjsu::cortex::DwtCounter arm_dwt_counter;
 
 // Uart port 0 is used to communicate back to the host computer
-sjsu::lpc40xx::Uart uart0(sjsu::lpc40xx::Uart::Port::kUart0);
+sjsu::lpc40xx::Uart & uart0 = sjsu::lpc40xx::GetUart<0>();
 
 // System timer is used to count milliseconds of time and to run the RTOS
 // scheduler.
@@ -93,17 +93,14 @@ extern "C"
 
   void vPortSetupTimerInterrupt(void)  // NOLINT
   {
-    // Disable timer so the callback can be configured
-    system_timer.Enable(false);
-
     // Set the SystemTick frequency to the RTOS tick frequency
     // It is critical that this happens before you set the system_clock,
     // since The system_timer keeps the time that the system_clock uses to
     // delay itself.
-    system_timer.ConfigureCallback(xPortSysTickHandler);
+    system_timer.settings.callback = xPortSysTickHandler;
 
     // Re-enable timer
-    system_timer.Enable(true);
+    system_timer.Initialize();
   }
 }
 
@@ -189,16 +186,14 @@ void InitializePlatform()
   system_controller.Initialize();
 
   // Set UART0 baudrate, which is required for printf and scanf to work properly
+  uart0.settings.baud_rate = config::kBaudRate;
   uart0.Initialize();
-  uart0.ConfigureBaudRate(config::kBaudRate);
-  uart0.Enable();
 
   sjsu::newlib::SetStdout(Lpc40xxStdOut);
   sjsu::newlib::SetStdin(Lpc40xxStdIn);
 
+  system_timer.settings.frequency = config::kRtosFrequency;
   system_timer.Initialize();
-  system_timer.ConfigureTickFrequency(config::kRtosFrequency);
-  system_timer.Enable();
 
   arm_dwt_counter.Initialize();
   sjsu::SetUptimeFunction(sjsu::cortex::SystemTimer::GetCount);

--- a/library/L0_Platform/msp432p401r/startup.cpp
+++ b/library/L0_Platform/msp432p401r/startup.cpp
@@ -1,3 +1,5 @@
+#include "L0_Platform/startup.hpp"
+
 #include <FreeRTOS.h>
 #include <task.h>
 
@@ -5,14 +7,13 @@
 #include <cstring>
 #include <iterator>
 
-#include "L0_Platform/ram.hpp"
-#include "L0_Platform/startup.hpp"
 #include "L0_Platform/msp432p401r/msp432p401r.h"
+#include "L0_Platform/ram.hpp"
 #include "L1_Peripheral/cortex/dwt_counter.hpp"
 #include "L1_Peripheral/cortex/system_timer.hpp"
+#include "L1_Peripheral/inactive.hpp"
 #include "L1_Peripheral/interrupt.hpp"
 #include "L1_Peripheral/msp432p401r/system_controller.hpp"
-#include "L1_Peripheral/inactive.hpp"
 #include "utility/log.hpp"
 #include "utility/macros.hpp"
 #include "utility/time.hpp"
@@ -64,17 +65,14 @@ extern "C"
 
   void vPortSetupTimerInterrupt(void)  // NOLINT
   {
-    // Disable timer so the callback can be configured
-    system_timer.Enable(false);
-
     // Set the SystemTick frequency to the RTOS tick frequency
     // It is critical that this happens before you set the system_clock,
     // since The system_timer keeps the time that the system_clock uses to
     // delay itself.
-    system_timer.ConfigureCallback(xPortSysTickHandler);
+    system_timer.settings.callback = xPortSysTickHandler;
 
     // Re-enable timer
-    system_timer.Enable(true);
+    system_timer.Initialize();
   }
 }
 
@@ -160,10 +158,8 @@ void InitializePlatform()
 
   system_controller.Initialize();
 
+  system_timer.settings.frequency = config::kRtosFrequency;
   system_timer.Initialize();
-  system_timer.ConfigureTickFrequency(config::kRtosFrequency);
-  system_timer.ConfigureCallback([]() {});
-  system_timer.Enable();
 
   arm_dwt_counter.Initialize();
   sjsu::SetUptimeFunction(sjsu::cortex::SystemTimer::GetCount);

--- a/library/L0_Platform/stm32f4xx/startup.cpp
+++ b/library/L0_Platform/stm32f4xx/startup.cpp
@@ -59,17 +59,14 @@ extern "C"
 
   void vPortSetupTimerInterrupt(void)  // NOLINT
   {
-    // Disable timer so the callback can be configured
-    system_timer.Enable(false);
-
     // Set the SystemTick frequency to the RTOS tick frequency
     // It is critical that this happens before you set the system_clock,
     // since The system_timer keeps the time that the system_clock uses to
     // delay itself.
-    system_timer.ConfigureCallback(xPortSysTickHandler);
+    system_timer.settings.callback = xPortSysTickHandler;
 
     // Re-enable timer
-    system_timer.Enable(true);
+    system_timer.Initialize();
   }
 }
 
@@ -201,10 +198,10 @@ void InitializePlatform()
   sjsu::InterruptController::SetPlatformController(&interrupt_controller);
   sjsu::SystemController::SetPlatformController(&system_controller);
 
+  system_controller.Initialize();
+
+  system_timer.settings.frequency = config::kRtosFrequency;
   system_timer.Initialize();
-  system_timer.ConfigureTickFrequency(config::kRtosFrequency);
-  system_timer.ConfigureCallback([]() {});
-  system_timer.Enable();
 
   arm_dwt_counter.Initialize();
   sjsu::SetUptimeFunction(sjsu::cortex::SystemTimer::GetCount);

--- a/library/L1_Peripheral/adc.hpp
+++ b/library/L1_Peripheral/adc.hpp
@@ -2,32 +2,28 @@
 
 #include <cstdint>
 
-#include "module.hpp"
 #include "inactive.hpp"
+#include "module.hpp"
 #include "utility/error_handling.hpp"
 #include "utility/units.hpp"
 
 namespace sjsu
 {
+/// Generic settings for a standard ADC peripheral
+struct AdcSettings_t
+{
+  /// The high side voltage reference of the ADC. Used to calculate an
+  /// approximation of the voltage of the ADC.
+  units::voltage::microvolt_t reference_voltage = 3.3_V;
+};
+
 /// Common abstraction interface for Analog-to-Digital (ADC) Converter. These
 /// peripherals are used to sense a voltage and convert it to a numeric value.
 ///
 /// @ingroup l1_peripheral
-class Adc : public Module
+class Adc : public Module<AdcSettings_t>
 {
  public:
-  // ===========================================================================
-  // Interface Methods
-  // ===========================================================================
-
-  // ---------------------------------------------------------------------------
-  // Configuration Methods
-  // ---------------------------------------------------------------------------
-
-  // ---------------------------------------------------------------------------
-  // Usage Methods
-  // ---------------------------------------------------------------------------
-
   /// Read the analog signal's value.
   /// The number active bits depends on the ADC being used and be known by
   /// running the GetActiveBits().
@@ -38,11 +34,8 @@ class Adc : public Module
   /// @returns The number of active bits for the ADC.
   virtual uint8_t GetActiveBits() = 0;
 
-  /// @returns The ADC reference voltage.
-  virtual units::voltage::microvolt_t ReferenceVoltage() = 0;
-
   // ===========================================================================
-  // Utility Methods
+  // Helper Functions
   // ===========================================================================
 
   /// @returns The ADC resolution based on the active bits.
@@ -59,7 +52,7 @@ class Adc : public Module
   /// @returns The measured voltage.
   units::voltage::microvolt_t Voltage()
   {
-    return Read() * ReferenceVoltage() / GetMaximumValue();
+    return Read() * (CurrentSettings().reference_voltage / GetMaximumValue());
   }
 };
 
@@ -71,7 +64,6 @@ inline sjsu::Adc & GetInactive<sjsu::Adc>()
   {
    public:
     void ModuleInitialize() override {}
-    void ModuleEnable(bool = true) override {}
     uint32_t Read() override
     {
       return 0;
@@ -79,10 +71,6 @@ inline sjsu::Adc & GetInactive<sjsu::Adc>()
     uint8_t GetActiveBits() override
     {
       return 12;
-    }
-    units::voltage::microvolt_t ReferenceVoltage() override
-    {
-      return 0_V;
     }
   };
 

--- a/library/L1_Peripheral/cortex/dwt_counter.hpp
+++ b/library/L1_Peripheral/cortex/dwt_counter.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "L0_Platform/lpc40xx/LPC40xx.h"
+#include "module.hpp"
 
 namespace sjsu
 {
@@ -8,7 +9,7 @@ namespace cortex
 {
 /// The DWT (Debug Watch and Trace) module in the Cortex M series of processors
 /// has a number of debugging
-class DwtCounter
+class DwtCounter : public sjsu::Module<>
 {
  public:
   /// Address of the hardware DWT registers
@@ -18,7 +19,7 @@ class DwtCounter
 
   /// Initialize the debug core to enable counting and then being counting on
   /// the DWT.
-  void Initialize()
+  void ModuleInitialize() override
   {
     core->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
     dwt->CYCCNT = 0;

--- a/library/L1_Peripheral/cortex/interrupt.hpp
+++ b/library/L1_Peripheral/cortex/interrupt.hpp
@@ -56,11 +56,12 @@ class InterruptController final : public sjsu::InterruptController
     handler();
   }
 
-  void Initialize(
-      InterruptHandler unregistered_handler = UnregisteredHandler) override
+  InterruptController()
   {
-    std::fill(table.begin(), table.end(), unregistered_handler);
+    std::fill(table.begin(), table.end(), nullptr);
   }
+
+  void ModuleInitialize() override {}
 
   void Enable(RegistrationInfo_t register_info) override
   {

--- a/library/L1_Peripheral/cortex/test/dwt_counter_test.cpp
+++ b/library/L1_Peripheral/cortex/test/dwt_counter_test.cpp
@@ -7,8 +7,6 @@
 
 namespace sjsu::cortex
 {
-EMIT_ALL_METHODS(DwtCounter);
-
 TEST_CASE("Testing ARM Cortex Data Watchdog Trace Counter")
 {
   DWT_Type local_dwt = {
@@ -32,6 +30,7 @@ TEST_CASE("Testing ARM Cortex Data Watchdog Trace Counter")
     CHECK(0 == local_dwt.CYCCNT);
     CHECK(DWT_CTRL_CYCCNTENA_Msk == local_dwt.CTRL);
   }
+
   SECTION("Get Count")
   {
     local_dwt.CYCCNT = 0;

--- a/library/L1_Peripheral/cortex/test/interrupt_test.cpp
+++ b/library/L1_Peripheral/cortex/test/interrupt_test.cpp
@@ -25,10 +25,7 @@ TEST_CASE("Testing cortex interrupt")
   testing::ClearStructure(&local_nvic);
   test_subject.nvic = &local_nvic;
 
-  // Making the unregistered handler nullptr guarantees that an exception will
-  // be thrown if an exception occurs, which is useful in the "Initialize" test
-  // section.
-  test_subject.Initialize(nullptr);
+  test_subject.Initialize();
 
   SECTION("Initialize")
   {

--- a/library/L1_Peripheral/dac.hpp
+++ b/library/L1_Peripheral/dac.hpp
@@ -13,21 +13,9 @@ namespace sjsu
 /// typically called a Digital-to-Analog peripheral.
 ///
 /// @ingroup l1_peripheral
-class Dac : public Module
+class Dac : public Module<>
 {
  public:
-  // ===========================================================================
-  // Interface Methods
-  // ===========================================================================
-
-  // ---------------------------------------------------------------------------
-  // Configuration Methods
-  // ---------------------------------------------------------------------------
-
-  // ---------------------------------------------------------------------------
-  // Usage Methods
-  // ---------------------------------------------------------------------------
-
   /// Set the DAC output the the value supplied. If the value is above what this
   /// driver can support, the value is clamped.
   ///
@@ -53,7 +41,6 @@ inline sjsu::Dac & GetInactive<sjsu::Dac>()
   {
    public:
     void ModuleInitialize() override {}
-    void ModuleEnable(bool = true) override {}
     void Write(uint32_t) override {}
     void SetVoltage(units::voltage::microvolt_t) override {}
     uint8_t GetActiveBits() override

--- a/library/L1_Peripheral/gpio.hpp
+++ b/library/L1_Peripheral/gpio.hpp
@@ -13,7 +13,7 @@ namespace sjsu
 {
 /// An abstract interface for General Purpose I/O
 /// @ingroup l1_peripheral
-class Gpio : public Module
+class Gpio : public Module<>
 {
  public:
   // ===========================================================================
@@ -41,18 +41,6 @@ class Gpio : public Module
     kFalling = 1,
     kBoth    = 2
   };
-
-  // ===========================================================================
-  // Interface Methods
-  // ===========================================================================
-
-  // ---------------------------------------------------------------------------
-  // Configuration Methods
-  // ---------------------------------------------------------------------------
-
-  // ---------------------------------------------------------------------------
-  // Usage Methods
-  // ---------------------------------------------------------------------------
 
   /// Set pin as an output or an input
   ///
@@ -88,7 +76,7 @@ class Gpio : public Module
   virtual void DetachInterrupt() = 0;
 
   // ===========================================================================
-  // Utility Methods
+  // Helper Functions
   // ===========================================================================
 
   /// Set pin to HIGH voltage
@@ -151,7 +139,6 @@ inline sjsu::Gpio & GetInactive<sjsu::Gpio>()
   {
    public:
     void ModuleInitialize() override {}
-    void ModuleEnable(bool = true) override {}
     void SetDirection(Direction) override {}
     void Set(State) override {}
     void Toggle() override {}

--- a/library/L1_Peripheral/interrupt.hpp
+++ b/library/L1_Peripheral/interrupt.hpp
@@ -4,6 +4,7 @@
 #include <functional>
 
 #include "L1_Peripheral/inactive.hpp"
+#include "module.hpp"
 
 namespace sjsu
 {
@@ -16,6 +17,7 @@ using InterruptHandler = std::function<void(void)>;
 /// Standard callback that should be executed when interrupts fire.
 using InterruptCallback = std::function<void(void)>;
 
+/// Definition of an interrupt callback that does... well... nothing really.
 inline static InterruptCallback do_nothing = []() {};
 
 /// An abstract interface for a platforms interrupt controller. This allows a
@@ -23,7 +25,7 @@ inline static InterruptCallback do_nothing = []() {};
 /// each.
 ///
 /// @ingroup l1_peripheral
-class InterruptController
+class InterruptController : public Module<>
 {
  private:
   /// Global platform interrupt controller scoped within this class. Most
@@ -65,19 +67,10 @@ class InterruptController
     return *platform_interrupt_controller;
   }
 
-  /// Initialize interrupt vector table.
-  ///
-  /// @note This MUST NOT be called by application code. This for use only in
-  /// the platform's startup. Doing this typically overwrites the interrupt
-  /// handlers with the unregistered_handler.
-  virtual void Initialize(InterruptHandler unregistered_handler = nullptr) = 0;
-
   /// Configures and enables the interrupt on the platform and also registers
   /// the interrupt handler.
   ///
-  /// @param register_info - the needed information to setup the interrupt, such
-  ///        as its vector number, priority, if it should be enabled with this
-  ///        call, etc. See RegistrationInfo_t documentation for more details.
+  /// @param register_info - the needed information to setup the interrupt.
   virtual void Enable(RegistrationInfo_t register_info) = 0;
 
   /// Disables and interrupt based on its interrupt request number
@@ -109,7 +102,7 @@ inline sjsu::InterruptController & GetInactive<sjsu::InterruptController>()
   class InactiveInterruptController : public sjsu::InterruptController
   {
    public:
-    void Initialize(InterruptHandler) override {}
+    void ModuleInitialize() override {}
     void Enable(RegistrationInfo_t) override {}
     void Disable(int) override {}
   };

--- a/library/L1_Peripheral/lpc17xx/adc.hpp
+++ b/library/L1_Peripheral/lpc17xx/adc.hpp
@@ -9,18 +9,10 @@ namespace lpc17xx
 {
 /// The LPC40xx driver is compatible with the lpc17xx peripheral
 using ::sjsu::lpc40xx::Adc;
-/// Namespace containing predefined Channel_t description objects. These
-/// objects can be passed directly to the constructor of an lpc40xx::Adc
-/// object.
-///
-/// Usage:
-///
-/// ```
-/// sjsu::lpc17xx::Adc adc(sjsu::lpc17xx::AdcChannel::kChannel0);
-/// ```
-struct AdcChannel  // NOLINT
+
+template <int channel>
+static Adc & GetAdc()
 {
- private:
   enum AdcMode : uint8_t
   {
     kCh0123Pins = 0b01,
@@ -28,72 +20,106 @@ struct AdcChannel  // NOLINT
     kCh67Pins   = 0b10,
   };
 
-  inline static lpc17xx::Pin adc_pin_channel0 = lpc17xx::Pin(0, 23);
-  inline static lpc17xx::Pin adc_pin_channel1 = lpc17xx::Pin(0, 24);
-  inline static lpc17xx::Pin adc_pin_channel2 = lpc17xx::Pin(0, 25);
-  inline static lpc17xx::Pin adc_pin_channel3 = lpc17xx::Pin(0, 26);
-  inline static lpc17xx::Pin adc_pin_channel4 = lpc17xx::Pin(1, 30);
-  inline static lpc17xx::Pin adc_pin_channel5 = lpc17xx::Pin(1, 31);
-  inline static lpc17xx::Pin adc_pin_channel6 = lpc17xx::Pin(0, 3);
-  inline static lpc17xx::Pin adc_pin_channel7 = lpc17xx::Pin(0, 2);
+  if constexpr (channel == 0)
+  {
+    static auto & adc_pin_channel0 = lpc17xx::GetPin<0, 23>();
+    static const sjsu::lpc40xx::Adc::Channel_t kChannel0 = {
+      .adc_pin      = adc_pin_channel0,
+      .channel      = 0,
+      .pin_function = AdcMode::kCh0123Pins,
+    };
+    static Adc adc_channel0(kChannel0);
+    return adc_channel0;
+  }
+  else if constexpr (channel == 1)
+  {
+    static auto & adc_pin_channel1 = lpc17xx::GetPin<0, 24>();
+    static const sjsu::lpc40xx::Adc::Channel_t kChannel1 = {
+      .adc_pin      = adc_pin_channel1,
+      .channel      = 1,
+      .pin_function = AdcMode::kCh0123Pins,
+    };
+    static Adc adc_channel1(kChannel1);
+    return adc_channel1;
+  }
+  else if constexpr (channel == 2)
+  {
+    static auto & adc_pin_channel2 = lpc17xx::GetPin<0, 25>();
+    static const sjsu::lpc40xx::Adc::Channel_t kChannel2 = {
+      .adc_pin      = adc_pin_channel2,
+      .channel      = 2,
+      .pin_function = AdcMode::kCh0123Pins,
+    };
+    static Adc adc_channel2(kChannel2);
+    return adc_channel2;
+  }
+  else if constexpr (channel == 3)
+  {
+    static auto & adc_pin_channel3 = lpc17xx::GetPin<0, 26>();
+    static const sjsu::lpc40xx::Adc::Channel_t kChannel3 = {
+      .adc_pin      = adc_pin_channel3,
+      .channel      = 3,
+      .pin_function = AdcMode::kCh0123Pins,
+    };
+    static Adc adc_channel3(kChannel3);
+    return adc_channel3;
+  }
+  else if constexpr (channel == 4)
+  {
+    static auto & adc_pin_channel4 = lpc17xx::GetPin<1, 30>();
+    static const sjsu::lpc40xx::Adc::Channel_t kChannel4 = {
+      .adc_pin      = adc_pin_channel4,
+      .channel      = 4,
+      .pin_function = AdcMode::kCh45Pins,
+    };
+    static Adc adc_channel4(kChannel4);
+    return adc_channel4;
+  }
+  else if constexpr (channel == 5)
+  {
+    static auto & adc_pin_channel5 = lpc17xx::GetPin<1, 31>();
+    static const sjsu::lpc40xx::Adc::Channel_t kChannel5 = {
+      .adc_pin      = adc_pin_channel5,
+      .channel      = 5,
+      .pin_function = AdcMode::kCh45Pins,
+    };
 
- public:
-  /// Predefined channel information for channel 0.
-  /// Pass this to the lpc17xx::Adc class to utilize adc channel0.
-  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel0 = {
-    .adc_pin      = adc_pin_channel0,
-    .channel      = 0,
-    .pin_function = AdcMode::kCh0123Pins,
-  };
-  /// Predefined channel information for channel 1.
-  /// Pass this to the lpc17xx::Adc class to utilize adc channel1.
-  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel1 = {
-    .adc_pin      = adc_pin_channel1,
-    .channel      = 1,
-    .pin_function = AdcMode::kCh0123Pins,
-  };
-  /// Predefined channel information for channel 2.
-  /// Pass this to the lpc17xx::Adc class to utilize adc channel2.
-  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel2 = {
-    .adc_pin      = adc_pin_channel2,
-    .channel      = 2,
-    .pin_function = AdcMode::kCh0123Pins,
-  };
-  /// Predefined channel information for channel 3.
-  /// Pass this to the lpc17xx::Adc class to utilize adc channel3.
-  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel3 = {
-    .adc_pin      = adc_pin_channel3,
-    .channel      = 3,
-    .pin_function = AdcMode::kCh0123Pins,
-  };
-  /// Predefined channel information for channel 4.
-  /// Pass this to the lpc17xx::Adc class to utilize adc channel4.
-  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel4 = {
-    .adc_pin      = adc_pin_channel4,
-    .channel      = 4,
-    .pin_function = AdcMode::kCh45Pins,
-  };
-  /// Predefined channel information for channel 5.
-  /// Pass this to the lpc17xx::Adc class to utilize adc channel5.
-  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel5 = {
-    .adc_pin      = adc_pin_channel5,
-    .channel      = 5,
-    .pin_function = AdcMode::kCh45Pins,
-  };
-  /// Predefined channel information for channel 6.
-  /// Pass this to the lpc17xx::Adc class to utilize adc channel6.
-  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel6 = {
-    .adc_pin      = adc_pin_channel6,
-    .channel      = 6,
-    .pin_function = AdcMode::kCh67Pins,
-  };
-  /// Predefined channel information for channel 7.
-  /// Pass this to the lpc17xx::Adc class to utilize adc channel7.
-  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel7 = {
-    .adc_pin      = adc_pin_channel7,
-    .channel      = 7,
-    .pin_function = AdcMode::kCh67Pins,
-  };
-};
+    static Adc adc_channel5(kChannel5);
+    return adc_channel5;
+  }
+  else if constexpr (channel == 6)
+  {
+    static auto & adc_pin_channel6 = lpc17xx::GetPin<0, 3>();
+    static const sjsu::lpc40xx::Adc::Channel_t kChannel6 = {
+      .adc_pin      = adc_pin_channel6,
+      .channel      = 6,
+      .pin_function = AdcMode::kCh67Pins,
+    };
+
+    static Adc adc_channel6(kChannel6);
+    return adc_channel6;
+  }
+  else if constexpr (channel == 7)
+  {
+    static auto & adc_pin_channel7 = lpc17xx::GetPin<0, 2>();
+    static const sjsu::lpc40xx::Adc::Channel_t kChannel7 = {
+      .adc_pin      = adc_pin_channel7,
+      .channel      = 7,
+      .pin_function = AdcMode::kCh67Pins,
+    };
+
+    static Adc adc_channel7(kChannel7);
+    return adc_channel7;
+  }
+  else
+  {
+    static_assert(InvalidOption<channel>,
+                  "\n\n"
+                  "SJSU-Dev2 Compile Time Error:\n"
+                  "    LPC40xx only supports ADC channels from 0 to 7. \n"
+                  "\n");
+    return GetAdc<0>();
+  }
+}
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/can.hpp
+++ b/library/L1_Peripheral/lpc17xx/can.hpp
@@ -8,5 +8,6 @@ namespace lpc17xx
 {
 // The LPC40xx driver is compatible with the lpc17xx peripheral
 using ::sjsu::lpc40xx::Can;
+using ::sjsu::lpc40xx::GetCan;
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/dac.hpp
+++ b/library/L1_Peripheral/lpc17xx/dac.hpp
@@ -8,5 +8,6 @@ namespace sjsu
 namespace lpc17xx
 {
 using ::sjsu::lpc40xx::Dac;
+using ::sjsu::lpc40xx::GetDac;
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/gpio.hpp
+++ b/library/L1_Peripheral/lpc17xx/gpio.hpp
@@ -7,5 +7,6 @@ namespace sjsu
 namespace lpc17xx
 {
 using sjsu::lpc40xx::Gpio;
+using sjsu::lpc40xx::GetGpio;
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/i2c.hpp
+++ b/library/L1_Peripheral/lpc17xx/i2c.hpp
@@ -12,57 +12,76 @@ namespace lpc17xx
 // peripheral.
 using ::sjsu::lpc40xx::I2c;
 
-/// Structure used as a namespace for predefined I2C Bus definitions.
-struct I2cBus  // NOLINT
+template <int port>
+inline I2c & GetI2c()
 {
- private:
-  inline static lpc17xx::Pin i2c0_sda_pin = lpc17xx::Pin(0, 27);
-  inline static lpc17xx::Pin i2c0_scl_pin = lpc17xx::Pin(0, 28);
+  // UM10562: Chapter 7: LPC408x/407x I/O configuration page 13
+  if constexpr (port == 0)
+  {
+    static auto & i2c0_sda_pin = lpc17xx::GetPin<0, 27>();
+    static auto & i2c0_scl_pin = lpc17xx::GetPin<0, 28>();
 
-  inline static lpc17xx::Pin i2c1_sda_pin = lpc17xx::Pin(0, 0);
-  inline static lpc17xx::Pin i2c1_scl_pin = lpc17xx::Pin(0, 1);
+    static I2c::Transaction_t transaction_i2c0;
 
-  inline static lpc17xx::Pin i2c2_sda_pin = lpc17xx::Pin(0, 10);
-  inline static lpc17xx::Pin i2c2_scl_pin = lpc17xx::Pin(0, 11);
+    static const lpc40xx::I2c::Port_t kI2c0 = {
+      .registers    = reinterpret_cast<lpc40xx::LPC_I2C_TypeDef *>(LPC_I2C0),
+      .id           = SystemController::Peripherals::kI2c0,
+      .irq_number   = I2C0_IRQn,
+      .transaction  = transaction_i2c0,
+      .sda_pin      = i2c0_sda_pin,
+      .scl_pin      = i2c0_scl_pin,
+      .pin_function = 0b01,
+    };
 
-  inline static I2c::Transaction_t transaction_i2c0;
-  inline static I2c::Transaction_t transaction_i2c1;
-  inline static I2c::Transaction_t transaction_i2c2;
+    static I2c i2c0(kI2c0);
+    return i2c0;
+  }
+  else if constexpr (port == 1)
+  {
+    static auto & i2c1_sda_pin = lpc17xx::GetPin<0, 0>();
+    static auto & i2c1_scl_pin = lpc17xx::GetPin<0, 1>();
 
- public:
-  // Definition for I2C bus 0 for LPC17xx.
-  /// NOTE: I2C0 is not available for the 80-pin package.
-  inline static const lpc40xx::I2c::Bus_t kI2c0 = {
-    .registers    = reinterpret_cast<lpc40xx::LPC_I2C_TypeDef *>(LPC_I2C0),
-    .id           = SystemController::Peripherals::kI2c0,
-    .irq_number   = I2C0_IRQn,
-    .transaction  = transaction_i2c0,
-    .sda_pin      = i2c0_sda_pin,
-    .scl_pin      = i2c0_scl_pin,
-    .pin_function = 0b01,
-  };
+    static I2c::Transaction_t transaction_i2c1;
 
-  /// Definition for I2C bus 1 for LPC17xx.
-  inline static const lpc40xx::I2c::Bus_t kI2c1 = {
-    .registers    = reinterpret_cast<lpc40xx::LPC_I2C_TypeDef *>(LPC_I2C1),
-    .id           = SystemController::Peripherals::kI2c1,
-    .irq_number   = I2C1_IRQn,
-    .transaction  = transaction_i2c1,
-    .sda_pin      = i2c1_sda_pin,
-    .scl_pin      = i2c1_scl_pin,
-    .pin_function = 0b11,
-  };
+    static const lpc40xx::I2c::Port_t kI2c1 = {
+      .registers    = reinterpret_cast<lpc40xx::LPC_I2C_TypeDef *>(LPC_I2C1),
+      .id           = SystemController::Peripherals::kI2c1,
+      .irq_number   = I2C1_IRQn,
+      .transaction  = transaction_i2c1,
+      .sda_pin      = i2c1_sda_pin,
+      .scl_pin      = i2c1_scl_pin,
+      .pin_function = 0b11,
+    };
 
-  /// Definition for I2C bus 2 for LPC17xx.
-  inline static const lpc40xx::I2c::Bus_t kI2c2 = {
-    .registers    = reinterpret_cast<lpc40xx::LPC_I2C_TypeDef *>(LPC_I2C2),
-    .id           = SystemController::Peripherals::kI2c2,
-    .irq_number   = I2C2_IRQn,
-    .transaction  = transaction_i2c2,
-    .sda_pin      = i2c2_sda_pin,
-    .scl_pin      = i2c2_scl_pin,
-    .pin_function = 0b10,
-  };
-};
+    static I2c i2c1(kI2c1);
+    return i2c1;
+  }
+  else if constexpr (port == 2)
+  {
+    static auto & i2c2_sda_pin = lpc17xx::GetPin<0, 10>();
+    static auto & i2c2_scl_pin = lpc17xx::GetPin<0, 11>();
+
+    static I2c::Transaction_t transaction_i2c2;
+
+    static const lpc40xx::I2c::Port_t kI2c2 = {
+      .registers    = reinterpret_cast<lpc40xx::LPC_I2C_TypeDef *>(LPC_I2C2),
+      .id           = SystemController::Peripherals::kI2c2,
+      .irq_number   = I2C2_IRQn,
+      .transaction  = transaction_i2c2,
+      .sda_pin      = i2c2_sda_pin,
+      .scl_pin      = i2c2_scl_pin,
+      .pin_function = 0b10,
+    };
+
+    static I2c i2c2(kI2c2);
+    return i2c2;
+  }
+  else
+  {
+    static_assert(InvalidOption<port>,
+                  "Support UART ports for LPC40xx are I2C0, I2C1, and I2C2.");
+    return GetI2c<0>();
+  }
+}
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/pulse_capture.hpp
+++ b/library/L1_Peripheral/lpc17xx/pulse_capture.hpp
@@ -19,8 +19,8 @@ struct PulseCaptureChannel  // NOLINT
   inline static lpc40xx::PulseCapture::CaptureChannelNumber
       timer0_channel_number =
           lpc40xx::PulseCapture::CaptureChannelNumber::kChannel1;
-  inline static Pin capture0_channel0_pin = Pin(1, 26);
-  inline static Pin capture0_channel1_pin = Pin(1, 27);
+  inline static Pin & capture0_channel0_pin = sjsu::lpc17xx::GetPin<1, 26>();
+  inline static Pin & capture0_channel1_pin = sjsu::lpc17xx::GetPin<1, 27>();
   inline static const lpc40xx::PulseCapture::CaptureChannelPartial_t
       kTimerPartial0 = {
         .timer_register =
@@ -37,8 +37,8 @@ struct PulseCaptureChannel  // NOLINT
   inline static lpc40xx::PulseCapture::CaptureChannelNumber
       timer1_channel_number =
           lpc40xx::PulseCapture::CaptureChannelNumber::kChannel1;
-  inline static Pin capture1_channel0_pin = Pin(1, 18);
-  inline static Pin capture1_channel1_pin = Pin(1, 19);
+  inline static Pin & capture1_channel0_pin = sjsu::lpc17xx::GetPin<1, 18>();
+  inline static Pin & capture1_channel1_pin = sjsu::lpc17xx::GetPin<1, 19>();
   inline static const lpc40xx::PulseCapture::CaptureChannelPartial_t
       kTimerPartial1 = {
         .timer_register =
@@ -55,8 +55,8 @@ struct PulseCaptureChannel  // NOLINT
   inline static lpc40xx::PulseCapture::CaptureChannelNumber
       timer2_channel_number =
           lpc40xx::PulseCapture::CaptureChannelNumber::kChannel1;
-  inline static Pin capture2_channel0_pin = Pin(0, 4);
-  inline static Pin capture2_channel1_pin = Pin(0, 5);
+  inline static Pin & capture2_channel0_pin = sjsu::lpc17xx::GetPin<0, 4>();
+  inline static Pin & capture2_channel1_pin = sjsu::lpc17xx::GetPin<0, 5>();
   inline static const lpc40xx::PulseCapture::CaptureChannelPartial_t
       kTimerPartial2 = {
         .timer_register =
@@ -73,8 +73,8 @@ struct PulseCaptureChannel  // NOLINT
   inline static lpc40xx::PulseCapture::CaptureChannelNumber
       timer3_channel_number =
           lpc40xx::PulseCapture::CaptureChannelNumber::kChannel1;
-  inline static Pin capture3_channel0_pin = Pin(0, 23);
-  inline static Pin capture3_channel1_pin = Pin(0, 24);
+  inline static Pin & capture3_channel0_pin = sjsu::lpc17xx::GetPin<0, 23>();
+  inline static Pin & capture3_channel1_pin = sjsu::lpc17xx::GetPin<0, 24>();
   inline static const lpc40xx::PulseCapture::CaptureChannelPartial_t
       kTimerPartial3 = {
         .timer_register =

--- a/library/L1_Peripheral/lpc17xx/pwm.hpp
+++ b/library/L1_Peripheral/lpc17xx/pwm.hpp
@@ -10,65 +10,7 @@ namespace lpc17xx
 {
 // The LPC40xx driver is compatible with the lpc17xx peripheral
 using ::sjsu::lpc40xx::Pwm;
-/// Structure used as a namespace for predefined Channel definitions
-struct PwmChannel  // NOLINT
-{
- private:
-  inline static lpc17xx::Pin pwm_pin0 = lpc17xx::Pin(2, 0);
-  inline static lpc17xx::Pin pwm_pin1 = lpc17xx::Pin(2, 1);
-  inline static lpc17xx::Pin pwm_pin2 = lpc17xx::Pin(2, 2);
-  inline static lpc17xx::Pin pwm_pin3 = lpc17xx::Pin(2, 3);
-  inline static lpc17xx::Pin pwm_pin4 = lpc17xx::Pin(2, 4);
-  inline static lpc17xx::Pin pwm_pin5 = lpc17xx::Pin(2, 5);
-
- public:
-  /// Definition of the PWM 1 peripheral.
-  inline static const lpc40xx::Pwm::Peripheral_t kPwm1Peripheral = {
-    .registers = reinterpret_cast<lpc40xx::LPC_PWM_TypeDef *>(LPC_PWM1),
-    .id        = SystemController::Peripherals::kPwm1,
-  };
-  /// Definition for channel 0 of PWM peripheral 1.
-  inline static const lpc40xx::Pwm::Channel_t kPwm0 = {
-    .peripheral        = kPwm1Peripheral,
-    .pin               = pwm_pin0,
-    .channel           = 1,
-    .pin_function_code = 0b01,
-  };
-  /// Definition for channel 1 of PWM peripheral 1.
-  inline static const lpc40xx::Pwm::Channel_t kPwm1 = {
-    .peripheral        = kPwm1Peripheral,
-    .pin               = pwm_pin1,
-    .channel           = 2,
-    .pin_function_code = 0b01,
-  };
-  /// Definition for channel 2 of PWM peripheral 1.
-  inline static const lpc40xx::Pwm::Channel_t kPwm2 = {
-    .peripheral        = kPwm1Peripheral,
-    .pin               = pwm_pin2,
-    .channel           = 3,
-    .pin_function_code = 0b01,
-  };
-  /// Definition for channel 3 of PWM peripheral 1.
-  inline static const lpc40xx::Pwm::Channel_t kPwm3 = {
-    .peripheral        = kPwm1Peripheral,
-    .pin               = pwm_pin3,
-    .channel           = 4,
-    .pin_function_code = 0b01,
-  };
-  /// Definition for channel 4 of PWM peripheral 1.
-  inline static const lpc40xx::Pwm::Channel_t kPwm4 = {
-    .peripheral        = kPwm1Peripheral,
-    .pin               = pwm_pin4,
-    .channel           = 5,
-    .pin_function_code = 0b01,
-  };
-  /// Definition for channel 5 of PWM peripheral 1.
-  inline static const lpc40xx::Pwm::Channel_t kPwm5 = {
-    .peripheral        = kPwm1Peripheral,
-    .pin               = pwm_pin5,
-    .channel           = 6,
-    .pin_function_code = 0b01,
-  };
-};
+// The LPC40xx GetPwm is compatible with the lpc17xx peripheral
+using ::sjsu::lpc40xx::GetPwm;
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/spi.hpp
+++ b/library/L1_Peripheral/lpc17xx/spi.hpp
@@ -11,38 +11,56 @@ namespace lpc17xx
 // The LPC40xx driver is compatible with the lpc17xx peripheral
 using ::sjsu::lpc40xx::Spi;
 
-/// Structure used as a namespace for predefined Bus definitions
-struct SpiBus  // NOLINT
+template <int port>
+inline Spi & GetSpi()
 {
- private:
-  // SSP0 pins
-  inline static lpc17xx::Pin mosi0 = lpc17xx::Pin(0, 18);
-  inline static lpc17xx::Pin miso0 = lpc17xx::Pin(0, 17);
-  inline static lpc17xx::Pin sck0  = lpc17xx::Pin(0, 15);
-  // SSP1 pins
-  inline static lpc17xx::Pin mosi1 = lpc17xx::Pin(0, 9);
-  inline static lpc17xx::Pin miso1 = lpc17xx::Pin(0, 8);
-  inline static lpc17xx::Pin sck1  = lpc17xx::Pin(0, 7);
+  if constexpr (port == 0)
+  {
+    // SSP0 pins
+    static lpc17xx::Pin & mosi0 = lpc17xx::GetPin<0, 18>();
+    static lpc17xx::Pin & miso0 = lpc17xx::GetPin<0, 17>();
+    static lpc17xx::Pin & sck0  = lpc17xx::GetPin<0, 15>();
 
- public:
-  /// Definition for SPI bus 0 for LPC17xx
-  inline static const lpc40xx::Spi::Bus_t kSpi0 = {
-    .registers    = reinterpret_cast<lpc40xx::LPC_SSP_TypeDef *>(LPC_SSP0),
-    .power_on_bit = SystemController::Peripherals::kSsp0,
-    .mosi         = mosi0,
-    .miso         = miso0,
-    .sck          = sck0,
-    .pin_function = 0b10,
-  };
-  /// Definition for SPI bus 1 for LPC17xx
-  inline static const lpc40xx::Spi::Bus_t kSpi1 = {
-    .registers    = reinterpret_cast<lpc40xx::LPC_SSP_TypeDef *>(LPC_SSP1),
-    .power_on_bit = SystemController::Peripherals::kSsp1,
-    .mosi         = mosi1,
-    .miso         = miso1,
-    .sck          = sck1,
-    .pin_function = 0b10,
-  };
-};
+    /// Definition for SPI bus 0 for LPC17xx
+    static const lpc40xx::Spi::Bus_t kSpi0 = {
+      .registers    = reinterpret_cast<lpc40xx::LPC_SSP_TypeDef *>(LPC_SSP0),
+      .power_on_bit = SystemController::Peripherals::kSsp0,
+      .mosi         = mosi0,
+      .miso         = miso0,
+      .sck          = sck0,
+      .pin_function = 0b10,
+    };
+
+    static Spi spi0(kSpi0);
+    return spi0;
+  }
+  else if constexpr (port == 1)
+  {
+    // SSP1 pins
+    static lpc17xx::Pin & mosi1 = lpc17xx::GetPin<0, 9>();
+    static lpc17xx::Pin & miso1 = lpc17xx::GetPin<0, 8>();
+    static lpc17xx::Pin & sck1  = lpc17xx::GetPin<0, 7>();
+
+    /// Definition for SPI bus 1 for LPC17xx
+    static const lpc40xx::Spi::Bus_t kSpi1 = {
+      .registers    = reinterpret_cast<lpc40xx::LPC_SSP_TypeDef *>(LPC_SSP1),
+      .power_on_bit = SystemController::Peripherals::kSsp1,
+      .mosi         = mosi1,
+      .miso         = miso1,
+      .sck          = sck1,
+      .pin_function = 0b10,
+    };
+
+    static Spi spi1(kSpi1);
+    return spi1;
+  }
+  else
+  {
+    static_assert(InvalidOption<port>,
+                  SJ2_ERROR_MESSAGE_DECORATOR(
+                      "LPC40xx only supports SPI0 and SPI1."));
+    return GetSpi<0>();
+  }
+}
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/test/pin_test.cpp
+++ b/library/L1_Peripheral/lpc17xx/test/pin_test.cpp
@@ -5,9 +5,8 @@
 #include "L4_Testing/testing_frameworks.hpp"
 #include "utility/debug.hpp"
 
+// PIN TEST IS COVERED BY LPC40XX tests
 namespace sjsu::lpc17xx
 {
-EMIT_ALL_METHODS(Pin);
-
 TEST_CASE("Testing lpc17xx Pin") {}
 }  // namespace sjsu::lpc17xx

--- a/library/L1_Peripheral/lpc17xx/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/lpc17xx/test/system_controller_test.cpp
@@ -7,8 +7,6 @@
 
 namespace sjsu::lpc17xx
 {
-EMIT_ALL_METHODS(SystemController);
-
 TEST_CASE("Testing LPC176x/5x System Controller")
 {
   // Simulate local version of LPC_SC

--- a/library/L1_Peripheral/lpc17xx/uart.hpp
+++ b/library/L1_Peripheral/lpc17xx/uart.hpp
@@ -5,54 +5,72 @@
 #include "L1_Peripheral/lpc40xx/system_controller.hpp"
 #include "L1_Peripheral/lpc40xx/uart.hpp"
 
-namespace sjsu
-{
-namespace lpc17xx
+namespace sjsu::lpc17xx
 {
 // The LPC40xx driver is compatible with the lpc17xx peripheral
 using ::sjsu::lpc40xx::Uart;
-/// Structure used as a namespace for predefined Port_t definitions.
-struct UartPort  // NOLINT
+
+template <int port>
+inline Uart & GetUart()
 {
- private:
-  inline static lpc17xx::Pin uart0_tx = lpc17xx::Pin(0, 2);
-  inline static lpc17xx::Pin uart0_rx = lpc17xx::Pin(0, 3);
+  if constexpr (port == 0)
+  {
+    static lpc17xx::Pin & uart0_tx = lpc17xx::GetPin<0, 2>();
+    static lpc17xx::Pin & uart0_rx = lpc17xx::GetPin<0, 3>();
+    /// Definition for uart port 0 for lpc40xx.
+    static const lpc40xx::Uart::Port_t kUart0 = {
+      .registers   = reinterpret_cast<lpc40xx::LPC_UART_TypeDef *>(LPC_UART0),
+      .power_on_id = lpc40xx::SystemController::Peripherals::kUart0,
+      .tx          = uart0_tx,
+      .rx          = uart0_rx,
+      .tx_function_id = 0b01,
+      .rx_function_id = 0b01,
+    };
 
-  inline static lpc17xx::Pin uart2_tx = lpc17xx::Pin(2, 8);
-  inline static lpc17xx::Pin uart2_rx = lpc17xx::Pin(2, 9);
+    static Uart uart(kUart0);
+    return uart;
+  }
+  else if constexpr (port == 2)
+  {
+    static lpc17xx::Pin & uart2_tx = lpc17xx::GetPin<2, 8>();
+    static lpc17xx::Pin & uart2_rx = lpc17xx::GetPin<2, 9>();
+    /// Definition for uart port 2 for lpc40xx.
+    static const lpc40xx::Uart::Port_t kUart2 = {
+      .registers   = reinterpret_cast<lpc40xx::LPC_UART_TypeDef *>(LPC_UART2),
+      .power_on_id = lpc40xx::SystemController::Peripherals::kUart2,
+      .tx          = uart2_tx,
+      .rx          = uart2_rx,
+      .tx_function_id = 0b010,
+      .rx_function_id = 0b010,
+    };
 
-  inline static lpc17xx::Pin uart3_tx = lpc17xx::Pin(4, 28);
-  inline static lpc17xx::Pin uart3_rx = lpc17xx::Pin(4, 29);
+    static Uart uart(kUart2);
+    return uart;
+  }
+  else if constexpr (port == 3)
+  {
+    static lpc17xx::Pin & uart3_tx = lpc17xx::GetPin<4, 28>();
+    static lpc17xx::Pin & uart3_rx = lpc17xx::GetPin<4, 29>();
+    /// Definition for uart port 3 for lpc40xx.
+    static const lpc40xx::Uart::Port_t kUart3 = {
+      .registers   = reinterpret_cast<lpc40xx::LPC_UART_TypeDef *>(LPC_UART3),
+      .power_on_id = lpc40xx::SystemController::Peripherals::kUart3,
+      .tx          = uart3_tx,
+      .rx          = uart3_rx,
+      .tx_function_id = 0b010,
+      .rx_function_id = 0b010,
+    };
 
- public:
-  /// Definition for uart port 0 for lpc40xx.
-  inline static const lpc40xx::Uart::Port_t kUart0 = {
-    .registers      = reinterpret_cast<lpc40xx::LPC_UART_TypeDef *>(LPC_UART0),
-    .power_on_id    = lpc40xx::SystemController::Peripherals::kUart0,
-    .tx             = uart0_tx,
-    .rx             = uart0_rx,
-    .tx_function_id = 0b01,
-    .rx_function_id = 0b01,
-  };
-  /// Definition for uart port 1 for lpc40xx.
-  inline static const lpc40xx::Uart::Port_t kUart2 = {
-    .registers      = reinterpret_cast<lpc40xx::LPC_UART_TypeDef *>(LPC_UART2),
-    .power_on_id    = lpc40xx::SystemController::Peripherals::kUart2,
-    .tx             = uart2_tx,
-    .rx             = uart2_rx,
-    .tx_function_id = 0b010,
-    .rx_function_id = 0b010,
-  };
-  /// Definition for uart port 2 for lpc40xx.
-  inline static const lpc40xx::Uart::Port_t kUart3 = {
-    .registers      = reinterpret_cast<lpc40xx::LPC_UART_TypeDef *>(LPC_UART3),
-    .power_on_id    = lpc40xx::SystemController::Peripherals::kUart3,
-    .tx             = uart3_tx,
-    .rx             = uart3_rx,
-    .tx_function_id = 0b010,
-    .rx_function_id = 0b010,
-  };
-};
-
-}  // namespace lpc17xx
-}  // namespace sjsu
+    static Uart uart(kUart3);
+    return uart;
+  }
+  else
+  {
+    static_assert(
+        InvalidOption<port>,
+        SJ2_ERROR_MESSAGE_DECORATOR("Support UART ports for LPC40xx are UART0, "
+                                    "UART2, UART3."));
+    return GetUart<0>();
+  }
+}
+}  // namespace sjsu::lpc17xx

--- a/library/L1_Peripheral/lpc40xx/eeprom.hpp
+++ b/library/L1_Peripheral/lpc40xx/eeprom.hpp
@@ -79,24 +79,19 @@ class Eeprom final : public sjsu::Storage
 
     // Initialize EEPROM clock
     eeprom_register->CLKDIV = static_cast<uint8_t>(kSystemClock / kEepromClk);
+
+    eeprom_register->PWRDWN = 0;
+  }
+
+  void ModulePowerDown() override
+  {
+    eeprom_register->PWRDWN = 1;
   }
 
   /// EEPROM is apart of the lpc40xx silicon so it is always present.
   bool IsMediaPresent() override
   {
     return true;
-  }
-
-  void ModuleEnable(bool enable = true) override
-  {
-    if (enable)
-    {
-      eeprom_register->PWRDWN = 0;
-    }
-    else
-    {
-      eeprom_register->PWRDWN = 1;
-    }
   }
 
   bool IsReadOnly() override
@@ -221,5 +216,13 @@ class Eeprom final : public sjsu::Storage
         (bit::Set(0, StatusRegister::kProgramStatusMask));
   }
 };
+
+template <int port>
+inline Eeprom & GetEeprom()
+{
+  static_assert(port == 0, "LPC40xx only supports EEPROM peripheral 0!");
+  static Eeprom eeprom;
+  return eeprom;
+}
 }  // namespace lpc40xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc40xx/pulse_capture.hpp
+++ b/library/L1_Peripheral/lpc40xx/pulse_capture.hpp
@@ -83,8 +83,8 @@ class PulseCapture final : public sjsu::PulseCapture
     inline static CaptureCallback timer0_callback = nullptr;
     inline static CaptureChannelNumber timer0_channel_number =
         CaptureChannelNumber::kChannel1;
-    inline static Pin capture0_channel0_pin                    = Pin(1, 26);
-    inline static Pin capture0_channel1_pin                    = Pin(1, 27);
+    inline static Pin & capture0_channel0_pin = GetPin<1, 26>();
+    inline static Pin & capture0_channel1_pin = GetPin<1, 27>();
     inline static const CaptureChannelPartial_t kTimerPartial0 = {
       .timer_register = LPC_TIM0,
       .id             = SystemController::Peripherals::kTimer0,
@@ -98,9 +98,9 @@ class PulseCapture final : public sjsu::PulseCapture
     inline static CaptureCallback timer1_callback = nullptr;
     inline static CaptureChannelNumber timer1_channel_number =
         CaptureChannelNumber::kChannel1;
-    inline static Pin capture1_channel0_pin                    = Pin(1, 18);
-    inline static Pin capture1_channel1_pin                    = Pin(1, 19);
-    inline static Pin capture1_pin                             = Pin(1, 14);
+    inline static Pin & capture1_channel0_pin = GetPin<1, 18>();
+    inline static Pin & capture1_channel1_pin = GetPin<1, 19>();
+    inline static Pin & capture1_pin          = GetPin<1, 14>();
     inline static const CaptureChannelPartial_t kTimerPartial1 = {
       .timer_register = LPC_TIM1,
       .id             = SystemController::Peripherals::kTimer1,
@@ -114,8 +114,8 @@ class PulseCapture final : public sjsu::PulseCapture
     inline static CaptureCallback timer2_callback = nullptr;
     inline static CaptureChannelNumber timer2_channel_number =
         CaptureChannelNumber::kChannel1;
-    inline static Pin capture2_channel0_pin                    = Pin(1, 14);
-    inline static Pin capture2_channel1_pin                    = Pin(0, 5);
+    inline static Pin & capture2_channel0_pin = GetPin<1, 14>();
+    inline static Pin & capture2_channel1_pin = GetPin<0, 5>();
     inline static const CaptureChannelPartial_t kTimerPartial2 = {
       .timer_register = LPC_TIM2,
       .id             = SystemController::Peripherals::kTimer2,
@@ -129,8 +129,8 @@ class PulseCapture final : public sjsu::PulseCapture
     inline static CaptureCallback timer3_callback = nullptr;
     inline static CaptureChannelNumber timer3_channel_number =
         CaptureChannelNumber::kChannel1;
-    inline static Pin capture3_channel0_pin                    = Pin(0, 23);
-    inline static Pin capture3_channel1_pin                    = Pin(0, 24);
+    inline static Pin & capture3_channel0_pin = GetPin<0, 23>();
+    inline static Pin & capture3_channel1_pin = GetPin<0, 24>();
     inline static const CaptureChannelPartial_t kTimerPartial3 = {
       .timer_register = LPC_TIM3,
       .id             = SystemController::Peripherals::kTimer3,
@@ -251,11 +251,13 @@ class PulseCapture final : public sjsu::PulseCapture
   {
     if (channel_ == CaptureChannelNumber::kChannel1)
     {
-      timer_.channel.capture_pin1.ConfigureFunction(3);
+      timer_.channel.capture_pin1.settings.function = 3;
+      timer_.channel.capture_pin1.Initialize();
     }
     else
     {
-      timer_.channel.capture_pin0.ConfigureFunction(3);
+      timer_.channel.capture_pin0.settings.function = 3;
+      timer_.channel.capture_pin0.Initialize();
     }
 
     static constexpr bit::Mask kModeBits[2] = { bit::MaskFromRange(0, 1),

--- a/library/L1_Peripheral/lpc40xx/test/eeprom_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/eeprom_test.cpp
@@ -6,8 +6,6 @@
 
 namespace sjsu::lpc40xx
 {
-EMIT_ALL_METHODS(Eeprom);
-
 TEST_CASE("Testing EEPROM")
 {
   // Simulate local version of LPC_EEPROM
@@ -43,30 +41,17 @@ TEST_CASE("Testing EEPROM")
     // Verify
     CHECK(local_eeprom.WSTATE == kWaitStateValues);
     CHECK(local_eeprom.CLKDIV == kClockDivider);
-  }
-
-  SECTION("Enable")
-  {
-    // Setup
-    // Setup: Set to 1 indicating that eeprom is powered down.
-    local_eeprom.PWRDWN = 1;
-
-    // Exercise
-    test_eeprom.SetStateToInitialized();
-    test_eeprom.Enable();
-
-    // Verify
     CHECK(local_eeprom.PWRDWN == 0);
   }
 
-  SECTION("Disable")
+  SECTION("PowerDown")
   {
     // Setup
+    test_eeprom.Initialize();
     local_eeprom.PWRDWN = 0;
 
     // Exercise
-    test_eeprom.SetStateToEnabled();
-    test_eeprom.Enable(false);
+    test_eeprom.PowerDown();
 
     // Verify
     CHECK(local_eeprom.PWRDWN == 1);

--- a/library/L1_Peripheral/lpc40xx/test/pulse_capture_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/pulse_capture_test.cpp
@@ -9,8 +9,6 @@
 
 namespace sjsu::lpc40xx
 {
-EMIT_ALL_METHODS(PulseCapture);
-
 PulseCapture::CaptureStatus_t isr_result;
 PulseCapture::CaptureCallback test_timer_callback = nullptr;
 
@@ -33,8 +31,8 @@ TEST_CASE("Testing lpc40xx Pulse Capture")
   static Mock<sjsu::Pin> mock_pin0;
   static Mock<sjsu::Pin> mock_pin1;
 
-  Fake(Method(mock_pin0, ConfigureFunction),
-       Method(mock_pin1, ConfigureFunction));
+  Fake(Method(mock_pin0, Pin::ModuleInitialize),
+       Method(mock_pin1, Pin::ModuleInitialize));
 
   sjsu::Pin & capture0_input_pin = mock_pin0.get();
   sjsu::Pin & capture1_input_pin = mock_pin1.get();

--- a/library/L1_Peripheral/lpc40xx/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/system_controller_test.cpp
@@ -6,8 +6,6 @@
 
 namespace sjsu::lpc40xx
 {
-EMIT_ALL_METHODS(SystemController);
-
 TEST_CASE("sjsu::lpc40xx::SystemController")
 {
   // Creating local instance of System Control (SC) registers

--- a/library/L1_Peripheral/lpc40xx/test/timer_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/timer_test.cpp
@@ -4,8 +4,6 @@
 
 namespace sjsu::lpc40xx
 {
-EMIT_ALL_METHODS(Timer);
-
 TEST_CASE("Testing lpc40xx Timer")
 {
   LPC_TIM_TypeDef local_timer_registers;

--- a/library/L1_Peripheral/lpc40xx/test/watchdog_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/watchdog_test.cpp
@@ -10,8 +10,6 @@ namespace sjsu
 {
 namespace lpc40xx
 {
-EMIT_ALL_METHODS(Watchdog);
-
 TEST_CASE("Testing lpc40xx watchdog")
 {
   constexpr std::chrono::seconds kTimerConstantSeconds = 1s;

--- a/library/L1_Peripheral/msp432p401r/pin.hpp
+++ b/library/L1_Peripheral/msp432p401r/pin.hpp
@@ -3,8 +3,8 @@
 #include <array>
 
 #include "L0_Platform/msp432p401r/msp432p401r.h"
-#include "L1_Peripheral/pin.hpp"
 #include "L1_Peripheral/gpio.hpp"
+#include "L1_Peripheral/pin.hpp"
 #include "utility/bit.hpp"
 #include "utility/log.hpp"
 
@@ -44,32 +44,50 @@ class Pin final : public sjsu::Pin
   constexpr Pin(uint8_t port, uint8_t pin) : sjsu::Pin(port, pin) {}
 
   /// @note GPIO hardare is enabled and ready by default on reset.
+  /// @note open_drain and as_analog is not supported on this platform.
+  /// @note the function must be a 3-bit function code.
   void ModuleInitialize() override
   {
-    // NOTE: port can only be 1-10 or 'J'
-    if (((port_ > 10) || (port_ == 0)) && (port_ != 'J'))
+    ConfigureFunction();
+    ConfigurePullResistor();
+    ConfigureOpenDrain();
+  }
+
+  /// Sets the drive strength of the pin.
+  ///
+  /// @param drive_strength The drive strength to set.
+  void SetDriveStrength(DriveStrength drive_strength)
+  {
+    volatile uint8_t * drive_strength_register = RegisterAddress(&Port()->DS);
+
+    if (drive_strength == DriveStrength::kHigh)
     {
-      throw Exception(std::errc::invalid_argument, "Port must be 1-10 or J");
+      *drive_strength_register = bit::Set(*drive_strength_register, GetPin());
     }
-    if (pin_ > 7)
+    else
     {
-      throw Exception(std::errc::invalid_argument,
-                      "Pin must be between 0 and 7");
+      *drive_strength_register = bit::Clear(*drive_strength_register, GetPin());
     }
   }
 
-  void ModuleEnable(bool = true) override {}
+ private:
+  void ConfigureOpenDrain()
+  {
+    if (settings.open_drain)
+    {
+      throw Exception(std::errc::operation_not_supported,
+                      "MSP does not support open drain pins");
+    }
+  }
 
   /// Configures the pin's function mode based on the specified 3-bit function
   /// code. Where the most significant bit determines the pin direction.
   ///
   /// @see Port Function Tables in 6.12 Input/Output Diagrams
   ///      http://www.ti.com/lit/ds/symlink/msp432p401r.pdf#page=138
-  ///
-  /// @param function The 3-bit function code.
-  void ConfigureFunction(uint8_t function) override
+  void ConfigureFunction()
   {
-    if (function > 0b111)
+    if (settings.function > 0b111)
     {
       throw Exception(
           std::errc::invalid_argument,
@@ -84,77 +102,44 @@ class Pin final : public sjsu::Pin
     volatile uint8_t * select0_register = RegisterAddress(&Port()->SEL0);
     *select1_register                   = static_cast<uint8_t>(
         bit::Insert(static_cast<uint32_t>(*select1_register),
-                    bit::Read(function, kSel1Bit), pin_));
+                    bit::Read(settings.function, kSel1Bit),
+                    GetPin()));
     *select0_register = static_cast<uint8_t>(
         bit::Insert(static_cast<uint32_t>(*select0_register),
-                    bit::Read(function, kSel0Bit), pin_));
+                    bit::Read(settings.function, kSel0Bit),
+                    GetPin()));
 
-    SetPinDirection(Gpio::Direction(bit::Read(function, kDirectionBit)));
+    SetPinDirection(
+        Gpio::Direction(bit::Read(settings.function, kDirectionBit)));
   }
 
   /// Sets the pin's resistor pull either as pull up, pull down, or none.
   ///
   /// @see 12.2.4 Pullup or Pulldown Resistor Enable Registers (PxREN)
   ///      https://www.ti.com/lit/ug/slau356i/slau356i.pdf#page=678
-  ///
-  /// @param resistor The resistor to set.
-  void ConfigurePullResistor(Resistor resistor) override
+  void ConfigurePullResistor()
   {
     volatile uint8_t * resistor_enable = RegisterAddress(&Port()->REN);
     // The output register (OUT) is used to select the pull down or pull up
     // resistor when resistor is enabled.
     volatile uint8_t * resistor_select = RegisterAddress(&Port()->OUT);
 
-    switch (resistor)
+    switch (settings.resistor)
     {
-      case Resistor::kNone:
-        *resistor_enable = bit::Clear(*resistor_enable, pin_);
+      case PinSettings_t::Resistor::kNone:
+        *resistor_enable = bit::Clear(*resistor_enable, GetPin());
         break;
-      case Resistor::kPullDown:
-        *resistor_enable = bit::Set(*resistor_enable, pin_);
-        *resistor_select = bit::Clear(*resistor_select, pin_);
+      case PinSettings_t::Resistor::kPullDown:
+        *resistor_enable = bit::Set(*resistor_enable, GetPin());
+        *resistor_select = bit::Clear(*resistor_select, GetPin());
         break;
-      case Resistor::kPullUp:
-        *resistor_enable = bit::Set(*resistor_enable, pin_);
-        *resistor_select = bit::Set(*resistor_select, pin_);
+      case PinSettings_t::Resistor::kPullUp:
+        *resistor_enable = bit::Set(*resistor_enable, GetPin());
+        *resistor_select = bit::Set(*resistor_select, GetPin());
         break;
-      case Resistor::kRepeater:
-        throw Exception(std::errc::not_supported,
-                        "Repeater mode not supported");
     }
   }
 
-  /// Sets the drive strength of the pin.
-  ///
-  /// @param drive_strength The drive strength to set.
-  void SetDriveStrength(DriveStrength drive_strength)
-  {
-    volatile uint8_t * drive_strength_register = RegisterAddress(&Port()->DS);
-
-    if (drive_strength == DriveStrength::kHigh)
-    {
-      *drive_strength_register = bit::Set(*drive_strength_register, pin_);
-    }
-    else
-    {
-      *drive_strength_register = bit::Clear(*drive_strength_register, pin_);
-    }
-  }
-
-  void ConfigureAsOpenDrain(bool) override
-  {
-    throw Exception(std::errc::operation_not_supported, "");
-  }
-
-  /// @note This function does nothing as setting the analog mode is not
-  ///       required to enable the use of the ADC.
-  [[deprecated("Unsupported operation")]] void ConfigureAsAnalogMode(
-      bool) override
-  {
-    throw Exception(std::errc::operation_not_supported, "");
-  }
-
- private:
   /// Sets the pin direction as output or input.
   ///
   /// @note The pin direction can determine the function of the pin when the
@@ -166,11 +151,11 @@ class Pin final : public sjsu::Pin
     volatile uint8_t * direction_register = RegisterAddress(&Port()->DIR);
     if (direction == Gpio::Direction::kOutput)
     {
-      *direction_register = bit::Set(*direction_register, pin_);
+      *direction_register = bit::Set(*direction_register, GetPin());
     }
     else
     {
-      *direction_register = bit::Clear(*direction_register, pin_);
+      *direction_register = bit::Clear(*direction_register, GetPin());
     }
   }
 
@@ -186,7 +171,7 @@ class Pin final : public sjsu::Pin
     // If the port number is odd or is 'J', use the low register. Otherwise. if
     // the port number is even, use the high register.
     uint32_t offset = 1;
-    if (static_cast<bool>(port_ & 0b1) || (port_ == 'J'))
+    if (static_cast<bool>(GetPort() & 0b1) || (GetPort() == 'J'))
     {
       offset = 0;
     }
@@ -196,19 +181,31 @@ class Pin final : public sjsu::Pin
   /// @returns The reference to the port structure base on the port number.
   DIO_PORT_Interruptable_Type * Port() const
   {
-    if (port_ == 'J')
+    if (GetPort() == 'J')
     {
       return ports[5];
     }
-    else if (!static_cast<bool>(port_ & 0b1))  // Even port number.
+    else if (!static_cast<bool>(GetPort() & 0b1))  // Even port number.
     {
-      return ports[(port_ - 1) / 2];
+      return ports[(GetPort() - 1) / 2];
     }
     // Odd port number
-    return ports[(port_ / 2)];
+    return ports[(GetPort() / 2)];
   }
 
   friend class Gpio;
 };
+
+template <int port, int pin_number>
+inline Pin & GetPin()
+{
+  // NOTE: port can only be 1-10 or 'J'
+  static_assert((1 <= port && port <= 10) || (port == 'J'),
+                "Port must be 1-10 or J");
+  static_assert(pin_number <= 7, "Pin must be between 0 and 7");
+
+  static Pin pin(port, pin_number);
+  return pin;
+}
 }  // namespace msp432p401r
 }  // namespace sjsu

--- a/library/L1_Peripheral/msp432p401r/system_controller.hpp
+++ b/library/L1_Peripheral/msp432p401r/system_controller.hpp
@@ -544,8 +544,8 @@ class SystemController final : public sjsu::SystemController
   ///
   /// @see https://www.ti.com/lit/ug/slau356i/slau356i.pdf#page=397
   ///
-  /// @param clock      The primary clock to configure.
-  /// @param oscillator The oscillator used to source the clock.
+  /// @param clock  The primary clock to configure.
+  /// @param source The oscillator used to source the clock.
   void SetClockSource(Clock clock, Oscillator source) const
   {
     constexpr bit::Mask kPrimaryClockSelectMasks[] = {

--- a/library/L1_Peripheral/msp432p401r/test/gpio_test.cpp
+++ b/library/L1_Peripheral/msp432p401r/test/gpio_test.cpp
@@ -6,8 +6,6 @@ namespace sjsu
 {
 namespace msp432p401r
 {
-EMIT_ALL_METHODS(Gpio);
-
 TEST_CASE("Testing Msp432p401r Gpio")
 {
   DIO_PORT_Interruptable_Type local_dio_a;

--- a/library/L1_Peripheral/msp432p401r/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/msp432p401r/test/system_controller_test.cpp
@@ -11,8 +11,6 @@ namespace sjsu
 {
 namespace msp432p401r
 {
-EMIT_ALL_METHODS(SystemController);
-
 TEST_CASE("Testing msp432p401r SystemController")
 {
   // Simulate local version of clock system (CS) registers.

--- a/library/L1_Peripheral/pin.hpp
+++ b/library/L1_Peripheral/pin.hpp
@@ -8,6 +8,89 @@
 
 namespace sjsu
 {
+/// Generic settings for a standard chip's Pin peripheral
+struct PinSettings_t : public MemoryEqualOperator_t<PinSettings_t>
+{
+  /// Defines the set of internal resistance connections to a pin. Read specific
+  /// enumeration constant comments/documentation to understand more about what
+  /// each one does.
+  enum class Resistor : uint8_t
+  {
+    /// Disable resistor pull. If the pin is setup as high-z (input mode) and
+    /// not connected to anything then the pin will be floating. Its value will
+    /// not undefined.
+    kNone = 0,
+
+    /// Connect pin to ground using weak (high resistance) resistor.
+    kPullDown,
+
+    /// Connect pin to controller digital voltage (VCC) using a weak (high
+    /// resistance) resistor.
+    kPullUp,
+  };
+
+  /// Set the pin's function using a function code.
+  /// The function code is very specific to the controller being used.
+  ///
+  /// But an example could be the LPC4078 chip's P0.0. It has the following
+  /// functions:
+  ///
+  ///    0. GPIO (General purpose input or output) pin
+  ///    1. CANBUS port 1 Read
+  ///    2. UART port 3 transmitter
+  ///    3. I2C port 1 serial data
+  ///    4. and UART port 0 transmitter
+  ///
+  /// Each function listed above is listed with its function code. If you pass
+  /// the value 4 into the ConfigureFunction function, for P0.0, it will set
+  /// that pin to the UART port 0 transmitter function. After that, if you
+  /// have properly enabled the UART hardware, when you attempt to send data
+  /// through the uart0 port, it will show up on the pin.
+  ///
+  /// Please consult the user manual for the chip you are using to figure out
+  /// which function codes correspond to specific functions.
+  ///
+  /// Generally, this method is only used laterally in the L1 layer. This is
+  /// due to the fact that other L1s need to use this library to setup their
+  /// external pins, but also due to the fact that a Hardware abstraction or
+  /// above should not have to concern itself with function codes, thus it is
+  /// the job of the L1 peripheral that uses this pin to manage its own
+  /// function code usage.
+  ///
+  uint8_t function = 0;
+
+  /// Set pin's resistor pull, setting ot either no resistor pull, pull down,
+  /// pull up and repeater.
+  Resistor resistor = Resistor::kPullUp;
+
+  /// Make pin open drain
+  bool open_drain = false;
+
+  /// Put pin into analog mode
+  bool as_analog = false;
+
+  /// Set the pin to use the internal pull up resistor
+  constexpr PinSettings_t PullUp()
+  {
+    resistor = Resistor::kPullUp;
+    return *this;
+  }
+
+  /// Set the pin to use the internal pull up resistor
+  constexpr PinSettings_t PullDown()
+  {
+    resistor = Resistor::kPullDown;
+    return *this;
+  }
+
+  /// Set the pin to not use a pull resistor
+  constexpr PinSettings_t Floating()
+  {
+    resistor = Resistor::kNone;
+    return *this;
+  }
+};
+
 /// Abstraction interface for physical electrical "pins".
 ///
 /// Pins are a type of electrical contact. Contacts are metal surfaces which can
@@ -27,135 +110,11 @@ namespace sjsu
 /// This interface represents a common set of functions that most controllers
 /// and systems support.
 /// @ingroup l1_peripheral
-class Pin : public Module
+class Pin : public Module<PinSettings_t>
 {
  public:
-  // ===========================================================================
-  // Interface Defintions
-  // ===========================================================================
-
-  /// Defines the set of internal resistance connections to a pin. Read specific
-  /// enumeration constant comments/documentation to understand more about what
-  /// each one does.
-  enum class Resistor : uint8_t
-  {
-    /// Disable resistor pull. If the pin is setup as high-z (input mode) and
-    /// not connected to anything then the pin will be floating. Its value will
-    /// not undefined.
-    kNone = 0,
-
-    /// Connect pin to ground using weak (high resistance) resistor.
-    kPullDown,
-
-    /// Connect pin to controller digital voltage (VCC) using a weak (high
-    /// resistance) resistor.
-    kPullUp,
-
-    /// Connect pin to a pull up or pull down resistor based what the pin's
-    /// previous state was.
-    ///
-    /// For example: if the pin was connected to a HIGH
-    /// voltage for a moment, then then was removed from this source (so now the
-    /// pin is disconnected or floating), then the pin will remember that
-    /// voltage state and enable the pull-up resistor.
-    ///
-    /// Connecting a LOW voltage source to the pin, will enable the pull-down
-    /// resistor.
-    kRepeater
-  };
-
   /// Set internal port and pin values.
   constexpr Pin(uint8_t port, uint8_t pin) : port_(port), pin_(pin) {}
-
-  // ===========================================================================
-  // Interface Methods
-  // ===========================================================================
-
-  // ---------------------------------------------------------------------------
-  // Configuration Methods
-  // ---------------------------------------------------------------------------
-
-  /// Set the pin's function using a function code.
-  /// The function code is very specific to the controller being used.
-  ///
-  /// But an example could be the LPC4078 chip's P0.0. It has the following
-  /// functions:
-  ///
-  ///    0. GPIO (General purpose input or output) pin
-  ///    1. CANBUS port 1 Read
-  ///    2. UART port 3 transmitter
-  ///    3. I2C port 1 serial data
-  ///    4. and UART port 0 transmitter
-  ///
-  /// Each function listed above is listed with its function code. If you pass
-  /// the value 4 into the ConfigureFunction function, for P0.0, it will set
-  /// that pin to the UART port 0 transmitter function. After that, if you have
-  /// properly enabled the UART hardware, when you attempt to send data through
-  /// the uart0 port, it will show up on the pin.
-  ///
-  /// Please consult the user manual for the chip you are using to figure out
-  /// which function codes correspond to specific functions.
-  ///
-  /// Generally, this method is only used laterally in the L1 layer. This is due
-  /// to the fact that other L1s need to use this library to setup their
-  /// external pins, but also due to the fact that a Hardware abstraction or
-  /// above should not have to concern itself with function codes, thus it is
-  /// the job of the L1 peripheral that uses this pin to manage its own function
-  /// code usage.
-  ///
-  /// @param function - pin function code
-  /// @throw sjsu::Exception - std::errc::invalid_argument the function code is
-  /// not valid.
-  virtual void ConfigureFunction(uint8_t function) = 0;
-
-  /// Set pin's resistor pull, setting ot either no resistor pull, pull down,
-  /// pull up and repeater.
-  ///
-  /// @param resistor - which resistor setup you would like.
-  /// @throw sjsu::Exception - with std::errc::not_supported if the pull option
-  /// is not supported by the MCU.
-  virtual void ConfigurePullResistor(Resistor resistor) = 0;
-
-  /// Set pin to open drain mode
-  ///
-  /// @param set_as_open_drain If false, disable open drain feature, pin
-  ///        becomes push-pull (a.k.a totem pole).
-  /// @throw sjsu::Exception - with std::errc::not_supported if open drain is
-  /// not supported by the MCU.
-  virtual void ConfigureAsOpenDrain(bool set_as_open_drain = true) = 0;
-
-  /// Set pin as analog mode
-  ///
-  /// @param set_as_analog If false, disable analog mode for pin
-  /// @throw sjsu::Exception - with std::errc::not_supported if analog mode is
-  /// not supported by the MCU.
-  virtual void ConfigureAsAnalogMode(bool set_as_analog = true) = 0;
-
-  // ---------------------------------------------------------------------------
-  // Usage Methods
-  // ---------------------------------------------------------------------------
-
-  // ===========================================================================
-  // Utility Methods
-  // ===========================================================================
-
-  /// Configure the pin to use the internal pull up resistor
-  void ConfigurePullUp()
-  {
-    return ConfigurePullResistor(Resistor::kPullUp);
-  }
-
-  /// Configure the pin to use the internal pull up resistor
-  void ConfigurePullDown()
-  {
-    return ConfigurePullResistor(Resistor::kPullDown);
-  }
-
-  /// Configure the pin to not use a pull resistor
-  void ConfigureFloating()
-  {
-    return ConfigurePullResistor(Resistor::kNone);
-  }
 
   /// Getter method for the pin's port.
   ///
@@ -173,10 +132,8 @@ class Pin : public Module
     return pin_;
   }
 
- protected:
-  /// Assigned port
+ private:
   uint8_t port_;
-  /// Assigned pin within the above port
   uint8_t pin_;
 };
 
@@ -189,11 +146,6 @@ inline sjsu::Pin & GetInactive<sjsu::Pin>()
    public:
     InactivePin() : sjsu::Pin(0, 0) {}
     void ModuleInitialize() override {}
-    void ModuleEnable(bool = true) override {}
-    void ConfigureFunction(uint8_t) override {}
-    void ConfigurePullResistor(Resistor) override {}
-    void ConfigureAsOpenDrain(bool) override {}
-    void ConfigureAsAnalogMode(bool) override {}
   };
 
   static InactivePin inactive;

--- a/library/L1_Peripheral/pwm.hpp
+++ b/library/L1_Peripheral/pwm.hpp
@@ -9,31 +9,20 @@
 
 namespace sjsu
 {
+/// Generic settings for a standard PWM peripheral
+struct PwmSettings_t
+{
+  /// The frequency of the PWM square wave
+  units::frequency::hertz_t frequency = 1_kHz;
+};
+
 /// An abstract interface for hardware that can generate Pulse Width Modulation
 /// (PWM) waveforms.
 ///
 /// @ingroup l1_peripheral
-class Pwm : public Module
+class Pwm : public Module<PwmSettings_t>
 {
  public:
-  // ===========================================================================
-  // Interface Methods
-  // ===========================================================================
-
-  // ---------------------------------------------------------------------------
-  // Configuration Methods
-  // ---------------------------------------------------------------------------
-
-  /// Set PWM waveform frequency. MUST be called before enabling the PWM.
-  ///
-  /// @param frequency - frequency to set the PWM waveform. Cannot be set
-  ///        higher than the peripheral frequency of the board.
-  virtual void ConfigureFrequency(units::frequency::hertz_t frequency) = 0;
-
-  // ---------------------------------------------------------------------------
-  // Usage Methods
-  // ---------------------------------------------------------------------------
-
   /// Set the duty cycle of the waveform
   ///
   /// @param duty_cycle - duty cycle precent from 0.0 to 1.0. Where 0.5 would
@@ -56,16 +45,11 @@ inline sjsu::Pwm & GetInactive<sjsu::Pwm>()
   {
    public:
     void ModuleInitialize() override {}
-    void ModuleEnable(bool = true) override {}
-
     void SetDutyCycle(float) override {}
-
     float GetDutyCycle() override
     {
       return 0.0;
     }
-
-    void ConfigureFrequency(units::frequency::hertz_t) override {}
   };
 
   static InactivePwm inactive;

--- a/library/L1_Peripheral/spi.hpp
+++ b/library/L1_Peripheral/spi.hpp
@@ -11,16 +11,9 @@
 
 namespace sjsu
 {
-/// An abstract interface for hardware that implements the Serial Peripheral
-/// Interface (SPI) communication protocol.
-/// @ingroup l1_peripheral
-class Spi : public Module
+/// Generic settings for a standard SPI peripheral
+struct SpiSettings_t : public MemoryEqualOperator_t<SpiSettings_t>
 {
- public:
-  // ===========================================================================
-  // Interface Definitions
-  // ===========================================================================
-
   /// SPI Data Frame bitwidths
   enum class FrameSize : uint8_t
   {
@@ -59,45 +52,22 @@ class Spi : public Module
     kSampleTrailing,
   };
 
-  // ===========================================================================
-  // Interface Methods
-  // ===========================================================================
+  /// Serial clock frequency
+  units::frequency::hertz_t clock_rate = 100_kHz;
+  /// The number of bits of each SPI transaction
+  FrameSize frame_size = FrameSize::kEightBits;
+  /// The polarity of the pins when the signal is idle
+  Polarity polarity = Polarity::kIdleLow;
+  /// The phase of the clock signal when communicating
+  Phase phase = Phase::kSampleLeading;
+};
 
-  // ---------------------------------------------------------------------------
-  // Configuration Methods
-  // ---------------------------------------------------------------------------
-
-  /// Set the serial clock signal/sample frequency.
-  ///
-  /// @param frequency - the clock rate in hertz to set the serial clock to.
-  /// Will attempt to get as close to the desired frequency as possible.
-  ///
-  /// @throw sjsu::Exception - if frequency is above what is possible for this
-  /// SPI peripheral. May be an indication that the input clock frequency of the
-  /// peripheral is not high enough to reach the desired frequency.
-  virtual void ConfigureFrequency(units::frequency::hertz_t frequency) = 0;
-
-  /// Set the behaviour/mode of the clock signal.
-  ///
-  /// @param polarity - clock polarity (see sjsu::Spi::Polarity for details)
-  /// @param phase - clock phase (see sjsu::Spi::Phase for details)
-  virtual void ConfigureClockMode(Polarity polarity = Polarity::kIdleLow,
-                                  Phase phase = Phase::kSampleLeading) = 0;
-
-  /// Set the serial clock signal/sample frequency as well as the polarity and
-  /// phase characteristics of the clock and data.
-  ///
-  /// @param size - the number of bits the SPI data frame size should be. Note
-  /// that many SPI implementations only support size 8 and size 16.
-  ///
-  /// @throw sjsu::Exception - if data size is not achievable with this SPI
-  /// implementation.
-  virtual void ConfigureFrameSize(FrameSize size = FrameSize::kEightBits) = 0;
-
-  // ---------------------------------------------------------------------------
-  // Usage Methods
-  // ---------------------------------------------------------------------------
-
+/// An abstract interface for hardware that implements the Serial Peripheral
+/// Interface (SPI) communication protocol.
+/// @ingroup l1_peripheral
+class Spi : public Module<SpiSettings_t>
+{
+ public:
   /// Write 8-bit data to the SPI bus and read back the data response on the
   /// bus.
   ///
@@ -113,15 +83,8 @@ class Spi : public Module
   virtual void Transfer(std::span<uint16_t> buffer) = 0;
 
   // ===========================================================================
-  // Utility Methods
+  // Helper Functions
   // ===========================================================================
-  void DefaultConfiguration()
-  {
-    // Use standard clock mode
-    ConfigureClockMode();
-    ConfigureFrameSize(FrameSize::kEightBits);
-    ConfigureFrequency(100_kHz);
-  }
 
   /// Transfer a single byte
   ///
@@ -193,13 +156,6 @@ inline sjsu::Spi & GetInactive<sjsu::Spi>()
   {
    public:
     void ModuleInitialize() override {}
-    void ModuleEnable(bool = true) override {}
-    void ConfigureFrequency(units::frequency::hertz_t) override {}
-    void ConfigureClockMode(Polarity = Polarity::kIdleLow,
-                            Phase    = Phase::kSampleLeading) override
-    {
-    }
-    void ConfigureFrameSize(FrameSize = FrameSize::kEightBits) override {}
     void Transfer(std::span<uint8_t>) override {}
     void Transfer(std::span<uint16_t>) override {}
   };

--- a/library/L1_Peripheral/stm32f10x/pin.hpp
+++ b/library/L1_Peripheral/stm32f10x/pin.hpp
@@ -43,17 +43,42 @@ class Pin final : public sjsu::Pin
         sjsu::bit::Insert(afio->MAPR, 0b010, sjsu::bit::MaskFromRange(24, 26));
   }
 
+  /// Maps the CONFIG flags for each pin use case
+  struct PinConfigMapping_t
+  {
+    /// Configuration bit 1
+    uint8_t CNF1;
+    /// Configuration bit 0
+    uint8_t CNF0;
+    /// Mode bits
+    uint8_t MODE;
+    /// Output data register
+    uint8_t PxODR;
+  };
+
   /// @param port - must be a capitol letter from 'A' to 'I'
   /// @param pin - must be between 0 to 15
   constexpr Pin(uint8_t port, uint8_t pin) : sjsu::Pin(port, pin) {}
 
+  /// Will not change the function of the pin but does change the
+  /// pin to its alternative function mode, meaning it will no longer respond or
+  /// operate based on the GPIO registers. Muxing pins to the correct function
+  /// must be done by the individual driver as the STM32F10x alternative
+  /// function registers do not follow any sort of consistent pattern.
+  ///
+  /// Set settings.function to 0 for gpio mode and set to 1 for alternative
+  /// mode.
+  /// If settings.as_analog is set to true, all other fields are ignored and the
+  /// pin is put into analog mode.
   void ModuleInitialize() override
   {
-    bool port_is_valid = ('A' <= port_ && port_ <= 'I');
-    if (!port_is_valid)
+    if (settings.function > 2)
     {
-      throw Exception(std::errc::invalid_argument,
-                      "Port must be between 'A' and 'I'");
+      throw Exception(
+          std::errc::invalid_argument,
+          "Only functions 0 (meaning General Purpose Output) or 1 (meaning "
+          "alternative function) or 2 (meaning General Purpose Floating Input) "
+          "allowed!");
     }
 
     auto & system = SystemController::GetPlatformController();
@@ -61,7 +86,7 @@ class Pin final : public sjsu::Pin
     // Enable the usage of alternative pin configurations
     system.PowerUpPeripheral(stm32f10x::SystemController::Peripherals::kAFIO);
 
-    switch (port_)
+    switch (GetPort())
     {
       case 'A':
         system.PowerUpPeripheral(
@@ -92,87 +117,123 @@ class Pin final : public sjsu::Pin
             stm32f10x::SystemController::Peripherals::kGpioG);
         break;
     }
-  }
 
-  /// Does nothing
-  void ModuleEnable(bool = true) override {}
+    static constexpr PinConfigMapping_t kPushPullGpioOutput = {
+      .CNF1  = 0,
+      .CNF0  = 0,
+      .MODE  = 0b11,  // Default to high speed 50 MHz
+      .PxODR = 0b0,   // Default to 0 LOW Voltage
+    };
 
-  /// Will not change the function of the pin but does change the
-  /// pin to its alternative function mode, meaning it will no longer respond or
-  /// operate based on the GPIO registers. Muxing pins to the correct function
-  /// must be done by the individual driver as the STM32F10x alternative
-  /// function registers do not follow any sort of consistent pattern.
-  ///
-  /// @param alternative_function - set to 0 for gpio mode and set to 1 for
-  ///        alternative mode.
-  void ConfigureFunction(uint8_t alternative_function) override
-  {
-    static constexpr auto kMode = bit::MaskFromRange(0, 1);
-    static constexpr auto kCFN1 = bit::MaskFromRange(3);
+    static constexpr PinConfigMapping_t kOpenDrainGpioOutput = {
+      .CNF1  = 0,
+      .CNF0  = 1,
+      .MODE  = 0b11,  // Default to high speed 50 MHz
+      .PxODR = 0b0,   // Default to 0 LOW Voltage
+    };
 
-    Initialize();
+    static constexpr PinConfigMapping_t kPushPullAlternativeOutput = {
+      .CNF1  = 1,
+      .CNF0  = 0,
+      .MODE  = 0b11,  // Default to high speed 50 MHz
+      .PxODR = 0b0,   // Default to 0 LOW Voltage
+    };
 
-    if (alternative_function > 0b1)
+    static constexpr PinConfigMapping_t kOpenDrainAlternativeOutput = {
+      .CNF1  = 1,
+      .CNF0  = 1,
+      .MODE  = 0b11,  // Default to high speed 50 MHz
+      .PxODR = 0b0,   // Default to 0 LOW Voltage
+    };
+
+    static constexpr PinConfigMapping_t kInputAnalog = {
+      .CNF1  = 0,
+      .CNF0  = 0,
+      .MODE  = 0b00,
+      .PxODR = 0b0,  // Don't care
+    };
+
+    static constexpr PinConfigMapping_t kInputFloat = {
+      .CNF1  = 0,
+      .CNF0  = 1,
+      .MODE  = 0b00,
+      .PxODR = 0b0,  // Don't care
+    };
+
+    static constexpr PinConfigMapping_t kInputPullDown = {
+      .CNF1  = 1,
+      .CNF0  = 0,
+      .MODE  = 0b00,
+      .PxODR = 0b0,  // Pull Down
+    };
+
+    static constexpr PinConfigMapping_t kInputPullUp = {
+      .CNF1  = 1,
+      .CNF0  = 0,
+      .MODE  = 0b00,
+      .PxODR = 0b1,  // Pull Up
+    };
+
+    PinConfigMapping_t mapping;
+
+    if (settings.as_analog)
     {
-      throw Exception(std::errc::invalid_argument, "Invalid function.");
+      mapping = kInputAnalog;
+    }
+    else if (settings.resistor == PinSettings_t::Resistor::kPullDown)
+    {
+      mapping = kInputPullDown;
+    }
+    else if (settings.resistor == PinSettings_t::Resistor::kPullUp)
+    {
+      mapping = kInputPullUp;
+    }
+    else if (settings.function == 0 && settings.open_drain == false)
+    {
+      mapping = kPushPullGpioOutput;
+    }
+    else if (settings.function == 0 && settings.open_drain == true)
+    {
+      mapping = kOpenDrainGpioOutput;
+    }
+    else if (settings.function == 1 && settings.open_drain == false)
+    {
+      mapping = kPushPullAlternativeOutput;
+    }
+    else if (settings.function == 1 && settings.open_drain == true)
+    {
+      mapping = kOpenDrainAlternativeOutput;
+    }
+    else if (settings.function == 2)
+    {
+      mapping = kInputFloat;
+    }
+    else
+    {
+      throw sjsu::Exception(
+          std::errc::not_supported,
+          "This pin configuration is not supported by the STM32F10x platform");
     }
 
-    uint32_t config = 0;
-    // Set the alternative bit flag
-    config = bit::Insert(config, alternative_function, kCFN1);
-    // Set output speed to 50 MHz RM008 page 161 Table 21.
-    config = bit::Insert(config, 0b11, kMode);
+    constexpr auto kCNF1 = bit::MaskFromRange(3);
+    constexpr auto kCNF0 = bit::MaskFromRange(2);
+    constexpr auto kMODE = bit::MaskFromRange(0, 1);
+
+    uint32_t config = bit::Value(0)
+                          .Insert(mapping.CNF1, kCNF1)
+                          .Insert(mapping.CNF0, kCNF0)
+                          .Insert(mapping.MODE, kMODE)
+                          .To<uint32_t>();
 
     SetConfig(config);
-  }
-
-  /// Should only be used for inputs. This method will change the pin's mode
-  /// form out to input.
-  void ConfigurePullResistor(Resistor resistor) override
-  {
-    bool pull_up   = true;
-    uint8_t config = 0;
-
-    // Configuration for analog input mode. See Table 20 on page 161 on RM0008
-    switch (resistor)
-    {
-      case Resistor::kNone: config = 0b0100; break;
-      case Resistor::kPullDown: pull_up = false; [[fallthrough]];
-      case Resistor::kPullUp: config = 0b1000; break;
-      case Resistor::kRepeater:
-      {
-        throw Exception(std::errc::not_supported, "Repeater not supported");
-      }
-    }
-
-    SetConfig(config);
-    Port()->ODR = bit::Insert(Port()->ODR, pull_up, pin_);
-  }
-
-  /// This function MUST NOT be called for pins set as inputs.
-  void ConfigureAsOpenDrain(bool set_as_open_drain = true) override
-  {
-    static constexpr auto kCFN0 = bit::MaskFromRange(2);
-
-    uint32_t config = GetConfig();
-
-    config = bit::Insert(config, set_as_open_drain, kCFN0);
-
-    SetConfig(config);
-  }
-
-  /// This function can only be used to set the pin as analog.
-  void ConfigureAsAnalogMode(bool = true) override
-  {
-    // Configuration for analog input mode. See Table 20 on page 161 on RM0008
-    SetConfig(0b0100);
+    Port()->ODR = bit::Insert(Port()->ODR, mapping.PxODR, GetPin());
   }
 
  private:
   /// Returns the a pointer the gpio port.
   GPIO_TypeDef * Port() const
   {
-    return gpio[port_ - 'A'];
+    return gpio[GetPort() - 'A'];
   }
 
   /// Returns a bit mask indicating where the config bits are in the config
@@ -180,7 +241,7 @@ class Pin final : public sjsu::Pin
   bit::Mask Mask() const
   {
     return {
-      .position = static_cast<uint32_t>((pin_ * 4) % 32),
+      .position = static_cast<uint32_t>((GetPin() * 4) % 32),
       .width    = 4,
     };
   }
@@ -191,7 +252,7 @@ class Pin final : public sjsu::Pin
   {
     volatile uint32_t * config = &Port()->CRL;
 
-    if (pin_ > 7)
+    if (GetPin() > 7)
     {
       config = &Port()->CRH;
     }
@@ -213,4 +274,19 @@ class Pin final : public sjsu::Pin
 
   friend class Gpio;
 };
+
+template <int port, int pin_number>
+inline Pin & GetPin()
+{
+  static_assert(
+      ('A' <= port && port <= 'I') && (0 <= pin_number && pin_number <= 15),
+      "\n\n"
+      "SJSU-Dev2 Compile Time Error:\n"
+      "    stm32f10x: Port must be between 'A' and 'I' and pin must be\n"
+      "    between 0 and 15!\n"
+      "\n");
+
+  static Pin pin(port, pin_number);
+  return pin;
+}
 }  // namespace sjsu::stm32f10x

--- a/library/L1_Peripheral/stm32f10x/test/adc_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/adc_test.cpp
@@ -1,9 +1,9 @@
 #include "L1_Peripheral/stm32f10x/adc.hpp"
+
 #include "L4_Testing/testing_frameworks.hpp"
 
 namespace sjsu::stm32f10x
 {
-EMIT_ALL_METHODS(Adc);
 TEST_CASE("Testing stm32f10x ADC")
 {
   Mock<SystemController> mock_controller;
@@ -12,11 +12,8 @@ TEST_CASE("Testing stm32f10x ADC")
 
   SystemController::SetPlatformController(&mock_controller.get());
 
-  Mock<sjsu::Pin> mock_adc;
-
-  Fake(Method(mock_adc, ModuleInitialize));
-  Fake(Method(mock_adc, ConfigureAsAnalogMode));
-  Fake(Method(mock_adc, ModuleEnable));
+  Mock<sjsu::Pin> mock_adc_pin;
+  Fake(Method(mock_adc_pin, ModuleInitialize));
 
   DMA_Channel_TypeDef local_dma;
   ADC_TypeDef local_adc;
@@ -28,7 +25,7 @@ TEST_CASE("Testing stm32f10x ADC")
   Adc::dma  = &local_dma;
 
   Adc::Channel_t mock_channel = {
-    .pin   = mock_adc.get(),
+    .pin   = mock_adc_pin.get(),
     .index = 5,
   };
 
@@ -83,17 +80,9 @@ TEST_CASE("Testing stm32f10x ADC")
     CHECK(static_cast<uint32_t>(kPeripheralDataAddress) == local_dma.CPAR);
     CHECK(static_cast<uint32_t>(kRamAddress) == local_dma.CMAR);
     CHECK(Adc::kDmaSettings == local_dma.CCR);
-  }
 
-  SECTION("Enable(true)")
-  {
-    // Exercise
-    test_subject.ModuleEnable();
-
-    // Verify
-    Verify(Method(mock_adc, ModuleInitialize)).Once();
-    Verify(Method(mock_adc, ConfigureAsAnalogMode).Using(true)).Once();
-    Verify(Method(mock_adc, ModuleEnable).Using(true)).Once();
+    Verify(Method(mock_adc_pin, ModuleInitialize)).Once();
+    CHECK(mock_adc_pin.get().CurrentSettings().as_analog == true);
   }
 
   SECTION("ReferenceVoltage()")

--- a/library/L1_Peripheral/stm32f10x/test/gpio_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/gpio_test.cpp
@@ -6,8 +6,6 @@
 
 namespace sjsu::stm32f10x
 {
-EMIT_ALL_METHODS(Gpio);
-
 namespace
 {
 bit::Mask Mask4Bit(sjsu::Gpio & gpio)
@@ -211,6 +209,7 @@ TEST_CASE("Testing stm32f10x Gpio")
       test[i].reg.CRH = 0xFFFF'FFFF;
 
       // Exercise
+      test[i].gpio.GetPin().settings.Floating();
       test[i].gpio.SetAsInput();
       // Exercise: Combine the two registers into 1 variable to make extraction
       //           easier.

--- a/library/L1_Peripheral/stm32f10x/test/spi_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/spi_test.cpp
@@ -6,8 +6,6 @@
 
 namespace sjsu::stm32f10x
 {
-EMIT_ALL_METHODS(Spi);
-
 TEST_CASE("Testing stm32f10x SPI")
 {
 }

--- a/library/L1_Peripheral/stm32f10x/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/system_controller_test.cpp
@@ -11,8 +11,6 @@
 
 namespace sjsu::stm32f10x
 {
-EMIT_ALL_METHODS(SystemController);
-
 TEST_CASE("Testing stm32f10x SystemController")
 {
   std::array<const SystemController::ResourceID *, 10> id = {

--- a/library/L1_Peripheral/stm32f4xx/gpio.hpp
+++ b/library/L1_Peripheral/stm32f4xx/gpio.hpp
@@ -21,9 +21,6 @@ class Gpio : public sjsu::Gpio
     pin_.Initialize();
   }
 
-  /// Pin/Gpio are both enabled by Initialize
-  void ModuleEnable(bool = true) override {}
-
   void SetDirection(Direction direction) override
   {
     if (direction == Direction::kInput)
@@ -88,4 +85,16 @@ class Gpio : public sjsu::Gpio
  private:
   sjsu::stm32f4xx::Pin pin_;
 };
+
+template <int port, int pin_number>
+inline Gpio & GetGpio()
+{
+  static_assert(
+      ('A' <= port && port <= 'I') && (0 <= pin_number && pin_number <= 15),
+      SJ2_ERROR_MESSAGE_DECORATOR("stm32f4xx: Port must be between 'A' and 'I' "
+                                  "and pin must be between 0 and 15!\n"));
+
+  static Gpio gpio(port, pin_number);
+  return gpio;
+}
 }  // namespace sjsu::stm32f4xx

--- a/library/L1_Peripheral/stm32f4xx/test/gpio_test.cpp
+++ b/library/L1_Peripheral/stm32f4xx/test/gpio_test.cpp
@@ -7,8 +7,6 @@
 
 namespace sjsu::stm32f4xx
 {
-EMIT_ALL_METHODS(Gpio);
-
 namespace
 {
 bit::Mask Mask2Bit(sjsu::Gpio & gpio)

--- a/library/L1_Peripheral/stm32f4xx/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/stm32f4xx/test/system_controller_test.cpp
@@ -10,8 +10,6 @@
 
 namespace sjsu::stm32f4xx
 {
-EMIT_ALL_METHODS(SystemController);
-
 TEST_CASE("Testing stm32f4xx SystemController")
 {
   std::array<const SystemController::ResourceID *, 13> id = {

--- a/library/L1_Peripheral/storage.hpp
+++ b/library/L1_Peripheral/storage.hpp
@@ -15,13 +15,9 @@ namespace sjsu
 /// Abstract interface for persistent memory storage systems.
 ///
 /// @ingroup l1_peripheral
-class Storage : public Module
+class Storage : public Module<>
 {
  public:
-  // ===========================================================================
-  // Interface Definitions
-  // ===========================================================================
-
   /// Defines the types of storage media.
   enum class Type
   {
@@ -42,18 +38,6 @@ class Storage : public Module
     /// Ferromagnetic RAM
     kFRam,
   };
-
-  // ===========================================================================
-  // Interface Methods
-  // ===========================================================================
-
-  // ---------------------------------------------------------------------------
-  // Configuration Methods
-  // ---------------------------------------------------------------------------
-
-  // ---------------------------------------------------------------------------
-  // Usage Methods
-  // ---------------------------------------------------------------------------
 
   /// @return the type of memory this driver controls. Can be called without
   ///         calling Initialize() first.
@@ -107,7 +91,7 @@ class Storage : public Module
   virtual void Read(uint32_t block_address, std::span<uint8_t> data) = 0;
 
   // ===========================================================================
-  // Utility Methods
+  // Helper Functions
   // ===========================================================================
 
   /// Helper function that overloads the Write function to allow usage of the
@@ -136,7 +120,6 @@ inline sjsu::Storage & GetInactive<sjsu::Storage>()
     }
 
     void ModuleInitialize() override {}
-    void ModuleEnable(bool = true) override {}
 
     bool IsMediaPresent() override
     {

--- a/library/L1_Peripheral/system_controller.hpp
+++ b/library/L1_Peripheral/system_controller.hpp
@@ -164,7 +164,7 @@ class SystemController
   virtual void PowerDownPeripheral(ResourceID peripheral) const = 0;
 
   // ===========================================================================
-  // Utility Methods
+  // Helper Functions
   // ===========================================================================
 
   /// Returns the clock configuration object as a casted reference of

--- a/library/L1_Peripheral/system_timer.hpp
+++ b/library/L1_Peripheral/system_timer.hpp
@@ -6,41 +6,31 @@
 
 #include "L1_Peripheral/inactive.hpp"
 #include "L1_Peripheral/interrupt.hpp"
+#include "config.hpp"
 #include "module.hpp"
 #include "utility/error_handling.hpp"
 #include "utility/units.hpp"
 
 namespace sjsu
 {
+/// Generic settings for a standard System Timer peripheral
+struct SystemTimerSettings_t
+{
+  /// The operating frequency of the system timer. This specifies how often the
+  /// callback is called. Setting this to 1 kHz will result in callback being
+  /// called every 1ms.
+  units::frequency::hertz_t frequency = config::kRtosFrequency;
+
+  /// The callback to be executed based on the operating frequency.
+  InterruptCallback callback = []() {};
+};
+
 /// A system timer is a general timer used primarily for generating an interrupt
 /// at a fixed period, like 1ms or 10ms. Such interrupts are generally used to
 /// give control of the processor back to an operating.
 /// @ingroup l1_peripheral
-class SystemTimer : public Module
+class SystemTimer : public Module<SystemTimerSettings_t>
 {
- public:
-  // ===========================================================================
-  // Interface Methods
-  // ===========================================================================
-
-  // ---------------------------------------------------------------------------
-  // Configuration Methods
-  // ---------------------------------------------------------------------------
-
-  /// Set the function to be called when the System Timer interrupt fires.
-  ///
-  /// @param callback - function to be called on system timer event.
-  virtual void ConfigureCallback(InterruptCallback callback) = 0;
-
-  /// Set frequency of the timer.
-  ///
-  /// @param frequency - How many times per second should the system timer
-  ///         interrupt be called.
-  virtual void ConfigureTickFrequency(units::frequency::hertz_t frequency) = 0;
-
-  // ---------------------------------------------------------------------------
-  // Usage Methods
-  // ---------------------------------------------------------------------------
 };
 
 /// Template specialization that generates an inactive sjsu::SystemTimer.
@@ -51,9 +41,6 @@ inline sjsu::SystemTimer & GetInactive<sjsu::SystemTimer>()
   {
    public:
     void ModuleInitialize() override {}
-    void ModuleEnable(bool = true) override {}
-    void ConfigureCallback(InterruptCallback) override {}
-    void ConfigureTickFrequency(units::frequency::hertz_t) override {}
   };
 
   static InactiveSystemTimer inactive;

--- a/library/L1_Peripheral/test/adc_test.cpp
+++ b/library/L1_Peripheral/test/adc_test.cpp
@@ -10,7 +10,6 @@ TEST_CASE("Testing ADC Interface")
 
   Fake(Method(mock_adc, Read));
   Fake(Method(mock_adc, GetActiveBits));
-  Fake(Method(mock_adc, ReferenceVoltage));
 
   Adc & test_subject = mock_adc.get();
 
@@ -75,10 +74,12 @@ TEST_CASE("Testing ADC Interface")
       expected_voltage     = 3300_mV;
     }
 
+    Fake(Method(mock_adc, ModuleInitialize));
     When(Method(mock_adc, Read)).AlwaysReturn(expected_adc_reading);
     When(Method(mock_adc, GetActiveBits)).AlwaysReturn(expected_active_bits);
-    When(Method(mock_adc, ReferenceVoltage))
-        .AlwaysReturn(expected_reference_voltage);
+    // Setup: set settings and initialize mock ADC to save the settings.
+    mock_adc.get().settings.reference_voltage = expected_reference_voltage;
+    mock_adc.get().Initialize();
 
     // Exercise
     auto actual_voltage = test_subject.Voltage();
@@ -86,7 +87,6 @@ TEST_CASE("Testing ADC Interface")
     // Verify
     Verify(Method(mock_adc, GetActiveBits)).Once();
     Verify(Method(mock_adc, Read)).Once();
-    Verify(Method(mock_adc, ReferenceVoltage)).Once();
 
     CHECK(actual_voltage.to<float>() ==
           doctest::Approx(expected_voltage.to<float>()).epsilon(0.01f));

--- a/library/L1_Peripheral/test/pin_test.cpp
+++ b/library/L1_Peripheral/test/pin_test.cpp
@@ -1,41 +1,37 @@
-#include "L4_Testing/testing_frameworks.hpp"
 #include "L1_Peripheral/pin.hpp"
+
+#include "L4_Testing/testing_frameworks.hpp"
 
 namespace sjsu
 {
 TEST_CASE("Testing L1 pin")
 {
   Mock<sjsu::Pin> mock_pin;
-  Fake(Method(mock_pin, ConfigurePullResistor));
-
   sjsu::Pin & pin = mock_pin.get();
 
   SECTION("PullUp()")
   {
     // Exercise
-    pin.ConfigurePullUp();
+    pin.settings.PullUp();
 
     // Verify
-    Verify(Method(mock_pin, ConfigurePullResistor)
-               .Using(sjsu::Pin::Resistor::kPullUp));
+    CHECK(pin.settings.resistor == PinSettings_t::Resistor::kPullUp);
   }
   SECTION("PullDown()")
   {
     // Exercise
-    pin.ConfigurePullDown();
+    pin.settings.PullDown();
 
     // Verify
-    Verify(Method(mock_pin, ConfigurePullResistor)
-               .Using(sjsu::Pin::Resistor::kPullDown));
+    CHECK(pin.settings.resistor == PinSettings_t::Resistor::kPullDown);
   }
-  SECTION("ConfigureFloating()")
+  SECTION("Floating()")
   {
     // Exercise
-    pin.ConfigureFloating();
+    pin.settings.Floating();
 
     // Verify
-    Verify(Method(mock_pin, ConfigurePullResistor)
-               .Using(sjsu::Pin::Resistor::kNone));
+    CHECK(pin.settings.resistor == PinSettings_t::Resistor::kNone);
   }
 }
 }  // namespace sjsu

--- a/library/L1_Peripheral/uart.hpp
+++ b/library/L1_Peripheral/uart.hpp
@@ -12,15 +12,10 @@
 
 namespace sjsu
 {
-/// An abstract interface for hardware that implements the Universal
-/// Asynchronous Receiver Transmitter (UART) hardware communication Protocol.
-/// @ingroup l1_peripheral
-class Uart : public Module
+/// Generic settings for a standard UART peripheral
+struct UartSettings_t : public MemoryEqualOperator_t<UartSettings_t>
 {
- public:
-  // ===========================================================================
-  // Interface Definitions
-  // ===========================================================================
+  /// Defines the available frame sizes for UART payloads
   enum class FrameSize : uint8_t
   {
     kFiveBits,
@@ -30,49 +25,43 @@ class Uart : public Module
     kNineBits,
   };
 
+  /// Defines the available stop bits options
   enum class StopBits : uint8_t
   {
     kSingle,
     kDouble,
   };
 
+  /// Defines the parity bit options
   enum class Parity : uint8_t
   {
+    /// Disable parity checks
     kNone = 0,
+    /// Enable parity and set HIGH when the number of bits is odd
     kOdd,
+    /// Enable parity and set HIGH when the number of bits is even
     kEven,
-    kForced1,
-    kForced0
   };
 
-  // ===========================================================================
-  // Interface Methods
-  // ===========================================================================
+  /// The operating baud rate (speed) of the UART signals.
+  uint32_t baud_rate = 9600;
 
-  // ---------------------------------------------------------------------------
-  // Configuration Methods
-  // ---------------------------------------------------------------------------
+  /// The number of bits for the UART packet payload.
+  FrameSize frame_size = FrameSize::kEightBits;
 
-  /// Set UART baud rate.
-  /// Will attempt to provide a baud rate closest to the value supplied.
-  ///
-  /// @param baud_rate the speed of the UART transmit and receive.
-  virtual void ConfigureBaudRate(uint32_t baud_rate) = 0;
+  /// The number of stop bits at the end of the.
+  StopBits stop = StopBits::kSingle;
 
-  /// Set UART baud rate.
-  /// Will attempt to provide a baud rate closest to the value supplied.
-  ///
-  /// @param size - Size of UART data frames (8 is standard).
-  /// @param stop - Number of stop bits (1 stop bit is standard)
-  /// @param parity - Type of parity control (none parity is standard)
-  virtual void ConfigureFormat(FrameSize size = FrameSize::kEightBits,
-                               StopBits stop  = StopBits::kSingle,
-                               Parity parity  = Parity::kNone) = 0;
+  /// The parity bit settings for UART.
+  Parity parity = Parity::kNone;
+};
 
-  // ---------------------------------------------------------------------------
-  // Usage Methods
-  // ---------------------------------------------------------------------------
-
+/// An abstract interface for hardware that implements the Universal
+/// Asynchronous Receiver Transmitter (UART) hardware communication Protocol.
+/// @ingroup l1_peripheral
+class Uart : public Module<UartSettings_t>
+{
+ public:
   /// Checks if there is data available for this port.
   ///
   /// @returns true if the UART port has received some data.
@@ -104,7 +93,7 @@ class Uart : public Module
   }
 
   // ===========================================================================
-  // Utility Methods
+  // Helper Functions
   // ===========================================================================
 
   /// Transmit just 1 byte
@@ -213,13 +202,6 @@ inline sjsu::Uart & GetInactive<sjsu::Uart>()
   {
    public:
     void ModuleInitialize() override {}
-    void ModuleEnable(bool) override {}
-    void ConfigureBaudRate(uint32_t) override {}
-    void ConfigureFormat(FrameSize = FrameSize::kEightBits,
-                         StopBits  = StopBits::kSingle,
-                         Parity    = Parity::kNone) override
-    {
-    }
     void Write(std::span<const uint8_t>) override {}
     size_t Read(std::span<uint8_t>) override
     {

--- a/library/L2_HAL/actuators/servo/test/rmd_x_test.cpp
+++ b/library/L2_HAL/actuators/servo/test/rmd_x_test.cpp
@@ -5,16 +5,11 @@
 
 namespace sjsu
 {
-EMIT_ALL_METHODS(RmdX);
-
 TEST_CASE("Testing RMD-X7")
 {
   Mock<Can> mock_can;
 
   Fake(Method(mock_can, Can::ModuleInitialize));
-  Fake(Method(mock_can, Can::ModuleEnable));
-  Fake(Method(mock_can, Can::ConfigureBaudRate));
-  Fake(Method(mock_can, Can::ConfigureReceiveHandler));
   Fake(OverloadedMethod(mock_can, Can::Send, void(const Can::Message_t &)));
   Fake(Method(mock_can, Can::Receive));
   Fake(Method(mock_can, Can::HasData));
@@ -27,40 +22,16 @@ TEST_CASE("Testing RMD-X7")
   // Inject test_gpio into button object
   RmdX test_servo(network, kId);
 
-  SECTION("ModuleInitialize")
+  SECTION("Initialize()")
   {
-    test_servo.ModuleInitialize();
+    // Exercise
+    test_servo.Initialize();
 
-    Verify(Method(mock_can, ModuleInitialize),
-           Method(mock_can, ConfigureBaudRate).Using(1_MHz),
-           Method(mock_can, ModuleEnable))
+    // Verify
+    Verify(Method(mock_can, ModuleInitialize)).Once();
+    CHECK(mock_can.get().CurrentSettings().baud_rate == 1_MHz);
+    Verify(OverloadedMethod(mock_can, Send, void(const Can::Message_t &)))
         .Once();
-
-    Verify(Method(mock_can, ModuleInitialize),
-           Method(mock_can, ConfigureBaudRate).Using(1_MHz),
-           Method(mock_can, ModuleEnable))
-        .Once();
-  }
-
-  SECTION("ModuleEnable")
-  {
-    SECTION("true")
-    {
-      // Nothing should happen so this always succeeds
-    }
-
-    SECTION("false")
-    {
-      // Setup
-      mock_can.get().SetStateToEnabled();
-
-      // Exercise
-      test_servo.ModuleEnable(false);
-
-      // Verify
-      Verify(OverloadedMethod(mock_can, Send, void(const Can::Message_t &)))
-          .Once();
-    }
   }
 }
 }  // namespace sjsu

--- a/library/L2_HAL/audio/buzzer.hpp
+++ b/library/L2_HAL/audio/buzzer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 
 #include "L1_Peripheral/pwm.hpp"
@@ -18,7 +19,7 @@ namespace sjsu
 /// // Set buzzer to 550 Hz @ 75% volume.
 /// buzzer.Beep(550_Hz, 0.75f);
 /// ```
-class Buzzer : public Module
+class Buzzer : public Module<>
 {
  public:
   /// Initialize Buzzer with a pwm signal.
@@ -27,18 +28,8 @@ class Buzzer : public Module
   void ModuleInitialize() override
   {
     pwm_.Initialize();
-  }
-
-  void ModuleEnable(bool enable = true) override
-  {
-    // Enable/Disable the pwm module.
-    pwm_.Enable(enable);
-
-    if (enable)
-    {
-      // Stop the buzzer from producing any audio.
-      Stop();
-    }
+    // Stop the buzzer from producing any audio.
+    Stop();
   }
 
   /// Turn off buzzer.
@@ -54,13 +45,12 @@ class Buzzer : public Module
   void Beep(units::frequency::hertz_t frequency = 500_Hz, float volume = 1.0f)
   {
     // Need to disable and re-enable pwm in order to change the frequency.
-    pwm_.Enable(false);
-    pwm_.ConfigureFrequency(frequency);
-    pwm_.Enable(true);
+    pwm_.settings.frequency = frequency;
+    pwm_.Initialize();
 
     // NOTE: Since the PWM is at its loudest at 50% duty cycle, the maximum PWM
     // is divided by 2.
-    pwm_.SetDutyCycle(volume / 2);
+    pwm_.SetDutyCycle(std::clamp(volume, 0.0f, 1.0f) / 2);
   }
 
   /// @return gets the current running volume of the device.

--- a/library/L2_HAL/audio/test/buzzer_test.cpp
+++ b/library/L2_HAL/audio/test/buzzer_test.cpp
@@ -5,17 +5,13 @@
 
 namespace sjsu
 {
-EMIT_ALL_METHODS(Buzzer);
-
 TEST_CASE("Testing buzzer")
 {
   // Create mock for PWM class
   Mock<Pwm> mock_pwm_pin;
 
   Fake(Method(mock_pwm_pin, ModuleInitialize),
-       Method(mock_pwm_pin, ModuleEnable),
-       Method(mock_pwm_pin, SetDutyCycle),
-       Method(mock_pwm_pin, ConfigureFrequency));
+       Method(mock_pwm_pin, SetDutyCycle));
 
   Pwm & pwm = mock_pwm_pin.get();
 
@@ -29,28 +25,7 @@ TEST_CASE("Testing buzzer")
 
     // Verify
     Verify(Method(mock_pwm_pin, ModuleInitialize)).Once();
-  }
-
-  SECTION("Enable()")
-  {
-    // Exercise
-    pwm.SetStateToInitialized();
-    test_subject.ModuleEnable();
-
-    // Verify
-    Verify(Method(mock_pwm_pin, ModuleEnable).Using(true),
-           Method(mock_pwm_pin, SetDutyCycle).Using(0.0f));
-  }
-
-  SECTION("Enable(false)")
-  {
-    // Exercise
-    pwm.SetStateToEnabled();
-    test_subject.ModuleEnable(false);
-
-    // Verify
-    Verify(Method(mock_pwm_pin, ModuleEnable).Using(false));
-    Verify(Method(mock_pwm_pin, SetDutyCycle).Using(0.0f)).Never();
+    Verify(Method(mock_pwm_pin, SetDutyCycle).Using(0.0f));
   }
 
   SECTION("Beep()")
@@ -60,16 +35,14 @@ TEST_CASE("Testing buzzer")
     constexpr float kVolume   = 0.5f;
 
     // Exercise
-    pwm.SetStateToEnabled();
     test_subject.Beep(kFrequency, kVolume);
 
     // Verify
     // NOTE: Since the PWM is at its loudest at 50% duty cycle, the maximum PWM
     // is divided by 2.
-    Verify(Method(mock_pwm_pin, ModuleEnable).Using(false),
-           Method(mock_pwm_pin, ConfigureFrequency).Using(kFrequency),
-           Method(mock_pwm_pin, ModuleEnable).Using(true),
-           Method(mock_pwm_pin, SetDutyCycle).Using(kVolume / 2));
+    Verify(Method(mock_pwm_pin, ModuleInitialize)).Once();
+    Verify(Method(mock_pwm_pin, SetDutyCycle).Using(kVolume / 2));
+    CHECK(mock_pwm_pin.get().CurrentSettings().frequency == kFrequency);
   }
 
   SECTION("Stop()")

--- a/library/L2_HAL/boards/sjone.hpp
+++ b/library/L2_HAL/boards/sjone.hpp
@@ -13,44 +13,38 @@
 struct sjone  // NOLINT
 {
   /// Predefined SJOne spi0 peripheral
-  inline static sjsu::lpc17xx::Spi spi0 =
-      sjsu::lpc17xx::Spi(sjsu::lpc17xx::SpiBus::kSpi0);
+  inline static sjsu::lpc17xx::Spi & spi0 = sjsu::lpc17xx::GetSpi<0>();
   /// Predefined SJOne spi1 peripheral
-  inline static sjsu::lpc17xx::Spi spi1 =
-      sjsu::lpc17xx::Spi(sjsu::lpc17xx::SpiBus::kSpi1);
+  inline static sjsu::lpc17xx::Spi & spi1 = sjsu::lpc17xx::GetSpi<1>();
 
   /// Predefined SJOne i2c0 peripheral
-  inline static sjsu::lpc17xx::I2c i2c0 =
-      sjsu::lpc17xx::I2c(sjsu::lpc17xx::I2cBus::kI2c0);
+  inline static sjsu::lpc17xx::I2c & i2c0 = sjsu::lpc17xx::GetI2c<0>();
   /// Predefined SJOne i2c1 peripheral
-  inline static sjsu::lpc17xx::I2c i2c1 =
-      sjsu::lpc17xx::I2c(sjsu::lpc17xx::I2cBus::kI2c1);
+  inline static sjsu::lpc17xx::I2c & i2c1 = sjsu::lpc17xx::GetI2c<1>();
   /// Predefined SJOne i2c2 peripheral
-  inline static sjsu::lpc17xx::I2c i2c2 =
-      sjsu::lpc17xx::I2c(sjsu::lpc17xx::I2cBus::kI2c2);
+  inline static sjsu::lpc17xx::I2c & i2c2 = sjsu::lpc17xx::GetI2c<2>();
 
   /// Predefined SJOne led0 peripheral
-  inline static sjsu::lpc40xx::Gpio led0 = sjsu::lpc40xx::Gpio(1, 0);
+  inline static sjsu::lpc40xx::Gpio & led0 = sjsu::lpc40xx::GetGpio<1, 0>();
   /// Predefined SJOne led1 peripheral
-  inline static sjsu::lpc40xx::Gpio led1 = sjsu::lpc40xx::Gpio(1, 1);
+  inline static sjsu::lpc40xx::Gpio & led1 = sjsu::lpc40xx::GetGpio<1, 1>();
   /// Predefined SJOne led2 peripheral
-  inline static sjsu::lpc40xx::Gpio led2 = sjsu::lpc40xx::Gpio(1, 4);
+  inline static sjsu::lpc40xx::Gpio & led2 = sjsu::lpc40xx::GetGpio<1, 4>();
   /// Predefined SJOne led3 peripheral
-  inline static sjsu::lpc40xx::Gpio led3 = sjsu::lpc40xx::Gpio(1, 8);
+  inline static sjsu::lpc40xx::Gpio & led3 = sjsu::lpc40xx::GetGpio<1, 8>();
 
   /// Predefined SJOne adc2 peripheral
-  inline static sjsu::lpc17xx::Adc adc2 =
-      sjsu::lpc17xx::Adc(sjsu::lpc17xx::AdcChannel::kChannel2);
+  inline static sjsu::lpc17xx::Adc & adc2 = sjsu::lpc17xx::GetAdc<2>();
 
   /// @returns fully constructed onboard Mma8452q device driver
-  [[gnu::always_inline]] inline static sjsu::Mma8452q & Accelerometer()
+  inline static sjsu::Mma8452q & Accelerometer()
   {
     static sjsu::Mma8452q accelerometer(i2c2);
     return accelerometer;
   }
 
   /// @returns fully constructed onboard Sd device driver
-  [[gnu::always_inline]] inline static sjsu::Sd & SdCard()
+  inline static sjsu::Sd & SdCard()
   {
     static sjsu::lpc17xx::Gpio sd_cs = sjsu::lpc17xx::Gpio(2, 6);
     static sjsu::Sd sd(spi1, sd_cs, sjsu::GetInactive<sjsu::Gpio>());
@@ -58,14 +52,14 @@ struct sjone  // NOLINT
   }
 
   /// @returns fully constructed onboard Tmp102 device driver
-  [[gnu::always_inline]] inline static sjsu::Tmp102 & Temperature()
+  inline static sjsu::Tmp102 & Temperature()
   {
     static sjsu::Tmp102 tmp102(i2c2);
     return tmp102;
   }
 
   /// @returns fully constructed onboard Temt6000x01 device driver
-  [[gnu::always_inline]] inline static sjsu::Temt6000x01 & LightSensor()
+  inline static sjsu::Temt6000x01 & LightSensor()
   {
     // A 10kOhm pull-down resistor is used on the SJOne board.
     constexpr units::impedance::ohm_t kPullDownResistance = 10_kOhm;

--- a/library/L2_HAL/boards/sjtwo.hpp
+++ b/library/L2_HAL/boards/sjtwo.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "L1_Peripheral/inactive.hpp"
 #include "L1_Peripheral/lpc40xx/gpio.hpp"
 #include "L1_Peripheral/lpc40xx/i2c.hpp"
 #include "L1_Peripheral/lpc40xx/spi.hpp"
-#include "L1_Peripheral/inactive.hpp"
 #include "L2_HAL/displays/oled/ssd1306.hpp"
 #include "L2_HAL/memory/sd.hpp"
 #include "L2_HAL/sensors/environment/temperature/si7060.hpp"
@@ -16,63 +16,57 @@
 struct sjtwo  // NOLINT
 {
   /// Predefined SJTwo spi0 peripheral
-  inline static sjsu::lpc40xx::Spi spi0 =
-      sjsu::lpc40xx::Spi(sjsu::lpc40xx::Spi::Bus::kSpi0);
+  inline static sjsu::lpc40xx::Spi & spi0 = sjsu::lpc40xx::GetSpi<0>();
   /// Predefined SJTwo spi1 peripheral
-  inline static sjsu::lpc40xx::Spi spi1 =
-      sjsu::lpc40xx::Spi(sjsu::lpc40xx::Spi::Bus::kSpi1);
+  inline static sjsu::lpc40xx::Spi & spi1 = sjsu::lpc40xx::GetSpi<1>();
   /// Predefined SJTwo spi2 peripheral
-  inline static sjsu::lpc40xx::Spi spi2 =
-      sjsu::lpc40xx::Spi(sjsu::lpc40xx::Spi::Bus::kSpi2);
+  inline static sjsu::lpc40xx::Spi & spi2 = sjsu::lpc40xx::GetSpi<2>();
 
   /// Predefined SJTwo i2c0 peripheral
-  inline static sjsu::lpc40xx::I2c i2c0 =
-      sjsu::lpc40xx::I2c(sjsu::lpc40xx::I2c::Bus::kI2c0);
+  inline static sjsu::lpc40xx::I2c & i2c0 = sjsu::lpc40xx::GetI2c<0>();
   /// Predefined SJTwo i2c1 peripheral
-  inline static sjsu::lpc40xx::I2c i2c1 =
-      sjsu::lpc40xx::I2c(sjsu::lpc40xx::I2c::Bus::kI2c1);
+  inline static sjsu::lpc40xx::I2c & i2c1 = sjsu::lpc40xx::GetI2c<1>();
   /// Predefined SJTwo i2c2 peripheral
-  inline static sjsu::lpc40xx::I2c i2c2 =
-      sjsu::lpc40xx::I2c(sjsu::lpc40xx::I2c::Bus::kI2c2);
+  inline static sjsu::lpc40xx::I2c & i2c2 = sjsu::lpc40xx::GetI2c<2>();
 
   /// Predefined SJTwo led0 peripheral
-  inline static sjsu::lpc40xx::Gpio led0 = sjsu::lpc40xx::Gpio(2, 3);
+  inline static sjsu::lpc40xx::Gpio & led0 = sjsu::lpc40xx::GetGpio<2, 3>();
   /// Predefined SJTwo led1 peripheral
-  inline static sjsu::lpc40xx::Gpio led1 = sjsu::lpc40xx::Gpio(1, 26);
+  inline static sjsu::lpc40xx::Gpio & led1 = sjsu::lpc40xx::GetGpio<1, 26>();
   /// Predefined SJTwo led2 peripheral
-  inline static sjsu::lpc40xx::Gpio led2 = sjsu::lpc40xx::Gpio(1, 24);
+  inline static sjsu::lpc40xx::Gpio & led2 = sjsu::lpc40xx::GetGpio<1, 24>();
   /// Predefined SJTwo led3 peripheral
-  inline static sjsu::lpc40xx::Gpio led3 = sjsu::lpc40xx::Gpio(1, 18);
+  inline static sjsu::lpc40xx::Gpio & led3 = sjsu::lpc40xx::GetGpio<1, 18>();
 
   /// Predefined SJTwo button0 peripheral
-  inline static sjsu::lpc40xx::Gpio button0 = sjsu::lpc40xx::Gpio(1, 19);
+  inline static sjsu::lpc40xx::Gpio & button0 = sjsu::lpc40xx::GetGpio<1, 19>();
   /// Predefined SJTwo button1 peripheral
-  inline static sjsu::lpc40xx::Gpio button1 = sjsu::lpc40xx::Gpio(1, 15);
+  inline static sjsu::lpc40xx::Gpio & button1 = sjsu::lpc40xx::GetGpio<1, 15>();
   /// Predefined SJTwo button2 peripheral
-  inline static sjsu::lpc40xx::Gpio button2 = sjsu::lpc40xx::Gpio(0, 30);
+  inline static sjsu::lpc40xx::Gpio & button2 = sjsu::lpc40xx::GetGpio<0, 30>();
   /// Predefined SJTwo button3 peripheral
-  inline static sjsu::lpc40xx::Gpio button3 = sjsu::lpc40xx::Gpio(0, 29);
+  inline static sjsu::lpc40xx::Gpio & button3 = sjsu::lpc40xx::GetGpio<0, 29>();
 
   /// @returns fully constructed onboard Oled device driver
-  [[gnu::always_inline]] inline static sjsu::Graphics & Oled()
+  inline static sjsu::Graphics & Oled()
   {
     static sjsu::lpc40xx::Gpio oled_cs = sjsu::lpc40xx::Gpio(1, 22);
     static sjsu::lpc40xx::Gpio oled_dc = sjsu::lpc40xx::Gpio(1, 25);
-    static sjsu::Ssd1306 oled_display(spi1, oled_cs, oled_dc,
-                                      sjsu::GetInactive<sjsu::Gpio>());
+    static sjsu::Ssd1306 oled_display(
+        spi1, oled_cs, oled_dc, sjsu::GetInactive<sjsu::Gpio>());
     static sjsu::Graphics oled(oled_display);
     return oled;
   }
 
   /// @returns fully constructed onboard Accelerometer device driver
-  [[gnu::always_inline]] inline static sjsu::Mma8452q & Accelerometer()
+  inline static sjsu::Mma8452q & Accelerometer()
   {
     static sjsu::Mma8452q accelerometer(i2c2);
     return accelerometer;
   }
 
   /// @returns fully constructed onboard Sd Card device driver
-  [[gnu::always_inline]] inline static sjsu::Sd & SdCard()
+  inline static sjsu::Sd & SdCard()
   {
     static sjsu::lpc40xx::Gpio sd_cs = sjsu::lpc40xx::Gpio(1, 8);
     static sjsu::Sd sd(spi2, sd_cs, sjsu::GetInactive<sjsu::Gpio>());
@@ -80,14 +74,14 @@ struct sjtwo  // NOLINT
   }
 
   // /// @returns fully constructed onboard Gesture device driver
-  // [[gnu::always_inline]] inline static sjsu::Apds9960 & Gesture()
+  // inline static sjsu::Apds9960 & Gesture()
   // {
   //   static sjsu::Apds9960 apds9960(i2c2);
   //   return apds9960;
   // }
 
   /// @returns fully constructed onboard Temperature device driver
-  [[gnu::always_inline]] inline static sjsu::Si7060 & Temperature()
+  inline static sjsu::Si7060 & Temperature()
   {
     static sjsu::Si7060 si7060(i2c2);
     return si7060;

--- a/library/L2_HAL/communication/infrared_receiver.hpp
+++ b/library/L2_HAL/communication/infrared_receiver.hpp
@@ -2,24 +2,21 @@
 
 #include <functional>
 
-#include "utility/infrared_algorithms.hpp"
+#include "module.hpp"
 #include "utility/error_handling.hpp"
+#include "utility/infrared_algorithms.hpp"
 
 namespace sjsu
 {
 /// An abstract interface for communication drivers responsible for receiving
 /// infrared (IR) data.
-class InfraredReceiver
+class InfraredReceiver : public Module<>
 {
  public:
   /// Callback handler that is invoked when a complete data frame is
   /// successfully received.
   using DataReceivedHandler =
       std::function<void(const infrared::DataFrame_t *)>;
-
-  /// Initialize and enable hardware. This must be called before any other
-  /// method in this interface is called.
-  virtual void Initialize() = 0;
 
   /// Sets the callback handler that is invoked when a data frame is received.
   ///

--- a/library/L2_HAL/communication/internet_socket.hpp
+++ b/library/L2_HAL/communication/internet_socket.hpp
@@ -17,7 +17,7 @@ namespace sjsu
 /// within computer network. It is an endpoint in networking software.
 /// Modeled after Berkley Sockets (POSIX sockets)
 /// @ingroup communication
-class InternetSocket : public Module
+class InternetSocket : public Module<>
 {
  public:
   /// Which Internet Protocol to use for communicating with the remote host
@@ -67,7 +67,7 @@ class InternetSocket : public Module
 /// protocol. This interface is used for connecting a device to a Wifi hotspot
 /// (client).
 /// @ingroup communication
-class WiFi : public Module
+class WiFi : public Module<>
 {
  public:
   /// Contains network connection information such as IP address, netmask,

--- a/library/L2_HAL/communication/test/tsop752_test.cpp
+++ b/library/L2_HAL/communication/test/tsop752_test.cpp
@@ -5,8 +5,6 @@
 
 namespace sjsu
 {
-EMIT_ALL_METHODS(Tsop752);
-
 TEST_CASE("Tsop752 Infrared Receiver Test")
 {
   Mock<PulseCapture> mock_pulse_capture;
@@ -31,7 +29,7 @@ TEST_CASE("Tsop752 Infrared Receiver Test")
     ir_receiver.Initialize();
 
     // Verify
-    Verify(Method(mock_pulse_capture, Initialize)).Once();
+    Verify(Method(mock_timer, Initialize)).Once();
     Verify(Method(mock_pulse_capture, Initialize)).Once();
   }
 

--- a/library/L2_HAL/communication/tsop752.hpp
+++ b/library/L2_HAL/communication/tsop752.hpp
@@ -31,7 +31,7 @@ class Tsop752 final : public InfraredReceiver
   }
 
   /// Initializes the PulseCapture and Timer peripherals.
-  void Initialize() override
+  void ModuleInitialize() override
   {
     // using 1 MHz for 1µs precision (1 / 1'000'000 Hz = 1µs)
     constexpr units::frequency::hertz_t kFrequency = 1_MHz;

--- a/library/L2_HAL/displays/lcd/st7066u.hpp
+++ b/library/L2_HAL/displays/lcd/st7066u.hpp
@@ -14,7 +14,7 @@
 namespace sjsu
 {
 /// Driver for the St7066u driver of a LCD character display
-class St7066u : public Module
+class St7066u : public Module<>
 {
  public:
   /// Data transfer operation types.
@@ -127,42 +127,22 @@ class St7066u : public Module
   /// Initialize the pins needed to communicate with the LCD screen
   void ModuleInitialize() override
   {
-    // Phase 1. Initialize
     register_select_pin_.Initialize();
     read_write_pin_.Initialize();
     enable_pin_.Initialize();
     data_bus_.Initialize();
 
-    // Phase 2. Configure
-    // Phase 3. Enable
-    register_select_pin_.Enable();
-    read_write_pin_.Enable();
-    enable_pin_.Enable();
-    data_bus_.Enable();
-
-    // Phase 4. Setup
     register_select_pin_.SetAsOutput();
     read_write_pin_.SetAsOutput();
     enable_pin_.SetAsOutput();
     data_bus_.SetAsOutput();
 
     enable_pin_.SetHigh();
-  }
 
-  /// Initialize the pins needed to communicate with the LCD screen
-  void ModuleEnable(bool enable = true) override
-  {
-    if (enable)
-    {
-      WriteCommand(Value(Command::kDefaultDisplayConfiguration) |
-                   Value(kBusMode) | Value(kDisplayMode) | Value(kFontStyle));
-      SetDisplayOn();
-      ClearDisplay();
-    }
-    else
-    {
-      LogDebug("Disabled not supported for this driver");
-    }
+    WriteCommand(Value(Command::kDefaultDisplayConfiguration) |
+                 Value(kBusMode) | Value(kDisplayMode) | Value(kFontStyle));
+    SetDisplayOn();
+    ClearDisplay();
   }
 
   /// Clears all characters on the display by sending the clear display command

--- a/library/L2_HAL/displays/lcd/test/st7066u_test.cpp
+++ b/library/L2_HAL/displays/lcd/test/st7066u_test.cpp
@@ -6,8 +6,6 @@
 
 namespace sjsu
 {
-EMIT_ALL_METHODS(St7066u);
-
 TEST_CASE("Testing St7066u Parallel LCD Driver")
 {
   Mock<Gpio> mock_rs;  // RS: Register Select
@@ -16,22 +14,18 @@ TEST_CASE("Testing St7066u Parallel LCD Driver")
   Mock<ParallelBus> mock_data_bus;
 
   Fake(Method(mock_rs, ModuleInitialize));
-  Fake(Method(mock_rs, ModuleEnable));
   Fake(Method(mock_rs, SetDirection));
   Fake(Method(mock_rs, Set));
 
   Fake(Method(mock_rw, ModuleInitialize));
-  Fake(Method(mock_rw, ModuleEnable));
   Fake(Method(mock_rw, SetDirection));
   Fake(Method(mock_rw, Set));
 
   Fake(Method(mock_e, ModuleInitialize));
-  Fake(Method(mock_e, ModuleEnable));
   Fake(Method(mock_e, SetDirection));
   Fake(Method(mock_e, Set));
 
   Fake(Method(mock_data_bus, ModuleInitialize));
-  Fake(Method(mock_data_bus, ModuleEnable));
   Fake(Method(mock_data_bus, SetDirection));
   Fake(Method(mock_data_bus, Write));
 
@@ -61,11 +55,6 @@ TEST_CASE("Testing St7066u Parallel LCD Driver")
            Method(mock_e, ModuleInitialize),
            Method(mock_data_bus, ModuleInitialize));
 
-    Verify(Method(mock_rs, ModuleEnable).Using(true),
-           Method(mock_rw, ModuleEnable).Using(true),
-           Method(mock_e, ModuleEnable).Using(true),
-           Method(mock_data_bus, ModuleEnable).Using(true));
-
     Verify(Method(mock_rs, SetDirection).Using(Gpio::Direction::kOutput),
            Method(mock_rw, SetDirection).Using(Gpio::Direction::kOutput),
            Method(mock_e, SetDirection).Using(Gpio::Direction::kOutput),
@@ -74,7 +63,7 @@ TEST_CASE("Testing St7066u Parallel LCD Driver")
     Verify(Method(mock_e, Set).Using(Gpio::State::kHigh));
   }
 
-  SECTION("Enable()")
+  SECTION("Initialize() bus width")
   {
     // Setup
     constexpr St7066u::Command kDefaultConfiguration =
@@ -118,8 +107,7 @@ TEST_CASE("Testing St7066u Parallel LCD Driver")
       };
 
       // Exercise
-      four_bit_bus_lcd.SetState(Module::State::kInitialized);
-      four_bit_bus_lcd.Enable();
+      four_bit_bus_lcd.Initialize();
     }
 
     SECTION("With 8-bit Bus")
@@ -134,8 +122,7 @@ TEST_CASE("Testing St7066u Parallel LCD Driver")
       };
 
       // Exercise
-      eight_bit_bus_lcd.SetState(Module::State::kInitialized);
-      eight_bit_bus_lcd.Enable();
+      eight_bit_bus_lcd.Initialize();
     }
   }
 
@@ -144,7 +131,7 @@ TEST_CASE("Testing St7066u Parallel LCD Driver")
     constexpr Gpio::State kExpectedRegisterSelect =
         Gpio::State(St7066u::WriteOperation::kCommand);
     uint8_t expected_data;
-    St7066u lcd = four_bit_bus_lcd;
+    St7066u & lcd = four_bit_bus_lcd;
 
     SECTION("ClearDisplay")
     {
@@ -227,7 +214,7 @@ TEST_CASE("Testing St7066u Parallel LCD Driver")
     constexpr Gpio::State kExpectedRegisterSelect =
         Gpio::State(St7066u::WriteOperation::kCommand);
     uint8_t expected_data;
-    St7066u lcd = eight_bit_bus_lcd;
+    St7066u & lcd = eight_bit_bus_lcd;
 
     SECTION("ClearDisplay")
     {

--- a/library/L2_HAL/displays/oled/ssd1306.hpp
+++ b/library/L2_HAL/displays/oled/ssd1306.hpp
@@ -91,27 +91,15 @@ class Ssd1306 final : public PixelDisplay
 
   void ModuleInitialize() override
   {
-    // Phase 1: Initialize()
+    SpiSettings_t default_settings;  // Default construct
+    default_settings.clock_rate = clock_rate_;
+    spi_.settings               = default_settings;
+
     spi_.Initialize();
     cs_.Initialize();
     dc_.Initialize();
     reset_.Initialize();
 
-    // Phase 2: Configure()
-    if (spi_.RequiresConfiguration())
-    {
-      spi_.ConfigureClockMode();
-      spi_.ConfigureFrameSize(Spi::FrameSize::kEightBits);
-      spi_.ConfigureFrequency(clock_rate_);
-    }
-
-    // Phase 3: Enable()
-    spi_.Enable();
-    cs_.Enable();
-    dc_.Enable();
-    reset_.Enable();
-
-    // Phase 4: Usage
     cs_.SetAsOutput();
     dc_.SetAsOutput();
     reset_.SetAsOutput();
@@ -123,19 +111,9 @@ class Ssd1306 final : public PixelDisplay
     Delay(100us);
     reset_.SetHigh();
     Delay(100us);
-  }
 
-  void ModuleEnable(bool enable = true) override
-  {
-    if (enable)
-    {
-      Clear();
-      InitializationPanel();
-    }
-    else
-    {
-      LogDebug("Disable does nothing");
-    }
+    Clear();
+    InitializationPanel();
   }
 
   /// Clears the internal bitmap_ to zero (or a user defined clear_value)

--- a/library/L2_HAL/displays/pixel_display.hpp
+++ b/library/L2_HAL/displays/pixel_display.hpp
@@ -10,7 +10,7 @@ namespace sjsu
 {
 /// PixelDisplay is a common set of methods that all hardware display drivers
 /// must implement to work with the Graphics class.
-class PixelDisplay : public Module
+class PixelDisplay : public Module<>
 {
  public:
   /// Describes the color space and resolution of the display.

--- a/library/L2_HAL/io/parallel_bus.hpp
+++ b/library/L2_HAL/io/parallel_bus.hpp
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
-#include "module.hpp"
 #include "L1_Peripheral/gpio.hpp"
+#include "module.hpp"
 #include "utility/log.hpp"
 
 namespace sjsu
@@ -11,7 +11,7 @@ namespace sjsu
 /// ParallelBus is an abstraction for a set of parallel digital input/output
 /// pins that can be used to communicate over a parallel bus, read switch
 /// states, or possibly control control LEDs.
-class ParallelBus : public Module
+class ParallelBus : public Module<>
 {
  public:
   // ===========================================================================
@@ -59,17 +59,19 @@ class ParallelBus : public Module
   ///
   /// @param set_as_open_drain - if true, set output of parallel bus pins to
   /// open drain. Otherwise, set pin as push-pull.
-  virtual void ConfigureAsOpenDrain(
-      [[maybe_unused]] bool set_as_open_drain = true)
+  virtual void ConfigureAsOpenDrain(bool set_as_open_drain = true)
   {
-    throw sjsu::Exception(
-        std::errc::not_supported,
-        "ConfigureAsOpenDrain() is not available for this parallel bus "
-        "implementation.");
+    if (set_as_open_drain)
+    {
+      throw sjsu::Exception(
+          std::errc::not_supported,
+          "ConfigureAsOpenDrain() is not available for this parallel bus "
+          "implementation.");
+    }
   }
 
   // ===========================================================================
-  // Utility Methods
+  // Helper Functions
   // ===========================================================================
 
   /// Utility method for setting all pins to output.

--- a/library/L2_HAL/io/parallel_bus/parallel_gpio.hpp
+++ b/library/L2_HAL/io/parallel_bus/parallel_gpio.hpp
@@ -38,19 +38,12 @@ class ParallelGpio : public sjsu::ParallelBus
     }
   }
 
-  void ModuleEnable(bool enable = true) override
-  {
-    for (auto gpio : io_)
-    {
-      gpio->Enable(enable);
-    }
-  }
-
   void ConfigureAsOpenDrain(bool set_as_open_drain = true) override
   {
     for (auto gpio : io_)
     {
-      gpio->GetPin().ConfigureAsOpenDrain(set_as_open_drain);
+      gpio->GetPin().settings.open_drain = set_as_open_drain;
+      gpio->GetPin().Initialize();
     }
   }
 

--- a/library/L2_HAL/io/parallel_bus/test/parallel_gpio_test.cpp
+++ b/library/L2_HAL/io/parallel_bus/test/parallel_gpio_test.cpp
@@ -20,15 +20,15 @@ TEST_CASE("Testing Parallel Gpio Implementation")
   Mock<sjsu::Pin> mock_pin2;
   Mock<sjsu::Pin> mock_pin3;
 
+  Fake(Method(mock_pin0, ModuleInitialize));
+  Fake(Method(mock_pin1, ModuleInitialize));
+  Fake(Method(mock_pin2, ModuleInitialize));
+  Fake(Method(mock_pin3, ModuleInitialize));
+
   Fake(Method(mock_gpio0, ModuleInitialize));
   Fake(Method(mock_gpio1, ModuleInitialize));
   Fake(Method(mock_gpio2, ModuleInitialize));
   Fake(Method(mock_gpio3, ModuleInitialize));
-
-  Fake(Method(mock_gpio0, ModuleEnable));
-  Fake(Method(mock_gpio1, ModuleEnable));
-  Fake(Method(mock_gpio2, ModuleEnable));
-  Fake(Method(mock_gpio3, ModuleEnable));
 
   Fake(Method(mock_gpio0, SetDirection));
   Fake(Method(mock_gpio1, SetDirection));
@@ -39,11 +39,6 @@ TEST_CASE("Testing Parallel Gpio Implementation")
   Fake(Method(mock_gpio1, Set));
   Fake(Method(mock_gpio2, Set));
   Fake(Method(mock_gpio3, Set));
-
-  Fake(Method(mock_pin0, ConfigureAsOpenDrain));
-  Fake(Method(mock_pin1, ConfigureAsOpenDrain));
-  Fake(Method(mock_pin2, ConfigureAsOpenDrain));
-  Fake(Method(mock_pin3, ConfigureAsOpenDrain));
 
   When(Method(mock_gpio0, GetPin)).AlwaysReturn(mock_pin0.get());
   When(Method(mock_gpio1, GetPin)).AlwaysReturn(mock_pin1.get());
@@ -69,24 +64,6 @@ TEST_CASE("Testing Parallel Gpio Implementation")
     Verify(Method(mock_gpio1, ModuleInitialize));
     Verify(Method(mock_gpio2, ModuleInitialize));
     Verify(Method(mock_gpio3, ModuleInitialize));
-  }
-
-  SECTION("Enable()")
-  {
-    // Setup
-    mock_gpio0.get().SetStateToInitialized();
-    mock_gpio1.get().SetStateToInitialized();
-    mock_gpio2.get().SetStateToInitialized();
-    mock_gpio3.get().SetStateToInitialized();
-
-    // Exercise
-    test_subject.ModuleEnable();
-
-    // Verify
-    Verify(Method(mock_gpio0, ModuleEnable));
-    Verify(Method(mock_gpio1, ModuleEnable));
-    Verify(Method(mock_gpio2, ModuleEnable));
-    Verify(Method(mock_gpio3, ModuleEnable));
   }
 
   SECTION("SetDirection")
@@ -132,10 +109,14 @@ TEST_CASE("Testing Parallel Gpio Implementation")
       test_subject.ConfigureAsOpenDrain();
 
       // Verify
-      Verify(Method(mock_pin0, ConfigureAsOpenDrain).Using(true));
-      Verify(Method(mock_pin1, ConfigureAsOpenDrain).Using(true));
-      Verify(Method(mock_pin2, ConfigureAsOpenDrain).Using(true));
-      Verify(Method(mock_pin3, ConfigureAsOpenDrain).Using(true));
+      Verify(Method(mock_pin0, Pin::ModuleInitialize));
+      CHECK(mock_pin0.get().CurrentSettings().open_drain == true);
+      Verify(Method(mock_pin1, Pin::ModuleInitialize));
+      CHECK(mock_pin1.get().CurrentSettings().open_drain == true);
+      Verify(Method(mock_pin2, Pin::ModuleInitialize));
+      CHECK(mock_pin2.get().CurrentSettings().open_drain == true);
+      Verify(Method(mock_pin3, Pin::ModuleInitialize));
+      CHECK(mock_pin3.get().CurrentSettings().open_drain == true);
     }
 
     SECTION("Open Drain Disabled")
@@ -144,10 +125,14 @@ TEST_CASE("Testing Parallel Gpio Implementation")
       test_subject.ConfigureAsOpenDrain(false);
 
       // Verify
-      Verify(Method(mock_pin0, ConfigureAsOpenDrain).Using(false));
-      Verify(Method(mock_pin1, ConfigureAsOpenDrain).Using(false));
-      Verify(Method(mock_pin2, ConfigureAsOpenDrain).Using(false));
-      Verify(Method(mock_pin3, ConfigureAsOpenDrain).Using(false));
+      Verify(Method(mock_pin0, Pin::ModuleInitialize));
+      CHECK(mock_pin0.get().CurrentSettings().open_drain == false);
+      Verify(Method(mock_pin1, Pin::ModuleInitialize));
+      CHECK(mock_pin1.get().CurrentSettings().open_drain == false);
+      Verify(Method(mock_pin2, Pin::ModuleInitialize));
+      CHECK(mock_pin2.get().CurrentSettings().open_drain == false);
+      Verify(Method(mock_pin3, Pin::ModuleInitialize));
+      CHECK(mock_pin3.get().CurrentSettings().open_drain == false);
     }
   }
 

--- a/library/L2_HAL/memory_access_protocol.hpp
+++ b/library/L2_HAL/memory_access_protocol.hpp
@@ -5,17 +5,27 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
-#include <type_traits>
 #include <span>
+#include <type_traits>
 #include <utility>
 
 #include "L1_Peripheral/i2c.hpp"
+#include "utility/byte.hpp"
 #include "utility/enum.hpp"
 #include "utility/error_handling.hpp"
-#include "utility/byte.hpp"
 
 namespace sjsu
 {
+/// The MemoryAccessProtocol class is used to make interacting with devices over
+/// an external communication protocol, like SPI, I2C, Uart, a similar
+/// experience to manipulating variables, arrays and peripheral registers as if
+/// the memory was within the system's local memory map. It is a tools used to
+/// simplify code, make more readable, and in some cases, reduce the size of
+/// code size.
+///
+/// MemoryAccessProtocol is not limited to hardware communication protocols. For
+/// example, there is nothing stopping code from using this library to update a
+/// database or some values running on a server.
 class MemoryAccessProtocol
 {
  public:
@@ -49,22 +59,25 @@ class MemoryAccessProtocol
   template <AddressWidth address_width, std::endian endianness>
   struct Specification_t
   {
-    static constexpr auto AddressWidth()
+    /// @returns the width of the address space
+    static constexpr auto AddressWidth() noexcept
     {
       return address_width;
     }
-    static constexpr auto Endianness()
+    /// @returns the endianness of the register's contents.
+    static constexpr auto Endianness() noexcept
     {
       return endianness;
     }
   };
 
+  /// Holds the address of a register and how many bytes in size it is.
   struct AddressLocationPrototype_t
   {
-    /// Address location as a number. Prefer to use a radix that matches the
-    /// datasheet. For example, if the datasheet uses hex, use hexidecimal
-    /// values. If the addresses are in decimal, use decimal to make
-    /// verification easier.
+    /// Address location as a number. When setting this value, prefer to use a
+    /// radix that matches the datasheet. For example, if the datasheet uses
+    /// hex, use hexidecimal values. If the addresses are in decimal, use
+    /// decimal to make verification easier.
     uint32_t address;
 
     /// How many bytes constitute the width of the register. This can be larger
@@ -83,16 +96,19 @@ class MemoryAccessProtocol
   class Address
   {
    public:
+    /// @return constexpr auto - return the register specification
     static constexpr auto GetSpecification()
     {
       return Specification_t<address_width, endianness>{};
     }
 
+    /// @return constexpr auto - the width of the memory map's address space
     static constexpr auto AddressWidth()
     {
       return Value(GetSpecification().AddressWidth());
     }
 
+    /// @return the endianness of the register in this Address location
     static constexpr auto Endianess()
     {
       return GetSpecification().Endianness();
@@ -111,6 +127,7 @@ class MemoryAccessProtocol
     /// cast.
     uint8_t width;
 
+    /// Constructor for Address object
     explicit constexpr Address(Specification_t<address_width, endianness>,
                                AddressLocationPrototype_t proto)
         : address{}, width(proto.width)
@@ -128,27 +145,45 @@ class MemoryAccessProtocol
   class AccessHandler
   {
    public:
+    /// Largest reasonable integer to contain the size of an access handler.
     using ContainerInt = uint64_t;
 
+    /// @param memory_map - reference to a memory map protocol object
+    /// @param address - address/register to be accessed
     constexpr AccessHandler(MemoryAccessProtocol & memory_map,
                             const Address<address_width, endianness> & address)
         : map_(memory_map), address_(address)
     {
     }
 
+    /// Write the contents of payload to the address
+    /// @param payload - bytes to be written to the payload
     constexpr void Write(std::span<const uint8_t> payload)
     {
       return map_.Write(address_.address, payload);
     }
 
+    /// Read contents of register into payload
+    /// @param payload - buffer to read bytes of register into
     constexpr void Read(std::span<uint8_t> payload) const
     {
       return map_.Read(address_.address, payload);
     }
 
+    /// SFINAE template check a value used for a template paremater is in fact
+    /// an integer.
+    ///
+    /// @tparam T - The type to check.
     template <typename T>
     using IsInteger = std::enable_if_t<std::is_integral_v<T>>;
 
+    /// The value will be converted into an array of bytes fitting the
+    /// endianness of the memory map protocol and will be written to the memory
+    /// map using the memory map protocol's Write method.
+    ///
+    /// @tparam Integer - Type of the value to be written
+    /// @tparam typename - checks if the value is an integer
+    /// @param write_value - value to be written
     template <typename Integer, typename = IsInteger<Integer>>
     void operator=(Integer write_value)
     {
@@ -163,18 +198,37 @@ class MemoryAccessProtocol
       return Write(kValueSpan);
     }
 
+    /// Array of bytes to be written to the memory map using the memory map
+    /// protocol's Write method.
+    ///
+    /// @tparam N - number of elements in the array (do not set this value) it
+    /// is inferred by the compiler when called.
+    /// @param value_array - array of bytes to be written to the register.
     template <size_t N>
     void operator=(const std::array<uint8_t, N> && value_array)
     {
       return Write(value_array);
     }
 
+    /// Array of bytes to be written to the memory map using the memory map
+    /// protocol's Write method.
+    ///
+    /// @tparam N - number of elements in the array (do not set this value) it
+    /// is inferred by the compiler when called.
+    /// @param value_array - array of bytes to be written to the register.
     template <size_t N>
     void operator=(const std::array<uint8_t, N> & value_array)
     {
       return Write(value_array);
     }
 
+    /// Array of integers to be written to the memory map using the memory map
+    /// protocol's Write method. The array of integers is converted into a byte
+    /// array based on the endianness of the memory map registers.
+    ///
+    /// @tparam N - number of elements in the array (do not set this value) it
+    /// is inferred by the compiler when called.
+    /// @param value_array - array of integers to be written to the register.
     template <typename T, size_t N>
     void operator=(const std::array<T, N> && value_array)
     {
@@ -183,19 +237,32 @@ class MemoryAccessProtocol
       for (size_t i = 0; i < value_array.size(); i++)
       {
         auto byte_array = ToByteArray(endianness, value_array[i]);
-        std::copy(byte_array.begin(), byte_array.end(),
+        std::copy(byte_array.begin(),
+                  byte_array.end(),
                   endian_payload.begin() + (i * byte_array.size()));
       }
 
       return (*this = endian_payload);
     }
 
+    /// Array of integers to be written to the memory map using the memory map
+    /// protocol's Write method. The array of integers is converted into a byte
+    /// array based on the endianness of the memory map registers.
+    ///
+    /// @tparam N - number of elements in the array (do not set this value) it
+    /// is inferred by the compiler when called.
+    /// @param value_array - array of integers to be written to the register.
     template <typename T, size_t N>
     void operator=(const std::array<T, N> & value_array)
     {
       return (*this = std::move(value_array));
     }
 
+    /// Casting this into an integer will perform a read operation using the
+    /// memory access protocol and will convert the value to an integer.
+    ///
+    /// @tparam Integer - type to convert the contents of the register into
+    /// @return Integer - the value within the register
     template <typename Integer>
     operator Integer() const
     {
@@ -210,6 +277,7 @@ class MemoryAccessProtocol
       return ToInteger<Integer>(endianness, kReadSpan);
     }
 
+    /// Read contents of register and return it as an array of bytes
     template <size_t N>
     operator std::array<uint8_t, N>() const
     {
@@ -218,6 +286,7 @@ class MemoryAccessProtocol
       return result;
     }
 
+    /// Read contents of register and return it as an array of integers
     template <typename T, size_t N>
     operator std::array<T, N>() const
     {
@@ -250,14 +319,23 @@ class MemoryAccessProtocol
     return *this;                                                \
   }
 
+    /// Allows the usage of the | operator on memory mapped register.
     ADD_ARITHMETIC_OPERATION(|);
+    /// Allows the usage of the & operator on memory mapped register.
     ADD_ARITHMETIC_OPERATION(&);
+    /// Allows the usage of the ^ operator on memory mapped register.
     ADD_ARITHMETIC_OPERATION(^);
+    /// Allows the usage of the + operator on memory mapped register.
     ADD_ARITHMETIC_OPERATION(+);
+    /// Allows the usage of the - operator on memory mapped register.
     ADD_ARITHMETIC_OPERATION(-);
+    /// Allows the usage of the * operator on memory mapped register.
     ADD_ARITHMETIC_OPERATION(*);
+    /// Allows the usage of the / operator on memory mapped register.
     ADD_ARITHMETIC_OPERATION(/);
+    /// Allows the usage of the >> operator on memory mapped register.
     ADD_ARITHMETIC_OPERATION(>>);
+    /// Allows the usage of the << operator on memory mapped register.
     ADD_ARITHMETIC_OPERATION(<<);
 
 #undef ADD_ARITHMETIC_OPERATION
@@ -275,15 +353,35 @@ class MemoryAccessProtocol
   // Interface Methods
   // ===========================================================================
 
+  /// Perform a write operation on the register address and write the contents
+  /// of the payload to the register.
+  ///
+  /// @param address - Register address to write to
+  /// @param payload - bytes in this buffer to be written into the register
   virtual void Write(std::span<const uint8_t> address,
                      std::span<const uint8_t> payload) = 0;
+
+  /// Perform a read operation on the register address and store the contents
+  /// into the payload.
+  ///
+  /// @param address - Register address to read from
+  /// @param payload - buffer for bytes read from the register will be stored
   virtual void Read(std::span<const uint8_t> address,
-                    std::span<uint8_t> payload)        = 0;
+                    std::span<uint8_t> payload) = 0;
 
   // ===========================================================================
   // Class Methods
   // ===========================================================================
 
+  /// The main operator that makes access to registers as seemless as accessing
+  /// an array. Returns an AccessHandler object which, when assigned or
+  /// read from will communicate with the MemoryAccessProtocol in order to alter
+  /// the memory of the device register.
+  ///
+  /// @tparam address_width - width of the address space
+  /// @tparam endianness - endianness of the register
+  /// @param device_register - device register to access
+  /// @return auto - a AccessHandler object.
   template <AddressWidth address_width, std::endian endianness>
   auto operator[](
       const MemoryAccessProtocol::Address<address_width, endianness> &
@@ -293,7 +391,11 @@ class MemoryAccessProtocol
   }
 };  // namespace sjsu
 
-// TODO(#1330): Not implemented yet
+// TODO(#1330): Not implemented
+/// Generic Mock MemoryAccessProtocol that works for any size AddressWidth.
+/// Utilizes a std::unordered_map to keep track of the registers
+///
+/// @tparam size - the address width size.
 template <MemoryAccessProtocol::AddressWidth size>
 class MockProtocol : public MemoryAccessProtocol
 {
@@ -306,22 +408,24 @@ class MockProtocol<MemoryAccessProtocol::AddressWidth::kByte1>
     : public MemoryAccessProtocol
 {
  public:
+  /// Array of bytes to hold the memory map contents. This array is publicly
+  /// available so that unit tests can configure the contents.
   std::array<uint8_t, (1 << 8)> memory_map;
 
   void Write(std::span<const uint8_t> address,
              std::span<const uint8_t> payload) override
   {
     // Only use the first byte of the address
-    std::copy_n(payload.begin(), payload.size(),
-                memory_map.begin() + address[0]);
+    std::copy_n(
+        payload.begin(), payload.size(), memory_map.begin() + address[0]);
   }
 
   void Read(std::span<const uint8_t> address,
             std::span<uint8_t> payload) override
   {
     // Only use the first byte of the address
-    std::copy_n(memory_map.begin() + address[0], payload.size(),
-                payload.begin());
+    std::copy_n(
+        memory_map.begin() + address[0], payload.size(), payload.begin());
   }
 };
 
@@ -332,13 +436,20 @@ template <>
 class MockProtocol<MemoryAccessProtocol::AddressWidth::kByte2>
     : public MemoryAccessProtocol
 {
+  /// Array of bytes to hold the memory map contents. This array is publicly
+  /// available so that unit tests can configure the contents.
   std::array<uint8_t, (1 << 16)> memory_map_;
 };
 
+/// Generic MemoryAccessProtocol for common I2C devices
+///
+/// @tparam MaximumPayloadSize - The size of register in bytes.
 template <size_t MaximumPayloadSize = 1>
 class I2cProtocol : public MemoryAccessProtocol
 {
  public:
+  /// @param i2c_address - address of the device to communicate with
+  /// @param i2c - I2C peripheral to use
   constexpr I2cProtocol(uint8_t i2c_address, sjsu::I2c & i2c)
       : i2c_address_(i2c_address), i2c_(i2c)
   {
@@ -377,6 +488,14 @@ class I2cProtocol : public MemoryAccessProtocol
   sjsu::I2c & i2c_;
 };
 
+/// Used to validate at compile time a set of addresses do not overlap in
+/// memory.
+///
+/// @tparam address_width - number of bytes that represent the address
+/// @tparam endianness - the endianness of the memory
+/// @param addresses - list of MemoryAccessProtocol::Addresses
+/// @return true - the list of registers does NOT overlap
+/// @return false - the list of registers DOES overlap
 template <MemoryAccessProtocol::AddressWidth address_width,
           std::endian endianness>
 constexpr bool NoRegistersOverlap(

--- a/library/L2_HAL/sensors/battery/battery_charge.hpp
+++ b/library/L2_HAL/sensors/battery/battery_charge.hpp
@@ -7,7 +7,7 @@ namespace sjsu
 {
 /// @ingroup battery
 /// Abstract interface for a state of charge.
-class BatteryCharge : public Module
+class BatteryCharge : public Module<>
 {
  public:
   /// Read the state of battery charge from a device.

--- a/library/L2_HAL/sensors/battery/coulomb_counter.hpp
+++ b/library/L2_HAL/sensors/battery/coulomb_counter.hpp
@@ -8,7 +8,7 @@ namespace sjsu
 {
 /// Abstraction Interface for a coulomb counter. This device can give us
 /// information about a connected battery's power level.
-class CoulombCounter : public Module
+class CoulombCounter : public Module<>
 {
  public:
   /// Returns the cumulative amount of charge that has passed through the

--- a/library/L2_HAL/sensors/battery/max17043.hpp
+++ b/library/L2_HAL/sensors/battery/max17043.hpp
@@ -17,10 +17,12 @@ namespace sjsu
 class Max170343 : public BatteryCharge
 {
  public:
+  /// Memory map specification for the Max170343
   static constexpr MemoryAccessProtocol::Specification_t<
       MemoryAccessProtocol::AddressWidth::kByte1,
       std::endian::big>
       kSpec{};
+
   /// Map of all of the used device addresses in this driver.
   /// All registers are 2 bytes and must be completely r/w for success
   struct Map  // NOLINT
@@ -70,6 +72,14 @@ class Max170343 : public BatteryCharge
   {
   }
 
+  /// Max17043 Constructor for debugging or custom external map protocol
+  ///
+  /// @param external_map_protocol - alternative map protocol.
+  /// @param i2c - i2c peripheral used to commnicate with device.
+  /// @param alert_pin - pin that the devices alert pin is connected to.
+  /// @param callback - InterruptCallback that is used when the alert_pin goes
+  /// low.
+  /// @param address - max17043 device address.
   explicit constexpr Max170343(MemoryAccessProtocol & external_map_protocol,
                                I2c & i2c,
                                sjsu::Gpio & alert_pin,
@@ -85,30 +95,20 @@ class Max170343 : public BatteryCharge
 
   void ModuleInitialize() override
   {
+    // Initialize using previously set settings
     i2c_.Initialize();
 
-    if (i2c_.RequiresConfiguration())
-    {
-      i2c_.ConfigureClockRate();
-    }
-
-    i2c_.Enable();
+    // Wake up the device from sleep mode
+    ActiveMode(true);
+    alert_pin_.SetAsInput();
+    alert_pin_.GetPin().settings.PullDown();
+    alert_pin_.GetPin().Initialize();
+    alert_pin_.AttachInterrupt(callback_, sjsu::Gpio::Edge::kFalling);
   }
 
-  void ModuleEnable(bool enable = true) override
+  void ModulePowerDown() override
   {
-    if (enable)
-    {
-      // Wake up the device from sleep mode
-      ActiveMode(true);
-      alert_pin_.SetAsInput();
-      alert_pin_.GetPin().ConfigurePullDown();
-      alert_pin_.AttachInterrupt(callback_, sjsu::Gpio::Edge::kFalling);
-    }
-    else
-    {
-      ActiveMode(false);
-    }
+    ActiveMode(false);
   }
 
   float Read() override
@@ -122,6 +122,7 @@ class Max170343 : public BatteryCharge
     return charge_percent / 100.0f;
   }
 
+  /// @return units::voltage::volt_t - measured voltage of the battery
   units::voltage::volt_t GetVoltage()
   {
     uint16_t volt_data = memory_[Map::kCellVoltage];
@@ -134,6 +135,46 @@ class Max170343 : public BatteryCharge
     return voltage;
   }
 
+  /// Restart fuel-gauge calculations in the same manner as initial power-up
+  /// of the IC. Use if start up is noisy to reduce error.
+  void QuickStart()
+  {
+    memory_[Map::kMode] = 0x4000;
+  }
+
+  /// Completely reset the max17043 as if power had been removed. Device will
+  /// not ACK the I2C transaction.
+  void Reset()
+  {
+    memory_[Map::kCommand] = 0x5400;
+  }
+
+  /// Sets the threshold battery % for when the the ALERT signal is asserted
+  /// (pulled LOW)
+  ///
+  /// @param threshold - Battery percentage to alert host about. Must be between
+  /// 0.0f to 0.32f (presenting 0% and 32% respectively).
+  void SetAlertThreshold(float threshold)
+  {
+    threshold              = std::clamp(threshold, 0.0f, 0.32f);
+    uint8_t threshold_code = 32 - static_cast<uint8_t>(threshold * 100);
+
+    std::array<int8_t, 2> config_register = memory_[Map::kConfig];
+    config_register[1] = bit::Insert(config_register[1], threshold_code, 0, 5);
+    // Write the alert threshold
+    memory_[Map::kConfig] = config_register;
+  }
+
+  /// Clear alert signal
+  void ResetAlert()
+  {
+    std::array<int8_t, 2> config_register = memory_[Map::kConfig];
+    bit::Clear(config_register[1], 6);
+    // Reset the low battery alert
+    memory_[Map::kConfig] = config_register;
+  }
+
+ private:
   void ActiveMode(bool is_active = true)
   {
     std::array<int8_t, 2> config_register = memory_[Map::kConfig];
@@ -148,43 +189,6 @@ class Max170343 : public BatteryCharge
     memory_[Map::kConfig] = config_register;
   }
 
-  void QuickStart()
-  {
-    /// restart fuel-gauge calculations in the same manner as initial power-up
-    /// of the IC. Use if start up is noisy to reduce error.
-    memory_[Map::kMode] = 0x4000;
-  }
-
-  void Reset()
-  {
-    /// Completely reset the max17043 as if power had been removed. does not
-    /// i2c_ ACK
-    memory_[Map::kCommand] = 0x5400;
-  }
-
-  void SetAlertThreshold(float threshold)
-  {
-    // Sets the threshold for when the IC alerts that the battery% is running
-    // low by setting the alert byte to 1 and alert pin low.
-    if (threshold > 0.32f)
-      threshold = 0.32f;
-    uint8_t threshold_code = 32 - static_cast<uint8_t>(threshold * 100);
-
-    std::array<int8_t, 2> config_register = memory_[Map::kConfig];
-    config_register[1] = bit::Insert(config_register[1], threshold_code, 0, 5);
-    // Write the alert threshold
-    memory_[Map::kConfig] = config_register;
-  }
-
-  void ResetAlert()
-  {
-    std::array<int8_t, 2> config_register = memory_[Map::kConfig];
-    bit::Clear(config_register[1], 6);
-    // Reset the low battery alert
-    memory_[Map::kConfig] = config_register;
-  }
-
- private:
   I2c & i2c_;
   I2cProtocol<1> i2c_memory_;
   MemoryAccessProtocol & memory_;

--- a/library/L2_HAL/sensors/battery/test/ltc4150_test.cpp
+++ b/library/L2_HAL/sensors/battery/test/ltc4150_test.cpp
@@ -33,19 +33,16 @@ TEST_CASE("Test LTC4150 Coulomb Counter/ Battery Gas Gauge")
 
   Fake(
       Method(mock_primary_hardware_counter, HardwareCounter::ModuleInitialize));
-  Fake(Method(mock_primary_hardware_counter, HardwareCounter::ModuleEnable));
   Fake(Method(mock_primary_hardware_counter, HardwareCounter::GetCount));
   Fake(Method(mock_primary_hardware_counter, HardwareCounter::Set));
   Fake(Method(mock_primary_hardware_counter, HardwareCounter::SetDirection));
 
   Fake(Method(mock_backup_hardware_counter, HardwareCounter::ModuleInitialize));
-  Fake(Method(mock_backup_hardware_counter, HardwareCounter::ModuleEnable));
   Fake(Method(mock_backup_hardware_counter, HardwareCounter::GetCount));
   Fake(Method(mock_backup_hardware_counter, HardwareCounter::Set));
   Fake(Method(mock_backup_hardware_counter, HardwareCounter::SetDirection));
 
   Fake(Method(mock_primary_pol_gpio, Gpio::ModuleInitialize));
-  Fake(Method(mock_primary_pol_gpio, Gpio::ModuleEnable));
   Fake(Method(mock_primary_pol_gpio, Gpio::SetDirection));
   Fake(Method(mock_primary_pol_gpio, Gpio::Read));
   Fake(Method(mock_primary_pol_gpio, Gpio::DetachInterrupt));
@@ -53,7 +50,6 @@ TEST_CASE("Test LTC4150 Coulomb Counter/ Battery Gas Gauge")
       .AlwaysDo(GetLambda(primary_pol_isr));
 
   Fake(Method(mock_backup_pol_gpio, Gpio::ModuleInitialize));
-  Fake(Method(mock_backup_pol_gpio, Gpio::ModuleEnable));
   Fake(Method(mock_backup_pol_gpio, Gpio::SetDirection));
   Fake(Method(mock_backup_pol_gpio, Gpio::Read));
   Fake(Method(mock_backup_pol_gpio, Gpio::DetachInterrupt));
@@ -74,8 +70,8 @@ TEST_CASE("Test LTC4150 Coulomb Counter/ Battery Gas Gauge")
     When(Method(mock_backup_pol_gpio, Gpio::Read)).Return(false);
 
     // Exercise
-    primary_counter.ModuleInitialize();
-    backup_counter.ModuleInitialize();
+    primary_counter.Initialize();
+    backup_counter.Initialize();
 
     // Verify
     Verify(Method(mock_primary_hardware_counter,
@@ -88,27 +84,7 @@ TEST_CASE("Test LTC4150 Coulomb Counter/ Battery Gas Gauge")
                .Using(Gpio::Direction::kInput));
     Verify(Method(mock_backup_pol_gpio, Gpio::SetDirection)
                .Using(Gpio::Direction::kInput));
-    Verify(Method(mock_primary_hardware_counter, HardwareCounter::ModuleEnable))
-        .Exactly(1);
-    Verify(Method(mock_backup_hardware_counter, HardwareCounter::ModuleEnable))
-        .Exactly(1);
-  }
 
-  SECTION("Enable()")
-  {
-    // Setup
-    Ltc4150 primary_counter(mock_primary_hardware_counter.get(),
-                            mock_primary_pol_gpio.get(),
-                            resistance);
-    Ltc4150 backup_counter(mock_backup_hardware_counter.get(),
-                           mock_backup_pol_gpio.get(),
-                           resistance);
-
-    // Exercise
-    primary_counter.ModuleEnable();
-    backup_counter.ModuleEnable();
-
-    // Verify
     Verify(Method(mock_primary_pol_gpio, Gpio::AttachInterrupt));
     Verify(Method(mock_backup_pol_gpio, Gpio::AttachInterrupt));
   }
@@ -124,6 +100,7 @@ TEST_CASE("Test LTC4150 Coulomb Counter/ Battery Gas Gauge")
     Ltc4150 backup_counter(mock_backup_hardware_counter.get(),
                            mock_backup_pol_gpio.get(),
                            resistance);
+
     When(Method(mock_primary_pol_gpio, Gpio::Read)).Return(false);
     When(Method(mock_backup_pol_gpio, Gpio::Read)).Return(true);
     When(Method(mock_primary_hardware_counter, HardwareCounter::GetCount))
@@ -131,13 +108,11 @@ TEST_CASE("Test LTC4150 Coulomb Counter/ Battery Gas Gauge")
     When(Method(mock_backup_hardware_counter, HardwareCounter::GetCount))
         .Return(6);
 
-    primary_counter.ModuleInitialize();
-    primary_counter.ModuleEnable();
+    primary_counter.Initialize();
     CHECK(primary_counter.GetCharge().to<float>() ==
           doctest::Approx(kPrimaryCharge * 1000));
 
-    backup_counter.ModuleInitialize();
-    backup_counter.ModuleEnable();
+    backup_counter.Initialize();
     CHECK(backup_counter.GetCharge().to<float>() ==
           doctest::Approx(kBackupCharge * 1000));
   }

--- a/library/L2_HAL/sensors/distance/distance_sensor.hpp
+++ b/library/L2_HAL/sensors/distance/distance_sensor.hpp
@@ -16,7 +16,7 @@ namespace sjsu
 /// Interface for a sensor that can measure distance in a single dimension, such
 /// as 1D lidar, ultrasonic range sensor, or infared distance sensor.
 /// @ingroup sensors
-class DistanceSensor : public Module
+class DistanceSensor : public Module<>
 {
  public:
   /// Trigger a capture of the current distance reading and return it.

--- a/library/L2_HAL/sensors/environment/light/temt6000x01.hpp
+++ b/library/L2_HAL/sensors/environment/light/temt6000x01.hpp
@@ -29,11 +29,6 @@ class Temt6000x01 final : public LightSensor
     adc_.Initialize();
   }
 
-  void ModuleEnable(bool enable = true) override
-  {
-    adc_.Enable(enable);
-  }
-
   /// @returns The illuminance in units of lux ranging from 1 - 1'000.
   units::illuminance::lux_t GetIlluminance() override
   {

--- a/library/L2_HAL/sensors/environment/light_sensor.hpp
+++ b/library/L2_HAL/sensors/environment/light_sensor.hpp
@@ -7,7 +7,7 @@
 namespace sjsu
 {
 /// An abstract interface for light sensing device drivers.
-class LightSensor : public Module
+class LightSensor : public Module<>
 {
  public:
   /// @return The sensor reading in units of lux.
@@ -17,7 +17,7 @@ class LightSensor : public Module
   virtual units::illuminance::lux_t GetMaxIlluminance() = 0;
 
   // ===========================================================================
-  // Utility Methods
+  // Helper Functions
   // ===========================================================================
 
   /// Retreive the detected brightness as a percentage where:

--- a/library/L2_HAL/sensors/environment/temperature/si7060.hpp
+++ b/library/L2_HAL/sensors/environment/temperature/si7060.hpp
@@ -3,10 +3,10 @@
 #include "L1_Peripheral/i2c.hpp"
 #include "L2_HAL/sensors/environment/temperature_sensor.hpp"
 #include "utility/bit.hpp"
-#include "utility/units.hpp"
-#include "utility/math/limits.hpp"
 #include "utility/error_handling.hpp"
 #include "utility/log.hpp"
+#include "utility/math/limits.hpp"
+#include "utility/units.hpp"
 
 namespace sjsu
 {
@@ -47,33 +47,18 @@ class Si7060 final : public TemperatureSensor
 
   void ModuleInitialize() override
   {
-    if (i2c_.RequiresConfiguration())
-    {
-      i2c_.Initialize();
-      i2c_.ConfigureClockRate();
-      i2c_.Enable();
-    }
-  }
+    i2c_.Initialize();
 
-  void ModuleEnable(bool enable = true) override
-  {
-    if (enable)
-    {
-      uint8_t temperature_sensor_id_register;
+    uint8_t temperature_sensor_id_register;
 
-      i2c_.WriteThenRead(address_, { kIdRegister },
-                         &temperature_sensor_id_register, 1);
+    i2c_.WriteThenRead(
+        address_, { kIdRegister }, &temperature_sensor_id_register, 1);
 
-      if (temperature_sensor_id_register != kExpectedSensorId)
-      {
-        LogDebug("ID = 0x%02X\n", temperature_sensor_id_register);
-        throw Exception(std::errc::no_such_device,
-                        "Device ID does not match expected device ID 0x14");
-      }
-    }
-    else
+    if (temperature_sensor_id_register != kExpectedSensorId)
     {
-      LogInfo("Disable not supported for this driver.");
+      LogDebug("ID = 0x%02X\n", temperature_sensor_id_register);
+      throw Exception(std::errc::no_such_device,
+                      "Device ID does not match expected device ID 0x14");
     }
   }
 
@@ -92,8 +77,8 @@ class Si7060 final : public TemperatureSensor
     i2c_.Write(address_, { kAutomaticBitRegister, 0x01 });
 
     // These need to be in separate transactions
-    i2c_.WriteThenRead(address_, { kMostSignificantRegister },
-                       &most_significant_register, 1);
+    i2c_.WriteThenRead(
+        address_, { kMostSignificantRegister }, &most_significant_register, 1);
     i2c_.Read(address_, &least_significant_register, 1);
 
     // The write and read operation sets the most significant bit to one,

--- a/library/L2_HAL/sensors/environment/temperature/test/si7060_test.cpp
+++ b/library/L2_HAL/sensors/environment/temperature/test/si7060_test.cpp
@@ -5,33 +5,17 @@
 namespace sjsu
 {
 // Uncomment this when can class has been created
-EMIT_ALL_METHODS(Si7060);
-
 TEST_CASE("Si7060")
 {
   constexpr uint8_t kDeviceAddress = Si7060::kDefaultAddress;
   Mock<I2c> mock_i2c;
   Si7060 temperature_sensor(mock_i2c.get(), kDeviceAddress);
 
-  SECTION("Initialize")
+  SECTION("Initialization")
   {
     // Setup
-    Fake(Method(mock_i2c, ModuleInitialize));
-    Fake(Method(mock_i2c, ConfigureClockRate));
-    Fake(Method(mock_i2c, ModuleEnable));
+    Fake(Method(mock_i2c, I2c::ModuleInitialize));
 
-    // Exercise
-    temperature_sensor.ModuleInitialize();
-
-    // Verify
-    Verify(Method(mock_i2c, ModuleInitialize),
-           Method(mock_i2c, ConfigureClockRate),
-           Method(mock_i2c, ModuleEnable))
-        .Once();
-  }
-
-  SECTION("Enable")
-  {
     SECTION("Incorrect device information")
     {
       // Setup
@@ -44,7 +28,7 @@ TEST_CASE("Si7060")
               });
 
       // Exercise
-      SJ2_CHECK_EXCEPTION(temperature_sensor.ModuleEnable(),
+      SJ2_CHECK_EXCEPTION(temperature_sensor.Initialize(),
                           std::errc::no_such_device);
 
       // Verify
@@ -60,11 +44,13 @@ TEST_CASE("Si7060")
           });
 
       // Exercise
-      temperature_sensor.ModuleEnable();
+      temperature_sensor.Initialize();
 
       // Verify
       Verify(Method(mock_i2c, Transaction)).Once();
     }
+
+    Verify(Method(mock_i2c, I2c::ModuleInitialize)).Once();
   }
 
   SECTION("GetTemperature")

--- a/library/L2_HAL/sensors/environment/temperature/test/tmp102_test.cpp
+++ b/library/L2_HAL/sensors/environment/temperature/test/tmp102_test.cpp
@@ -1,10 +1,9 @@
 #include "L2_HAL/sensors/environment/temperature/tmp102.hpp"
+
 #include "L4_Testing/testing_frameworks.hpp"
 
 namespace sjsu
 {
-EMIT_ALL_METHODS(Tmp102);
-
 TEST_CASE("Testing Tmp102 Temperature Sensor")
 {
   constexpr uint8_t kDeviceAddress = Tmp102::DeviceAddress::kGround;
@@ -15,17 +14,12 @@ TEST_CASE("Testing Tmp102 Temperature Sensor")
   {
     // Setup
     Fake(Method(mock_i2c, ModuleInitialize));
-    Fake(Method(mock_i2c, ConfigureClockRate));
-    Fake(Method(mock_i2c, ModuleEnable));
 
     // Exercise
     temperature_sensor.ModuleInitialize();
 
     // Verify
-    Verify(Method(mock_i2c, ModuleInitialize),
-           Method(mock_i2c, ConfigureClockRate),
-           Method(mock_i2c, ModuleEnable))
-        .Once();
+    Verify(Method(mock_i2c, ModuleInitialize)).Once();
   }
 
   SECTION("GetTemperature")

--- a/library/L2_HAL/sensors/environment/temperature/tmp102.hpp
+++ b/library/L2_HAL/sensors/environment/temperature/tmp102.hpp
@@ -57,15 +57,8 @@ class Tmp102 final : public TemperatureSensor
 
   void ModuleInitialize() override
   {
-    if (i2c_.RequiresConfiguration())
-    {
-      i2c_.Initialize();
-      i2c_.ConfigureClockRate();
-      i2c_.Enable();
-    }
+    i2c_.Initialize();
   }
-
-  void ModuleEnable(bool = true) override {}
 
   units::temperature::celsius_t GetTemperature() override
   {

--- a/library/L2_HAL/sensors/environment/temperature_sensor.hpp
+++ b/library/L2_HAL/sensors/environment/temperature_sensor.hpp
@@ -7,7 +7,7 @@
 namespace sjsu
 {
 /// An abstract interface for temperature sensing device drivers.
-class TemperatureSensor : public Module
+class TemperatureSensor : public Module<>
 {
  public:
   /// Retrieves the temperature reading and writes the value to the designated

--- a/library/L2_HAL/sensors/movement/accelerometer.hpp
+++ b/library/L2_HAL/sensors/movement/accelerometer.hpp
@@ -4,36 +4,15 @@
 #include <cstdint>
 
 #include "module.hpp"
-#include "utility/log.hpp"
 #include "utility/error_handling.hpp"
+#include "utility/log.hpp"
 #include "utility/units.hpp"
 
-// TODO(#1080): Refactor Accelerometer
 namespace sjsu
 {
-/// @ingroup movement
-/// Abstract interface for devices that behave as accelerometers.
-/// Accelerometers are devices that can measure acceleration in X, Y, or Z axis.
-/// On the earth's surface, if the accelerometer is held still, and it is
-/// oriented flat on one of its axes, it will measure approximately 9.8 m/s^2 on
-/// that axis.
-class Accelerometer : public Module
+/// Generic settings for a standard Accelerometer device
+struct AccelerometerSettings_t
 {
- public:
-  /// Acceleration along each axis of detection
-  struct Acceleration_t
-  {
-    units::acceleration::meters_per_second_squared_t x;
-    units::acceleration::meters_per_second_squared_t y;
-    units::acceleration::meters_per_second_squared_t z;
-
-    void Print()
-    {
-      sjsu::LogInfo("{  x: %.4f m/s^2,  y: %.4f m/s^2,  z: %.4f m/s^2 }",
-                    x.to<double>(), y.to<double>(), z.to<double>());
-    }
-  };
-
   /// Set the maximum absolute acceleration that can be read by the
   /// accelerometer. NOT calling this before calling Enable() will result in the
   /// default full scale being used. Please consult the datasheet to see if this
@@ -50,11 +29,37 @@ class Accelerometer : public Module
   /// Its a trade off that is very application specific. In general most
   /// orientation measurements will require 2Gs of precision to account for
   /// accelerations caused by translation rather than simply rotation.
-  ///
-  /// @param gravity - the number of G(s) that defines the maximum acceleration
-  /// the accelerometer can sense.
-  virtual void ConfigureFullScale(
-      units::acceleration::standard_gravity_t gravity) = 0;
+  units::acceleration::standard_gravity_t gravity = 2_SG;
+};
+
+/// @ingroup movement
+/// Abstract interface for devices that behave as accelerometers.
+/// Accelerometers are devices that can measure acceleration in X, Y, or Z axis.
+/// On the earth's surface, if the accelerometer is held still, and it is
+/// oriented flat on one of its axes, it will measure approximately 9.8 m/s^2 on
+/// that axis.
+class Accelerometer : public Module<AccelerometerSettings_t>
+{
+ public:
+  /// Acceleration along each axis of detection
+  struct Acceleration_t
+  {
+    /// Acceleration in the x axis
+    units::acceleration::meters_per_second_squared_t x;
+    /// Acceleration in the y axis
+    units::acceleration::meters_per_second_squared_t y;
+    /// Acceleration in the z axis
+    units::acceleration::meters_per_second_squared_t z;
+
+    /// Print the acceleration of this object.
+    void Print()
+    {
+      sjsu::LogInfo("{  x: %.4f m/s^2,  y: %.4f m/s^2,  z: %.4f m/s^2 }",
+                    x.to<double>(),
+                    y.to<double>(),
+                    z.to<double>());
+    }
+  };
 
   /// Accelerometer driver will read each axis of acceleration and convert the
   /// data to m/s^2.

--- a/library/L2_HAL/sensors/optical/test/apds9960_test.cpp.disabled
+++ b/library/L2_HAL/sensors/optical/test/apds9960_test.cpp.disabled
@@ -3,8 +3,6 @@
 
 namespace sjsu
 {
-EMIT_ALL_METHODS(Apds9960);
-
 TEST_CASE("Testing Gesture Sensor")
 {
   SECTION("Initialize") {}

--- a/library/L2_HAL/sensors/signal/frequency_counter.hpp
+++ b/library/L2_HAL/sensors/signal/frequency_counter.hpp
@@ -9,24 +9,21 @@ namespace sjsu
 {
 /// FrequencyCounter can measure the frequency of a signal based on a hardware
 /// counter.
-class FrequencyCounter : public Module
+class FrequencyCounter : public Module<>
 {
  public:
-  // ===========================================================================
-  // Interface Methods
-  // ===========================================================================
-
-  // ---------------------------------------------------------------------------
-  // Configuration Methods
-  // ---------------------------------------------------------------------------
-
-  // ---------------------------------------------------------------------------
-  // Usage Methods
-  // ---------------------------------------------------------------------------
-
   /// @param counter - A hardware counter implementation that will be used to
   /// derive a frequency from.
   explicit FrequencyCounter(HardwareCounter * counter) : counter_(counter) {}
+
+  /// Initializes counter hardware. Will NOT start counting at this point. Will
+  /// also set the counting direction to count up.
+  void ModuleInitialize() override
+  {
+    counter_->Initialize();
+    counter_->SetDirection(HardwareCounter::Direction::kUp);
+    previous_time_ = Uptime();
+  }
 
   /// Resets the frequency counter.
   virtual void Reset()
@@ -58,22 +55,6 @@ class FrequencyCounter : public Module
     units::frequency::hertz_t result     = count_delta / time_delta;
     Reset();
     return result;
-  }
-
-  /// Initializes counter hardware. Will NOT start counting at this point. Will
-  /// also set the counting direction to count up.
-  void ModuleInitialize() override
-  {
-    counter_->Initialize();
-    counter_->SetDirection(HardwareCounter::Direction::kUp);
-  }
-
-  /// Will enable the hardware counter and start the time measurement that will
-  /// be used to measure the approximate frequency of the hardware counter.
-  void ModuleEnable(bool enable = true) override
-  {
-    counter_->Enable(enable);
-    previous_time_ = Uptime();
   }
 
  private:

--- a/library/L2_HAL/sensors/signal/test/frequency_counter_test.cpp
+++ b/library/L2_HAL/sensors/signal/test/frequency_counter_test.cpp
@@ -9,7 +9,6 @@ TEST_CASE("Testing FrequencyCounter")
   Mock<HardwareCounter> mock_counter;
 
   Fake(Method(mock_counter, ModuleInitialize));
-  Fake(Method(mock_counter, ModuleEnable));
   Fake(Method(mock_counter, Set));
   Fake(Method(mock_counter, SetDirection));
   Fake(Method(mock_counter, GetCount));
@@ -26,18 +25,6 @@ TEST_CASE("Testing FrequencyCounter")
     Verify(Method(mock_counter, SetDirection)
                .Using(HardwareCounter::Direction::kUp))
         .Once();
-  }
-
-  SECTION("Enable()")
-  {
-    // Setup
-    mock_counter.get().SetStateToInitialized();
-
-    // Exercise
-    counter.ModuleEnable();
-
-    // Verify
-    Verify(Method(mock_counter, ModuleEnable).Using(true)).Once();
   }
 }
 }  // namespace sjsu

--- a/library/L2_HAL/switches/button.hpp
+++ b/library/L2_HAL/switches/button.hpp
@@ -12,7 +12,7 @@ namespace sjsu
 /// constant polling in order to work. This is useful for situations where a
 /// gpio does not have interrupt capability, or interrupt capability is not
 /// desired.
-class Button : public Module
+class Button : public Module<>
 {
  public:
   /// Button Constructor
@@ -21,16 +21,7 @@ class Button : public Module
   void ModuleInitialize() override
   {
     button_.Initialize();
-  }
-
-  void ModuleEnable(bool enable = true) override
-  {
-    button_.Enable(enable);
-
-    if (enable)
-    {
-      button_.SetAsInput();
-    }
+    button_.SetAsInput();
   }
 
   /// Call this function continuously to detect if a button has been released.
@@ -86,6 +77,7 @@ class Button : public Module
     was_pressed_  = false;
     was_released_ = false;
   }
+
   /// @returns a reference to the internal sjsu::Gpio object.
   virtual const sjsu::Gpio & GetGpio()
   {

--- a/library/L2_HAL/switches/test/button_test.cpp
+++ b/library/L2_HAL/switches/test/button_test.cpp
@@ -4,8 +4,6 @@
 
 namespace sjsu
 {
-EMIT_ALL_METHODS(Button);
-
 TEST_CASE("Testing Button")
 {
   // Make a mock pin to work with
@@ -13,15 +11,11 @@ TEST_CASE("Testing Button")
   // Retrieve a reference to the Pin to be injected as the return value
   // of GPIOs GetPin() method.
   sjsu::Pin & test_pin = mock_pin.get();
-  // Fake the implementation of SetAsActiveLow and ConfigurePullResistor to be
-  // inspected later
-  Fake(Method(mock_pin, ConfigurePullResistor));
 
   // Create a mock gpio object
   Mock<sjsu::Gpio> mock_gpio;
   // Fake Read and SetAsInput so we can inspect them later
   Fake(Method(mock_gpio, ModuleInitialize),
-       Method(mock_gpio, ModuleEnable),
        Method(mock_gpio, Read),
        Method(mock_gpio, Set),
        Method(mock_gpio, SetDirection));
@@ -40,16 +34,14 @@ TEST_CASE("Testing Button")
   SECTION("Initialize")
   {
     // Exercise
-    test_subject.ModuleInitialize();
+    test_subject.Initialize();
 
     // Verify
     Verify(Method(mock_gpio, ModuleInitialize));
+    Verify(Method(mock_gpio, SetDirection).Using(Gpio::Direction::kInput));
   }
   SECTION("Button Released")
   {
-    // Reset button state
-    test_subject.ResetState();
-
     // Simulate button being idle
     When(Method(mock_gpio, Read)).AlwaysReturn(false);
     // With this check, the state of the button should be false, and since we
@@ -67,6 +59,7 @@ TEST_CASE("Testing Button")
     // return true.
     CHECK(test_subject.Released());
   }
+
   SECTION("Button Pressed")
   {
     // Reset button state

--- a/library/L3_Application/commandline.hpp
+++ b/library/L3_Application/commandline.hpp
@@ -167,7 +167,10 @@ struct CommandList_t
   /// commands.
   static constexpr size_t kCommandListBufferSize =
       sizeof(CommandInterface *) * kNumberOfCommands;
+
+  /// Memory resource for the commands vector
   StaticAllocator<kCommandListBufferSize> buffer;
+  /// Array of CommandInterface pointers
   std::pmr::vector<CommandInterface *> commands;
 };
 
@@ -262,7 +265,7 @@ class CommandLine
 
  private:
   /// AutoCompleteHandler is passed to the microrl object and used to handle
-  /// <tab> completion.
+  /// TAB completion.
   ///
   /// The handler first if the command is complete, which is found by checking
   /// if argc <= 1. If it is not, then the set of commands added to this
@@ -309,7 +312,7 @@ class CommandLine
   }
 
   /// ExecuteCommand is passed to the microrl object and used to execute a
-  /// command when the <enter> key is pressed.
+  /// command when the ENTER key is pressed.
   /// ExecuteCommand will compare argv[0] (name of the argument) with the list
   /// of command names and if one of them is found, that command will be
   /// executed.

--- a/library/L3_Application/commands/i2c_command.hpp
+++ b/library/L3_Application/commands/i2c_command.hpp
@@ -68,15 +68,20 @@ class I2cCommand final : public Command
                 i2c discover
   )";
 
+  /// Set of I2C command operations
   static inline const char * const kI2cOperations[] = { "read",
                                                         "write",
                                                         "discover",
                                                         nullptr };
 
-  static constexpr uint8_t kFirstI2cAddress = 0x08;
-  static constexpr uint8_t kLastI2cAddress  = 0x78;
-  static constexpr size_t kNumberOfI2cAddresses =
-      kLastI2cAddress - kFirstI2cAddress;
+  /// First non-reserved I2C address
+  static constexpr uint8_t kFirstAddress = 0x08;
+
+  /// Last non-reserved I2C address
+  static constexpr uint8_t kLastAddress = 0x78;
+
+  /// Number of scannable I2C addresses
+  static constexpr size_t kNumberOfI2cAddresses = kLastAddress - kFirstAddress;
 
   /// Sole constructor of the I2c command
   explicit I2cCommand(I2c & i2c)
@@ -241,8 +246,7 @@ class I2cCommand final : public Command
   {
     devices_found_.clear();
 
-    for (uint8_t address = kFirstI2cAddress; address < kLastI2cAddress;
-         address++)
+    for (uint8_t address = kFirstAddress; address < kLastAddress; address++)
     {
       uint8_t buffer;
       try

--- a/library/L3_Application/graphical_terminal.hpp
+++ b/library/L3_Application/graphical_terminal.hpp
@@ -3,11 +3,11 @@
 #include <cstdarg>
 #include <cstdint>
 
-#include "module.hpp"
 #include "L1_Peripheral/lpc40xx/gpio.hpp"
 #include "L1_Peripheral/lpc40xx/spi.hpp"
 #include "L2_HAL/displays/oled/ssd1306.hpp"
 #include "L3_Application/graphics.hpp"
+#include "module.hpp"
 
 namespace sjsu
 {
@@ -26,7 +26,7 @@ struct TerminalCache_t
 
 /// Utilizes a pixel display and a terminal character cache to create a
 /// Graphical Terminal on that display.
-class GraphicalTerminal : public Module
+class GraphicalTerminal : public Module<>
 {
  public:
   /// Maximum height of the font used for the graphical display
@@ -57,20 +57,13 @@ class GraphicalTerminal : public Module
   void ModuleInitialize() override
   {
     graphics_->Initialize();
+    graphics_->Clear();
+    graphics_->Update();
   }
 
-  void ModuleEnable(bool enable = true) override
+  void ModulePowerDown() override
   {
-    if (enable)
-    {
-      graphics_->Enable();
-      graphics_->Clear();
-      graphics_->Update();
-    }
-    else
-    {
-      graphics_->Enable(false);
-    }
+    graphics_->PowerDown();
   }
 
   /// Prints to the screen as printf would to STDOUT.
@@ -158,8 +151,8 @@ class GraphicalTerminal : public Module
       {
         int32_t x = j * kCharacterWidth;
         int32_t y = i * kCharacterHeight;
-        graphics_->DrawCharacter(x, y,
-                                 GetChar(((i + row_start_) % max_rows_), j));
+        graphics_->DrawCharacter(
+            x, y, GetChar(((i + row_start_) % max_rows_), j));
       }
     }
     graphics_->Update();

--- a/library/L3_Application/graphics.hpp
+++ b/library/L3_Application/graphics.hpp
@@ -13,7 +13,7 @@
 namespace sjsu
 {
 /// Graphics library to draw shapes and characters on a pixel display
-class Graphics : public Module
+class Graphics : public Module<>
 {
  public:
   /// Constructor for a graphics object.
@@ -31,11 +31,6 @@ class Graphics : public Module
   void ModuleInitialize() override
   {
     display_.Initialize();
-  }
-
-  void ModuleEnable(bool enable = true) override
-  {
-    display_.Enable(enable);
   }
 
   /// Update the display.

--- a/library/L3_Application/test/commandline_test.cpp
+++ b/library/L3_Application/test/commandline_test.cpp
@@ -4,8 +4,6 @@
 
 namespace sjsu
 {
-EMIT_ALL_METHODS(Command);
-
 namespace
 {
 FAKE_VALUE_FUNC(int, fake_command, int, const char * const *);

--- a/library/L3_Application/test/fatfs_test.cpp
+++ b/library/L3_Application/test/fatfs_test.cpp
@@ -127,7 +127,6 @@ TEST_CASE("Testing FAT FS")
       // Setup: Needed to verify disk_status's return value
       When(Method(mock_storage, IsMediaPresent)).AlwaysReturn(true);
       Fake(Method(mock_storage, ModuleInitialize));
-      Fake(Method(mock_storage, ModuleEnable));
 
       // Exercise
       CHECK(RES_OK == disk_initialize(0));
@@ -136,7 +135,6 @@ TEST_CASE("Testing FAT FS")
       // Verify
       Verify(Method(mock_storage, IsMediaPresent));
       Verify(Method(mock_storage, ModuleInitialize));
-      Verify(Method(mock_storage, ModuleEnable));
     }
   }
 

--- a/library/L3_Application/test/graphical_terminal_test.cpp
+++ b/library/L3_Application/test/graphical_terminal_test.cpp
@@ -3,8 +3,6 @@
 
 namespace sjsu
 {
-EMIT_ALL_METHODS(GraphicalTerminal);
-
 TEST_CASE("Graphics Terminal Test")
 {
   SECTION("Initialize") {}

--- a/library/L3_Application/test/graphics_test.cpp
+++ b/library/L3_Application/test/graphics_test.cpp
@@ -3,8 +3,6 @@
 
 namespace sjsu
 {
-EMIT_ALL_METHODS(Graphics);
-
 TEST_CASE("Graphics Test")
 {
   SECTION("Initialize") {}

--- a/library/L4_Testing/testing_frameworks.hpp
+++ b/library/L4_Testing/testing_frameworks.hpp
@@ -107,30 +107,6 @@ using namespace fakeit;  // NOLINT
 int HostTestWrite(std::span<const char> payload);
 int HostTestRead(std::span<char> payload);
 
-/// This magical method does a lot of tricks to convince the compiler to emit
-/// as many of the class methods as possible for methods of a function that may
-/// only exist in a header file.
-#define EMIT_ALL_METHODS(class_name)                         \
-  namespace                                                  \
-  {                                                          \
-  template <unsigned test_parameter>                         \
-  using class_name##_Template = class_name;                  \
-  int __LetsGo_##class_name(class_name##_Template<0> * obj)  \
-  {                                                          \
-    bool never_true = false;                                 \
-    bool * ptr      = &never_true;                           \
-    /* Emit destructors */                                   \
-    if (*ptr)                                                \
-    {                                                        \
-      class_name##_Template<0> emitter = *obj;               \
-      (void)emitter;                                         \
-      return 1;                                              \
-    }                                                        \
-    return 0;                                                \
-  }                                                          \
-  auto __full_##class_name = __LetsGo_##class_name(nullptr); \
-  }  // namespace
-
 /// @param expression - and expression that, when executed will throw
 /// @param error_code - the error code to compare the one held by the exception
 #define SJ2_CHECK_EXCEPTION(expression, error_code)                        \
@@ -147,100 +123,123 @@ int HostTestRead(std::span<char> payload);
     CHECK(e.GetCode() == error_code);                                      \
   }
 
+/// Default specialization of the Reflection class. If this class is used, it
+/// means that a specialization for the type does not exists. The data retrieved
+/// from this class typically indicates that the type is unknown.
 template <typename T>
 class Reflection
 {
  public:
+  /// The default name for types that cannot be found as a specialization of the
+  /// Reflection class
   static constexpr const char * Name()
   {
     return "?";
   }
 };
 
+/// Gives information about the type `uint8_t`
 template <>
 class Reflection<uint8_t>
 {
  public:
+  /// Name of the type "uint8_t"
   static constexpr const char * Name()
   {
     return "uint8_t";
   }
 };
 
+/// Gives information about the type `uint8_t`
 template <>
 class Reflection<const uint8_t>
 {
  public:
+  /// Name of the type "const"
   static constexpr const char * Name()
   {
     return "const uint8_t";
   }
 };
 
+/// Gives information about the type `uint16_t`
 template <>
 class Reflection<uint16_t>
 {
  public:
+  /// Name of the type "uint16_t"
   static constexpr const char * Name()
   {
     return "uint16_t";
   }
 };
 
+/// Gives information about the type `uint32_t`
 template <>
 class Reflection<uint32_t>
 {
  public:
+  /// Name of the type "uint32_t"
   static constexpr const char * Name()
   {
     return "uint32_t";
   }
 };
 
+/// Gives information about the type `uint64_t`
 template <>
 class Reflection<uint64_t>
 {
  public:
+  /// Name of the type "uint64_t"
   static constexpr const char * Name()
   {
     return "uint64_t";
   }
 };
 
+/// Gives information about the type `int8_t`
 template <>
 class Reflection<int8_t>
 {
  public:
+  /// Name of the type "int8_t"
   static constexpr const char * Name()
   {
     return "int8_t";
   }
 };
 
+/// Gives information about the type `int16_t`
 template <>
 class Reflection<int16_t>
 {
  public:
+  /// Name of the type "int16_t"
   static constexpr const char * Name()
   {
     return "int16_t";
   }
 };
 
+/// Gives information about the type `int32_t`
 template <>
 class Reflection<int32_t>
 {
  public:
+  /// Name of the type "int32_t"
   static constexpr const char * Name()
   {
     return "int32_t";
   }
 };
 
+/// Gives information about the type `int64_t`
 template <>
 class Reflection<int64_t>
 {
  public:
+  /// Name of the type "int64_t"
   static constexpr const char * Name()
   {
     return "int64_t";
@@ -249,9 +248,11 @@ class Reflection<int64_t>
 
 namespace doctest
 {
+/// Allows doctest to display a std::array<T>
 template <typename T, size_t N>
 struct StringMaker<std::array<T, N>>  // NOLINT
 {
+  /// Converts the std::array to a Doctest::String
   static String convert(const std::array<T, N> & array)  // NOLINT
   {
     std::string str;
@@ -277,9 +278,11 @@ struct StringMaker<std::array<T, N>>  // NOLINT
   }
 };
 
+/// Allows doctest to display a std::span<T>
 template <typename T>
 struct StringMaker<std::span<T>>
 {
+  /// Converts the std::span to a Doctest::String
   static String convert(const std::span<T> & span)  // NOLINT
   {
     std::string str;
@@ -305,18 +308,22 @@ struct StringMaker<std::span<T>>
   }
 };
 
+/// DocTest template specialization for printing std::errc
 template <>
 struct StringMaker<std::errc>
 {
+  /// Converts the std::errc to a Doctest::String
   static String convert(const std::errc & error_code)  // NOLINT
   {
     return sjsu::Stringify(error_code);
   }
 };
 
+/// DocTest template specialization for printing std::chrono::duration
 template <typename T, typename U>
 struct StringMaker<std::chrono::duration<T, U>>  // NOLINT
 {
+  /// Converts the std::chrono::duration to a Doctest::String
   static String convert(const std::chrono::duration<T, U> & duration)  // NOLINT
   {
     return std::to_string(duration.count()).c_str();

--- a/library/third_party/fatfs/source/sjsu-dev2/diskio.cpp
+++ b/library/third_party/fatfs/source/sjsu-dev2/diskio.cpp
@@ -58,7 +58,7 @@ extern "C" DSTATUS disk_status(BYTE drive_number)
 
   // If the media was never initialized by calling disk_initialize, which occurs
   // after an f_mount() call, then return STA_NOINIT.
-  if (!storage->IsEnabled())
+  if (storage->GetState() != sjsu::State::kInitialized)
   {
     return STA_NOINIT;
   }
@@ -77,11 +77,8 @@ extern "C" DSTATUS disk_initialize(BYTE drive_number)
   // Get a reference for the storage drive
   auto & storage = drive[drive_number];
 
-  // Attempt to initialize media peripherals and on failure return STA_NOINIT
-  storage->Initialize();
-
   // Attempt to enable media and on failure return STA_NOINIT
-  storage->Enable();
+  storage->Initialize();
 
   return RES_OK;
 }

--- a/library/utility/allocator.hpp
+++ b/library/utility/allocator.hpp
@@ -75,6 +75,7 @@ class StaticAllocator : public std::pmr::memory_resource
   }
 
  protected:
+  /// Implemenation of the do_allocate() method for std::pmr::memory_resource
   void * do_allocate(std::size_t bytes, std::size_t alignment) override
   {
     LogDebug("Allocating %zu @ alignment %zu, left: %zu\n",
@@ -95,6 +96,7 @@ class StaticAllocator : public std::pmr::memory_resource
     return allocated_address;
   }
 
+  /// Implemenation of the do_deallocate() method for std::pmr::memory_resource
   void do_deallocate(void * p,
                      std::size_t bytes,
                      std::size_t alignment) override
@@ -102,6 +104,7 @@ class StaticAllocator : public std::pmr::memory_resource
     return resource_.deallocate(p, bytes, alignment);
   }
 
+  /// Implemenation of the do_is_equal() method for std::pmr::memory_resource
   bool do_is_equal(
       const std::pmr::memory_resource & other) const noexcept override
   {

--- a/library/utility/bit.hpp
+++ b/library/utility/bit.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <array>
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <type_traits>
 
@@ -126,6 +126,13 @@ template <typename T>
   return static_cast<T>((target >> position) & mask);
 }
 
+/// Extract value from integer.
+///
+/// @tparam T - return type container.
+/// @tparam U - type of the input target value.
+/// @param target - Value to extract the data from.
+/// @param bitmask - The location of the data to extract from the target.
+/// @return constexpr T - extracted value.
 template <typename T>
 [[nodiscard]] constexpr T Extract(T target, Mask bitmask)
 {
@@ -212,6 +219,12 @@ template <typename T, typename U>
   return static_cast<T>(target);
 }
 
+/// Insert a set of contiguous bits into a target value.
+///
+/// @param target the target that will have bits inserted into it.
+/// @param value the bits to be inserted into the target
+/// @param bitmask the position and width of bits in the target to insert the
+/// value of bits.
 template <typename T, typename U>
 [[nodiscard]] constexpr T Insert(T target, U value, Mask bitmask)
 {
@@ -630,6 +643,14 @@ class Value
   constexpr operator T() const
   {
     return value_;
+  }
+
+  /// Allows implicit conversion from this type into the integer type.
+  /// @return T - the type of this value
+  template <typename Int>
+  constexpr Int To() const
+  {
+    return static_cast<Int>(value_);
   }
 
  private:

--- a/library/utility/byte.hpp
+++ b/library/utility/byte.hpp
@@ -9,6 +9,16 @@
 
 namespace sjsu
 {
+/// Convert a numeric value into an array of bytes.
+///
+/// @tparam T - value to be converted into an array of bytes
+/// @tparam array_size - the size of the resultant array. This can be bigger
+/// than the size of the integer/value type. Just like how a 2 byte integer can
+/// fit in a 8 byte register.
+/// @param endian - the endianness of the byte array.
+/// @param value - the value to be converted into an array
+/// @return constexpr auto - the std::array<> containing the value in bytes the
+/// size of array_size.
 template <typename T, size_t array_size = sizeof(T)>
 constexpr auto ToByteArray(std::endian endian, T value)
 {
@@ -37,10 +47,23 @@ constexpr auto ToByteArray(std::endian endian, T value)
   return array;
 }
 
+/// Convert an array into a span based on its endianness. Useful for picking out
+/// values within an array that
+///
+/// @tparam N - number of bytes within the array. Do not set this value, it is
+/// inferred by the passed in std::array.
+/// @param endian - the endianness of the subspan.
+/// @param bytes - array containing the bytes to be converted into a span.
+/// @param width - the width of the integer contents within array. This value
+/// must be 1 or equal to `N` (size of the array). Any lower or greater and the
+/// consequences are undefined.
+/// @return constexpr auto - std::span of the array based on the endianness.
+/// Note that a span is non-owning, meaning that it will point to invalid data
+/// if the passed in bytes is no longer valid.
 template <size_t N>
 constexpr auto ByteArrayToSpan(std::endian endian,
                                const std::array<uint8_t, N> & bytes,
-                               size_t width)
+                               size_t width = N)
 {
   if (endian == std::endian::big)
   {
@@ -52,6 +75,12 @@ constexpr auto ByteArrayToSpan(std::endian endian,
   }
 }
 
+/// Convert an array/span into an integer with respect to endianness.
+///
+/// @tparam T - the integer type that the array will be assembled into
+/// @param endian - endianness of the input array
+/// @param array - the array of bytes to be assembled into a integer.
+/// @return constexpr auto - the converted value.
 template <typename T>
 constexpr auto ToInteger(std::endian endian, std::span<const uint8_t> array)
 {
@@ -83,6 +112,14 @@ constexpr auto ToInteger(std::endian endian, std::span<const uint8_t> array)
   return value;
 }
 
+/// Like ToInteger, except that, it converts an array of bytes into an array of
+/// Integers.
+///
+/// @tparam T - the integer type that the array will be assembled into
+/// @tparam N - number of integers to convert.
+/// @param endian - endianness of the bytes array
+/// @param bytes - array of bytes to be converted into an array of integers.
+/// @return constexpr auto - array of the converted values.
 template <typename T, size_t N>
 constexpr auto ToIntegerArray(std::endian endian,
                               std::span<const uint8_t> bytes)

--- a/library/utility/error_handling.hpp
+++ b/library/utility/error_handling.hpp
@@ -17,6 +17,8 @@
 
 namespace sjsu
 {
+/// @return constexpr const char* - the string representation of the std::errc
+/// code passed.
 constexpr const char * Stringify(std::errc error_code)
 {
   if constexpr (config::kStoreErrorCodeStrings)
@@ -128,11 +130,17 @@ constexpr const char * Stringify(std::errc error_code)
   return "unknown";
 }
 
+/// The standard exception class for SJSU-Dev2
 class Exception : std::exception
 {
  public:
+  /// Default message for exceptions without a context message.
   constexpr static const char * kEmptyMessage = "(undefined)";
 
+  /// @param error_code_enum - error code that represents this error
+  /// @param location_message - a message that descripes the exception and why
+  /// it occurred.
+  /// @param source_location - location of where this exception was created.
   explicit Exception(
       std::errc error_code_enum,
       const char * location_message = kEmptyMessage,
@@ -146,6 +154,7 @@ class Exception : std::exception
     line_     = source_location.line();
   }
 
+  /// @return const char* - return the message associated with this excpetion
   const char * what() const noexcept override
   {
     return message_;
@@ -155,20 +164,40 @@ class Exception : std::exception
   void Print() const
   {
     /// Print the colored error text to STDOUT
-    printf("Error:%s(%d):%s:%d:%s(): %s\n", Stringify(code_),
-           static_cast<int>(code_), file_, line_, function_, message_);
+    printf("Error:%s(%d):%s:%d:%s(): %s\n",
+           Stringify(code_),
+           static_cast<int>(code_),
+           file_,
+           line_,
+           function_,
+           message_);
   }
 
+  /// @return std::errc - the error code number
   std::errc GetCode() const
   {
     return code_;
   }
 
+  /// Check if the exception object has and error code equal to the compared
+  /// error code
+  ///
+  /// @param exception - the exception object to compare
+  /// @param error - the error code to check against
+  /// @return true - `exception` has the same error code as `error`
+  /// @return false - `exception` does NOT have the same error code as `error`
   friend bool operator==(const Exception & exception, std::errc error)
   {
     return exception.GetCode() == error;
   }
 
+  /// Check if the exception object has and error code equal to the compared
+  /// error code
+  ///
+  /// @param error - the error code to check against
+  /// @param exception - the exception object to compare
+  /// @return true - `exception` has the same error code as `error`
+  /// @return false - `exception` does NOT have the same error code as `error`
   friend bool operator==(std::errc error, const Exception & exception)
   {
     return exception.GetCode() == error;

--- a/library/utility/time.hpp
+++ b/library/utility/time.hpp
@@ -32,7 +32,10 @@ inline std::chrono::nanoseconds DefaultUptime()
 /// Global Uptime function, preset to DefaultUptime() for testing purposes.
 /// In general, this function is overwritten by
 inline UptimeFunction Uptime = DefaultUptime;  // NOLINT
+
+/// Global count of the time.
 inline std::chrono::nanoseconds global_time = 0ns;
+
 /// Returns the system uptime in nanoseconds, do not use this function directly
 ///
 /// @param uptime_function - new system wide uptime function to override the
@@ -104,14 +107,14 @@ inline bool Wait(std::chrono::nanoseconds timeout)
   return Wait(timeout, []() -> bool { return false; });
 }
 
-// Declare an external linkage to the linux nanosleep() function. This is
-// not needed for linux builds but is required to keep the ARM compiler from
-// stating that the nanosleep() function does not exist, as it is #ifdef
-// out in the header file.
-//
-// During the linking stage, since the constexpr if will fail, this path
-// will be removed form the code, and thus no linking errors due to an
-// undefined function call.
+/// Declare an external linkage to the linux nanosleep() function. This is
+/// not needed for linux builds but is required to keep the ARM compiler from
+/// stating that the nanosleep() function does not exist, as it is "ifdef"
+/// out in the header file.
+///
+/// During the linking stage, since the constexpr if will fail, this path
+/// will be removed form the code, and thus no linking errors due to an
+/// undefined function call.
 extern int nanosleep(const timespec *, const timespec *);  // NOLINT
 
 /// Delay the system for a duration of time

--- a/makefile
+++ b/makefile
@@ -104,6 +104,7 @@ SJ2_DEFAULT_CFLAGS   = -g -fmessage-length=0 -fexceptions -ffunction-sections \
                        -Wno-main -Wno-variadic-macros -Wall -Wextra -Wshadow \
                        -Wfloat-equal -Wundef -Wno-format-nonliteral \
                        -Wconversion -Wdouble-promotion -Wswitch -Wformat=2 \
+											 -Wno-missing-field-initializers \
                        -Wno-uninitialized -Wnull-dereference \
 											 -fdiagnostics-color -MMD -MP
 

--- a/projects/continuous_integration/scripts/purge_all_projects.sh
+++ b/projects/continuous_integration/scripts/purge_all_projects.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+BUILD_CAPTURE=0
+
+# Get base path
+COMMON_SCRIPT_DIRECTORY=$(dirname "$0")
+SJBASE=$(cd "${COMMON_SCRIPT_DIRECTORY}/../../../" ; pwd -P)
+
+. ${COMMON_SCRIPT_DIRECTORY}/common.sh
+
+####################################
+#    All Projects Build Check      #
+####################################
+print_divider "Checking that all projects build"
+
+printf "$YELLOW    Building hello_world Project $RESET"
+# Change to the hello_world project
+cd "$SJBASE/projects/hello_world"
+# Purge repository of all application and framework build files and start
+# building from scratch
+SILENCE=$(make purge)
+# Set build capture to return code from the build
+BUILD_CAPTURE=$?
+print_status $BUILD_CAPTURE
+echo ""
+
+printf "$YELLOW    Building Starter Project $RESET"
+# Change to the Hyperload project
+cd "$SJBASE/projects/starter"
+# Clean the build and start building from scratch
+SILENCE=$(make purge)
+# Set build capture to return code from the build
+SPECIFIC_BUILD_CAPTURE=$?
+BUILD_CAPTURE=$(($BUILD_CAPTURE + $SPECIFIC_BUILD_CAPTURE))
+print_status $SPECIFIC_BUILD_CAPTURE
+echo ""
+
+printf "$YELLOW    Building Barebones Project $RESET"
+# Change to the Hyperload project
+cd "$SJBASE/projects/barebones"
+# Clean the build and start building from scratch
+SILENCE=$(make purge)
+# Set build capture to return code from the build
+SPECIFIC_BUILD_CAPTURE=$?
+BUILD_CAPTURE=$(($BUILD_CAPTURE + $SPECIFIC_BUILD_CAPTURE))
+print_status $SPECIFIC_BUILD_CAPTURE
+echo ""
+
+# Build all example projects
+cd $SJBASE/demos/
+# Get all demos with makefiles but ignore multiplatform projects
+LIST_OF_PROJECT=$(find $SJBASE/demos/ -name "makefile" | \
+                  grep -v "multiplatform")
+
+for d in $LIST_OF_PROJECT
+do
+  PROJECT_PATH=$(dirname $d)
+  cd "$PROJECT_PATH"
+  printf "$YELLOW    Building Demo $PROJECT_PATH $RESET"
+  # Clean the build and start building from scratch
+  SILENCE=$(make purge)
+  # Add the return codes of the previous build capture. None zero means that at
+  # least one of the captures failed.
+  SPECIFIC_BUILD_CAPTURE=$?
+  BUILD_CAPTURE=$(($BUILD_CAPTURE + $SPECIFIC_BUILD_CAPTURE))
+  print_status $SPECIFIC_BUILD_CAPTURE
+  echo ""
+done
+
+# Get all multiplatform projects
+LIST_OF_PROJECT=$(find $SJBASE/demos/multiplatform -name "makefile")
+LIST_OF_PLATFORMS=(lpc40xx lpc17xx stm32f4xx stm32f10x msp432p401r)
+
+for d in $LIST_OF_PROJECT
+do
+  for p in "${LIST_OF_PLATFORMS[@]}"
+  do
+    PROJECT_PATH=$(dirname $d)
+    cd "$PROJECT_PATH"
+    printf "$YELLOW"
+    printf "    Building Multiplatform Demo ($p)\n"
+    printf "        $PROJECT_PATH"
+    printf "$RESET "
+    # Clean the build and start building from scratch
+    SILENCE=$(make purge)
+    # Add the return codes of the previous build capture. None zero means that
+    # at least one of the captures failed.
+    SPECIFIC_BUILD_CAPTURE=$?
+    BUILD_CAPTURE=$(($BUILD_CAPTURE + $SPECIFIC_BUILD_CAPTURE))
+    print_status $SPECIFIC_BUILD_CAPTURE
+    echo ""
+  done
+done
+
+exit $BUILD_CAPTURE


### PR DESCRIPTION
This new API seeks to make modules of SJSU-Dev2:

- Simplier
- Faster (runtime performance)
- Cheaper (ROM savings)
- Safer
- More consistent

The new API does the following:

- Makes the states: Reset, Initialized, PoweredDown and Critical, which
  eliminates Enabled and Disabled.
- Configuration() methods are replaces with Settings_t structures that
  are typically POD (plain old datastructures) and can be copied and
  read from.
- Introduces the GetPeripheral<>() factories which return statically
  allocated peripherals in a safe way that allows custom compiler errors
  if invalid peripherals are requested.
- Modules are now no longer copy constructible.

The consequences of these changes are the following:

1. Initialization steps for a module have been simplified. No longer
   Construct, Init, Config, Enable, Use.
   Now it is Construct, Config, Init, Use.
2. Configuration options can be inspected later on without a virtual call
   which would add to the already large vtables.
3. Removal of virtual calls drops flash size significantly. Many
   projects drop by 1k and more.
4. Configuration for a module can be saved in ROM or be predefined in a
   constexpr static variable, making setting up a module as easy as a
   single assignment and a single function call, vs many function calls.
5. The new access factories allow for verbose and greatly explanitory
   error messages when attempting to access a peripheral.
6. The new access factories, if used, also ensure that only 1 instance
   of a peripheral is used at a time. If you use GetUart<1>().Write() in
   multiple locations, additional Uart peripherals are not created, but
   access to the same Uart peripheral is used each time.
7. The removal of copy construction for modules means that application
   developers do not have to worry about accidently performing copies of
   modules with seperate and inconsistent state. This will also help
   prevent the peripheral factories from generating copies on accident.

Additional changes:

- Pin API changes:
    - Eliminate the unused repeater mode as a resistor option

- Doxygen
    - EXTRACT_ALL = false, which brings back all of the warnings due to
      undocumented code. This resulted in many of the class functions being
      moved to the private sections of their classes.