### PR TITLE
Fix Issue with LPC40xx UART Baud Rate Calculation

### DIFF
--- a/demos/multiplatform/esp8266/source/main.cpp
+++ b/demos/multiplatform/esp8266/source/main.cpp
@@ -4,6 +4,7 @@
 
 #include "peripherals/lpc40xx/uart.hpp"
 #include "peripherals/stm32f10x/uart.hpp"
+#include "peripherals/interrupt.hpp"
 #include "devices/communication/esp8266.hpp"
 #include "utility/debug.hpp"
 #include "utility/log.hpp"
@@ -35,6 +36,7 @@ int main()
   else if constexpr (sjsu::build::kPlatform == sjsu::build::Platform::lpc40xx)
   {
     sjsu::LogInfo("Current Platform LPC40xx...");
+    sjsu::lpc40xx::SetMaximumClockSpeed();
     static auto & uart3 = sjsu::lpc40xx::GetUart<3>();
     uart                = &uart3;
   }
@@ -78,11 +80,28 @@ int main()
 
   socket.Write(write_payload, 5s);
 
-  sjsu::LogInfo("Reading back response from server (%s)...", host.data());
-
   std::array<uint8_t, 1024 * 2> response;
   size_t read_back = socket.Read(response, 10s);
 
+  sjsu::LogInfo("Reading back response from server (%s)...", host.data());
+  sjsu::LogInfo("Printing Server Response:");
+  printf("%.*s\n", read_back, response.data());
+  puts("===================================================================");
+
+  socket.Write(write_payload, 5s);
+
+  read_back = socket.Read(response, 10s);
+
+  sjsu::LogInfo("Reading back response from server (%s)...", host.data());
+  sjsu::LogInfo("Printing Server Response:");
+  printf("%.*s\n", read_back, response.data());
+  puts("===================================================================");
+
+  socket.Write(write_payload, 5s);
+
+  read_back = socket.Read(response, 10s);
+
+  sjsu::LogInfo("Reading back response from server (%s)...", host.data());
   sjsu::LogInfo("Printing Server Response:");
   printf("%.*s\n", read_back, response.data());
   puts("===================================================================");

--- a/library/peripherals/lpc40xx/system_controller.hpp
+++ b/library/peripherals/lpc40xx/system_controller.hpp
@@ -736,11 +736,15 @@ inline void SetMaximumClockSpeed()
   config.cpu.clock   = SystemController::CpuClockSelect::kPll0;
   config.cpu.divider = 1;
 
+  sjsu::cortex::__disable_irq();
+
   // Initialize system clock rates.
   system.Initialize();
 
   // Initialize platform with new clock configuration settings.
   sjsu::InitializePlatform();
+
+  sjsu::cortex::__enable_irq();
 }
 }  // namespace lpc40xx
 }  // namespace sjsu

--- a/library/peripherals/lpc40xx/test/uart_test.cpp
+++ b/library/peripherals/lpc40xx/test/uart_test.cpp
@@ -76,18 +76,19 @@ TEST_CASE("Testing lpc40xx Uart")
         static_cast<uint8_t>((kCalibration.divide_latch >> 8) & 0xFF);
     const uint8_t kExpectedLowerByte =
         static_cast<uint8_t>(kCalibration.divide_latch & 0xFF);
-    const uint8_t kExpectedFdr = static_cast<uint8_t>(
-        (kCalibration.multiply & 0xF) << 4 | (kCalibration.divide_add & 0xF));
+    const uint8_t kExpectedFdr = kCalibration.fraction;
 
     // Exercise
     test_subject.Initialize();
 
     // Verify
     Verify(Method(mock_system_controller, PowerUpPeripheral)
-               .Matching([](sjsu::SystemController::ResourceID id) {
-                 return sjsu::lpc40xx::SystemController::Peripherals::kUart2
-                            .device_id == id.device_id;
-               }));
+               .Matching(
+                   [](sjsu::SystemController::ResourceID id)
+                   {
+                     return sjsu::lpc40xx::SystemController::Peripherals::kUart2
+                                .device_id == id.device_id;
+                   }));
 
     // Verify
     CHECK(mock_tx.get().CurrentSettings() ==


### PR DESCRIPTION
- Use a constexpr table of baudrate fractional dividers and simplify
  parts of the baud rate calculation.
- Replace broken fractional divider estimation, which genearted values
  above and below 1.1 and 1.9, with table which ensure that the values
  within are either 0 or 1.1 to 1.9.

- Fix issue with sjsu::lpc40xx::SetMaximumSpeed() where it can cause
  problems with interrupts. Now it will disable interrupts during the
  system speed transition.

- Fix issue with esp8266 demo where there is a print statement between
  the socket write and socket read which, for devices without UART DMA
  support results in missing data the length of time the print occurs.